### PR TITLE
Add Expression and ExpressionParser for FE pseudo-language

### DIFF
--- a/Sources/FeLangCore/Expression.swift
+++ b/Sources/FeLangCore/Expression.swift
@@ -1,0 +1,247 @@
+/// Represents an expression in FE pseudo-language.
+public indirect enum Expression: Equatable, Codable, Sendable {
+    // Primary expressions
+    case literal(Literal)
+    case identifier(String)
+    
+    // Binary expressions
+    case binary(BinaryOperator, Expression, Expression)
+    
+    // Unary expressions
+    case unary(UnaryOperator, Expression)
+    
+    // Postfix expressions
+    case arrayAccess(Expression, Expression)
+    case functionCall(String, [Expression])
+}
+
+/// Represents literal values in FE pseudo-language.
+public enum Literal: Equatable, Sendable {
+    case integer(Int)
+    case real(Double)
+    case string(String)
+    case character(Character)
+    case boolean(Bool)
+}
+
+extension Literal: Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .integer(let value):
+            try container.encode(["integer": value])
+        case .real(let value):
+            try container.encode(["real": value])
+        case .string(let value):
+            try container.encode(["string": value])
+        case .character(let value):
+            try container.encode(["character": String(value)])
+        case .boolean(let value):
+            try container.encode(["boolean": value])
+        }
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dict = try container.decode([String: AnyCodable].self)
+        
+        if let value = dict["integer"]?.value as? Int {
+            self = .integer(value)
+        } else if let value = dict["real"]?.value as? Double {
+            self = .real(value)
+        } else if let value = dict["string"]?.value as? String {
+            self = .string(value)
+        } else if let value = dict["character"]?.value as? String, let char = value.first {
+            self = .character(char)
+        } else if let value = dict["boolean"]?.value as? Bool {
+            self = .boolean(value)
+        } else {
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Invalid literal value"))
+        }
+    }
+}
+
+/// Helper type for decoding heterogeneous values
+private struct AnyCodable: Codable {
+    let value: Any
+    
+    init<T>(_ value: T) {
+        self.value = value
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if let value = try? container.decode(Int.self) {
+            self.value = value
+        } else if let value = try? container.decode(Double.self) {
+            self.value = value
+        } else if let value = try? container.decode(String.self) {
+            self.value = value
+        } else if let value = try? container.decode(Bool.self) {
+            self.value = value
+        } else {
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unsupported type"))
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        
+        if let value = value as? Int {
+            try container.encode(value)
+        } else if let value = value as? Double {
+            try container.encode(value)
+        } else if let value = value as? String {
+            try container.encode(value)
+        } else if let value = value as? Bool {
+            try container.encode(value)
+        } else {
+            throw EncodingError.invalidValue(value, .init(codingPath: encoder.codingPath, debugDescription: "Unsupported type"))
+        }
+    }
+}
+
+/// Represents binary operators with their precedence and associativity.
+public enum BinaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
+    // Arithmetic operators
+    case add = "+"
+    case subtract = "-"
+    case multiply = "*"
+    case divide = "/"
+    case modulo = "%"
+    
+    // Comparison operators
+    case equal = "="
+    case notEqual = "≠"
+    case greater = ">"
+    case greaterEqual = "≧"
+    case less = "<"
+    case lessEqual = "≦"
+    
+    // Logical operators
+    case and = "and"
+    case or = "or"
+    
+    /// Returns the precedence level of this operator.
+    /// Higher numbers indicate higher precedence.
+    public var precedence: Int {
+        switch self {
+        case .or:
+            return 1
+        case .and:
+            return 2
+        case .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual:
+            return 3
+        case .add, .subtract:
+            return 4
+        case .multiply, .divide, .modulo:
+            return 5
+        }
+    }
+    
+    /// Returns true if this operator is left-associative.
+    /// All binary operators in FE pseudo-language are left-associative.
+    public var isLeftAssociative: Bool {
+        return true
+    }
+}
+
+/// Represents unary operators.
+public enum UnaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
+    case not = "not"
+    case plus = "+"
+    case minus = "-"
+    
+    /// Returns the precedence level of this operator.
+    /// Unary operators have high precedence (6).
+    public var precedence: Int {
+        return 6
+    }
+}
+
+// MARK: - TokenType Mapping Extensions
+
+extension BinaryOperator {
+    /// Creates a binary operator from a token type.
+    /// Returns nil if the token type doesn't correspond to a binary operator.
+    public init?(tokenType: TokenType) {
+        switch tokenType {
+        case .plus:
+            self = .add
+        case .minus:
+            self = .subtract
+        case .multiply:
+            self = .multiply
+        case .divide:
+            self = .divide
+        case .modulo:
+            self = .modulo
+        case .equal:
+            self = .equal
+        case .notEqual:
+            self = .notEqual
+        case .greater:
+            self = .greater
+        case .greaterEqual:
+            self = .greaterEqual
+        case .less:
+            self = .less
+        case .lessEqual:
+            self = .lessEqual
+        case .andKeyword:
+            self = .and
+        case .orKeyword:
+            self = .or
+        default:
+            return nil
+        }
+    }
+}
+
+extension UnaryOperator {
+    /// Creates a unary operator from a token type.
+    /// Returns nil if the token type doesn't correspond to a unary operator.
+    public init?(tokenType: TokenType) {
+        switch tokenType {
+        case .notKeyword:
+            self = .not
+        case .plus:
+            self = .plus
+        case .minus:
+            self = .minus
+        default:
+            return nil
+        }
+    }
+}
+
+extension Literal {
+    /// Creates a literal from a token.
+    /// Returns nil if the token doesn't represent a literal value.
+    public init?(token: Token) {
+        switch token.type {
+        case .integerLiteral:
+            guard let value = Int(token.lexeme) else { return nil }
+            self = .integer(value)
+        case .realLiteral:
+            guard let value = Double(token.lexeme) else { return nil }
+            self = .real(value)
+        case .stringLiteral:
+            // Remove the surrounding quotes
+            let content = String(token.lexeme.dropFirst().dropLast())
+            self = .string(content)
+        case .characterLiteral:
+            // Remove the surrounding quotes and get the character
+            let content = token.lexeme.dropFirst().dropLast()
+            guard let character = content.first else { return nil }
+            self = .character(character)
+        case .trueKeyword:
+            self = .boolean(true)
+        case .falseKeyword:
+            self = .boolean(false)
+        default:
+            return nil
+        }
+    }
+} 

--- a/Sources/FeLangCore/Expression.swift
+++ b/Sources/FeLangCore/Expression.swift
@@ -3,13 +3,13 @@ public indirect enum Expression: Equatable, Codable, Sendable {
     // Primary expressions
     case literal(Literal)
     case identifier(String)
-    
+
     // Binary expressions
     case binary(BinaryOperator, Expression, Expression)
-    
+
     // Unary expressions
     case unary(UnaryOperator, Expression)
-    
+
     // Postfix expressions
     case arrayAccess(Expression, Expression)
     case functionCall(String, [Expression])
@@ -40,11 +40,11 @@ extension Literal: Codable {
             try container.encode(["boolean": value])
         }
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dict = try container.decode([String: AnyCodable].self)
-        
+
         if let value = dict["integer"]?.value as? Int {
             self = .integer(value)
         } else if let value = dict["real"]?.value as? Double {
@@ -64,14 +64,14 @@ extension Literal: Codable {
 /// Helper type for decoding heterogeneous values
 private struct AnyCodable: Codable {
     let value: Any
-    
+
     init<T>(_ value: T) {
         self.value = value
     }
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        
+
         if let value = try? container.decode(Int.self) {
             self.value = value
         } else if let value = try? container.decode(Double.self) {
@@ -84,10 +84,10 @@ private struct AnyCodable: Codable {
             throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unsupported type"))
         }
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        
+
         if let value = value as? Int {
             try container.encode(value)
         } else if let value = value as? Double {
@@ -110,7 +110,7 @@ public enum BinaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
     case multiply = "*"
     case divide = "/"
     case modulo = "%"
-    
+
     // Comparison operators
     case equal = "="
     case notEqual = "≠"
@@ -118,11 +118,11 @@ public enum BinaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
     case greaterEqual = "≧"
     case less = "<"
     case lessEqual = "≦"
-    
+
     // Logical operators
     case and = "and"
     case or = "or"
-    
+
     /// Returns the precedence level of this operator.
     /// Higher numbers indicate higher precedence.
     public var precedence: Int {
@@ -139,7 +139,7 @@ public enum BinaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
             return 5
         }
     }
-    
+
     /// Returns true if this operator is left-associative.
     /// All binary operators in FE pseudo-language are left-associative.
     public var isLeftAssociative: Bool {
@@ -152,7 +152,7 @@ public enum UnaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
     case not = "not"
     case plus = "+"
     case minus = "-"
-    
+
     /// Returns the precedence level of this operator.
     /// Unary operators have high precedence (6).
     public var precedence: Int {
@@ -244,4 +244,4 @@ extension Literal {
             return nil
         }
     }
-} 
+}

--- a/Sources/FeLangCore/ExpressionParser.swift
+++ b/Sources/FeLangCore/ExpressionParser.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+/// A parser for FE pseudo-language expressions using precedence climbing.
+/// This parser correctly handles operator precedence and left-associativity.
+public struct ExpressionParser {
+    
+    public init() {}
+    
+    /// Parses an expression from an array of tokens.
+    /// - Parameter tokens: Array of tokens to parse
+    /// - Returns: Parsed expression
+    /// - Throws: ParsingError if parsing fails
+    public func parseExpression(from tokens: [Token]) throws -> Expression {
+        var parser = TokenStream(tokens)
+        let expression = try parseExpression(&parser)
+        
+        // Check if we've consumed all tokens (except EOF)
+        if let remaining = parser.peek(), remaining.type != .eof {
+            throw ParsingError.unexpectedToken(remaining, expected: .eof)
+        }
+        
+        return expression
+    }
+    
+    /// Parses an expression with minimum precedence of 0.
+    private func parseExpression(_ parser: inout TokenStream) throws -> Expression {
+        return try parseExpression(&parser, minPrecedence: 0)
+    }
+    
+    /// Parses an expression with the specified minimum precedence.
+    /// This implements the precedence climbing algorithm.
+    private func parseExpression(_ parser: inout TokenStream, minPrecedence: Int) throws -> Expression {
+        // Parse left operand
+        var leftExpr = try parseUnaryExpression(&parser)
+        
+        // Parse operators and right operands
+        while let op = tryParseBinaryOperator(&parser, minPrecedence: minPrecedence) {
+            // For left-associative operators, increase precedence by 1
+            let nextMinPrec = op.isLeftAssociative ? op.precedence + 1 : op.precedence
+            let rightExpr = try parseExpression(&parser, minPrecedence: nextMinPrec)
+            
+            // Combine into binary expression
+            leftExpr = Expression.binary(op, leftExpr, rightExpr)
+        }
+        
+        return leftExpr
+    }
+    
+    /// Parses a unary expression.
+    private func parseUnaryExpression(_ parser: inout TokenStream) throws -> Expression {
+        // Try to parse unary operators
+        if let op = tryParseUnaryOperator(&parser) {
+            let expr = try parseUnaryExpression(&parser)
+            return Expression.unary(op, expr)
+        }
+        
+        // Parse postfix expressions
+        return try parsePostfixExpression(&parser)
+    }
+    
+    /// Parses postfix expressions (array access and function calls).
+    private func parsePostfixExpression(_ parser: inout TokenStream) throws -> Expression {
+        var expr = try parsePrimaryExpression(&parser)
+        
+        // Parse postfix operations
+        while true {
+            if parser.peek()?.type == .leftBracket {
+                // Array access: expr[index]
+                parser.advance() // consume '['
+                let indexExpr = try parseExpression(&parser)
+                try expectToken(&parser, .rightBracket)
+                expr = Expression.arrayAccess(expr, indexExpr)
+            } else if parser.peek()?.type == .leftParen,
+                      case .identifier(let name) = expr {
+                // Function call: identifier(args...)
+                parser.advance() // consume '('
+                let args = try parseArgumentList(&parser)
+                try expectToken(&parser, .rightParen)
+                expr = Expression.functionCall(name, args)
+            } else {
+                // No more postfix operations
+                break
+            }
+        }
+        
+        return expr
+    }
+    
+    /// Parses primary expressions (literals, identifiers, parentheses).
+    private func parsePrimaryExpression(_ parser: inout TokenStream) throws -> Expression {
+        guard let token = parser.advance() else {
+            throw ParsingError.unexpectedEndOfInput
+        }
+        
+        // Literal expressions
+        if let literal = Literal(token: token) {
+            return Expression.literal(literal)
+        }
+        
+        // Identifier expressions
+        if token.type == .identifier {
+            return Expression.identifier(token.lexeme)
+        }
+        
+        // Parenthesized expressions
+        if token.type == .leftParen {
+            let expr = try parseExpression(&parser)
+            try expectToken(&parser, .rightParen)
+            return expr
+        }
+        
+        throw ParsingError.expectedPrimaryExpression(token)
+    }
+    
+    // MARK: - Helper Methods
+    
+    /// Tries to parse a binary operator with minimum precedence.
+    private func tryParseBinaryOperator(_ parser: inout TokenStream, minPrecedence: Int) -> BinaryOperator? {
+        guard let token = parser.peek(),
+              let op = BinaryOperator(tokenType: token.type),
+              op.precedence >= minPrecedence else {
+            return nil
+        }
+        
+        parser.advance() // consume the operator
+        return op
+    }
+    
+    /// Tries to parse a unary operator.
+    private func tryParseUnaryOperator(_ parser: inout TokenStream) -> UnaryOperator? {
+        guard let token = parser.peek(),
+              let op = UnaryOperator(tokenType: token.type) else {
+            return nil
+        }
+        
+        parser.advance() // consume the operator
+        return op
+    }
+    
+    /// Expects a specific token type and consumes it.
+    private func expectToken(_ parser: inout TokenStream, _ expectedType: TokenType) throws {
+        guard let token = parser.advance() else {
+            throw ParsingError.unexpectedEndOfInput
+        }
+        
+        guard token.type == expectedType else {
+            throw ParsingError.unexpectedToken(token, expected: expectedType)
+        }
+    }
+    
+    /// Parses an argument list for function calls.
+    private func parseArgumentList(_ parser: inout TokenStream) throws -> [Expression] {
+        var arguments: [Expression] = []
+        
+        // Handle empty argument list
+        if parser.peek()?.type == .rightParen {
+            return arguments
+        }
+        
+        // Parse first argument
+        arguments.append(try parseExpression(&parser))
+        
+        // Parse remaining arguments
+        while parser.peek()?.type == .comma {
+            parser.advance() // consume ','
+            arguments.append(try parseExpression(&parser))
+        }
+        
+        return arguments
+    }
+}
+
+// MARK: - TokenStream Helper
+
+/// A simple token stream for parsing.
+private struct TokenStream {
+    private let tokens: [Token]
+    private var index: Int = 0
+    
+    init(_ tokens: [Token]) {
+        self.tokens = tokens
+    }
+    
+    /// Peeks at the current token without consuming it.
+    mutating func peek() -> Token? {
+        guard index < tokens.count else { return nil }
+        return tokens[index]
+    }
+    
+    /// Advances to the next token and returns the current one.
+    mutating func advance() -> Token? {
+        guard index < tokens.count else { return nil }
+        let token = tokens[index]
+        index += 1
+        return token
+    }
+}
+
+// MARK: - Parsing Errors
+
+/// Errors that can occur during expression parsing.
+public enum ParsingError: Error, Equatable {
+    case unexpectedEndOfInput
+    case unexpectedToken(Token, expected: TokenType)
+    case expectedPrimaryExpression(Token)
+}
+
+extension ParsingError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unexpectedEndOfInput:
+            return "Unexpected end of input"
+        case .unexpectedToken(let token, let expected):
+            return "Unexpected token '\(token.lexeme)' at \(token.position), expected \(expected)"
+        case .expectedPrimaryExpression(let token):
+            return "Expected primary expression at \(token.position), got '\(token.lexeme)'"
+        }
+    }
+} 

--- a/Sources/FeLangCore/ExpressionParser.swift
+++ b/Sources/FeLangCore/ExpressionParser.swift
@@ -3,9 +3,9 @@ import Foundation
 /// A parser for FE pseudo-language expressions using precedence climbing.
 /// This parser correctly handles operator precedence and left-associativity.
 public struct ExpressionParser {
-    
+
     public init() {}
-    
+
     /// Parses an expression from an array of tokens.
     /// - Parameter tokens: Array of tokens to parse
     /// - Returns: Parsed expression
@@ -13,39 +13,39 @@ public struct ExpressionParser {
     public func parseExpression(from tokens: [Token]) throws -> Expression {
         var parser = TokenStream(tokens)
         let expression = try parseExpression(&parser)
-        
+
         // Check if we've consumed all tokens (except EOF)
         if let remaining = parser.peek(), remaining.type != .eof {
             throw ParsingError.unexpectedToken(remaining, expected: .eof)
         }
-        
+
         return expression
     }
-    
+
     /// Parses an expression with minimum precedence of 0.
     private func parseExpression(_ parser: inout TokenStream) throws -> Expression {
         return try parseExpression(&parser, minPrecedence: 0)
     }
-    
+
     /// Parses an expression with the specified minimum precedence.
     /// This implements the precedence climbing algorithm.
     private func parseExpression(_ parser: inout TokenStream, minPrecedence: Int) throws -> Expression {
         // Parse left operand
         var leftExpr = try parseUnaryExpression(&parser)
-        
+
         // Parse operators and right operands
         while let op = tryParseBinaryOperator(&parser, minPrecedence: minPrecedence) {
             // For left-associative operators, increase precedence by 1
             let nextMinPrec = op.isLeftAssociative ? op.precedence + 1 : op.precedence
             let rightExpr = try parseExpression(&parser, minPrecedence: nextMinPrec)
-            
+
             // Combine into binary expression
             leftExpr = Expression.binary(op, leftExpr, rightExpr)
         }
-        
+
         return leftExpr
     }
-    
+
     /// Parses a unary expression.
     private func parseUnaryExpression(_ parser: inout TokenStream) throws -> Expression {
         // Try to parse unary operators
@@ -53,15 +53,15 @@ public struct ExpressionParser {
             let expr = try parseUnaryExpression(&parser)
             return Expression.unary(op, expr)
         }
-        
+
         // Parse postfix expressions
         return try parsePostfixExpression(&parser)
     }
-    
+
     /// Parses postfix expressions (array access and function calls).
     private func parsePostfixExpression(_ parser: inout TokenStream) throws -> Expression {
         var expr = try parsePrimaryExpression(&parser)
-        
+
         // Parse postfix operations
         while true {
             if parser.peek()?.type == .leftBracket {
@@ -82,38 +82,38 @@ public struct ExpressionParser {
                 break
             }
         }
-        
+
         return expr
     }
-    
+
     /// Parses primary expressions (literals, identifiers, parentheses).
     private func parsePrimaryExpression(_ parser: inout TokenStream) throws -> Expression {
         guard let token = parser.advance() else {
             throw ParsingError.unexpectedEndOfInput
         }
-        
+
         // Literal expressions
         if let literal = Literal(token: token) {
             return Expression.literal(literal)
         }
-        
+
         // Identifier expressions
         if token.type == .identifier {
             return Expression.identifier(token.lexeme)
         }
-        
+
         // Parenthesized expressions
         if token.type == .leftParen {
             let expr = try parseExpression(&parser)
             try expectToken(&parser, .rightParen)
             return expr
         }
-        
+
         throw ParsingError.expectedPrimaryExpression(token)
     }
-    
+
     // MARK: - Helper Methods
-    
+
     /// Tries to parse a binary operator with minimum precedence.
     private func tryParseBinaryOperator(_ parser: inout TokenStream, minPrecedence: Int) -> BinaryOperator? {
         guard let token = parser.peek(),
@@ -121,51 +121,51 @@ public struct ExpressionParser {
               op.precedence >= minPrecedence else {
             return nil
         }
-        
+
         parser.advance() // consume the operator
         return op
     }
-    
+
     /// Tries to parse a unary operator.
     private func tryParseUnaryOperator(_ parser: inout TokenStream) -> UnaryOperator? {
         guard let token = parser.peek(),
               let op = UnaryOperator(tokenType: token.type) else {
             return nil
         }
-        
+
         parser.advance() // consume the operator
         return op
     }
-    
+
     /// Expects a specific token type and consumes it.
     private func expectToken(_ parser: inout TokenStream, _ expectedType: TokenType) throws {
         guard let token = parser.advance() else {
             throw ParsingError.unexpectedEndOfInput
         }
-        
+
         guard token.type == expectedType else {
             throw ParsingError.unexpectedToken(token, expected: expectedType)
         }
     }
-    
+
     /// Parses an argument list for function calls.
     private func parseArgumentList(_ parser: inout TokenStream) throws -> [Expression] {
         var arguments: [Expression] = []
-        
+
         // Handle empty argument list
         if parser.peek()?.type == .rightParen {
             return arguments
         }
-        
+
         // Parse first argument
         arguments.append(try parseExpression(&parser))
-        
+
         // Parse remaining arguments
         while parser.peek()?.type == .comma {
             parser.advance() // consume ','
             arguments.append(try parseExpression(&parser))
         }
-        
+
         return arguments
     }
 }
@@ -176,17 +176,17 @@ public struct ExpressionParser {
 private struct TokenStream {
     private let tokens: [Token]
     private var index: Int = 0
-    
+
     init(_ tokens: [Token]) {
         self.tokens = tokens
     }
-    
+
     /// Peeks at the current token without consuming it.
     mutating func peek() -> Token? {
         guard index < tokens.count else { return nil }
         return tokens[index]
     }
-    
+
     /// Advances to the next token and returns the current one.
     mutating func advance() -> Token? {
         guard index < tokens.count else { return nil }
@@ -216,4 +216,4 @@ extension ParsingError: LocalizedError {
             return "Expected primary expression at \(token.position), got '\(token.lexeme)'"
         }
     }
-} 
+}

--- a/Tests/FeLangCoreTests/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/ExpressionParserTests.swift
@@ -1,0 +1,491 @@
+import Foundation
+import Testing
+@testable import FeLangCore
+
+// Alias to avoid conflict with Foundation.Expression
+typealias FEExpression = FeLangCore.Expression
+
+@Suite("ExpressionParser Tests")
+struct ExpressionParserTests {
+    
+    // MARK: - Helper Methods
+    
+    /// Helper method to tokenize and parse an expression
+    private func parseExpression(_ input: String) throws -> FEExpression {
+        let tokens = try ParsingTokenizer.tokenize(input)
+        let parser = ExpressionParser()
+        return try parser.parseExpression(from: tokens)
+    }
+    
+    /// Helper method to create a source position for testing
+    private func testPosition() -> SourcePosition {
+        return SourcePosition(line: 1, column: 1, offset: 0)
+    }
+    
+    // MARK: - Basic Literal Tests
+    
+    @Test func testIntegerLiteral() throws {
+        let expr = try parseExpression("42")
+        #expect(expr == .literal(Literal.integer(42)))
+    }
+    
+    @Test func testRealLiteral() throws {
+        let expr = try parseExpression("3.14")
+        #expect(expr == .literal(Literal.real(3.14)))
+    }
+    
+    @Test func testStringLiteral() throws {
+        let expr = try parseExpression("'hello'")
+        #expect(expr == .literal(Literal.string("hello")))
+    }
+    
+    @Test func testCharacterLiteral() throws {
+        let expr = try parseExpression("'A'")
+        #expect(expr == .literal(.character("A")))
+    }
+    
+    @Test func testBooleanLiterals() throws {
+        let trueExpr = try parseExpression("true")
+        let falseExpr = try parseExpression("false")
+        
+        #expect(trueExpr == .literal(.boolean(true)))
+        #expect(falseExpr == .literal(.boolean(false)))
+    }
+    
+    @Test func testIdentifier() throws {
+        let expr = try parseExpression("variable")
+        #expect(expr == .identifier("variable"))
+    }
+    
+    // MARK: - Basic Arithmetic Tests
+    
+    @Test func testSimpleAddition() throws {
+        let expr = try parseExpression("1 + 2")
+        let expected = Expression.binary(.add, .literal(.integer(1)), .literal(.integer(2)))
+        #expect(expr == expected)
+    }
+    
+    @Test func testSimpleSubtraction() throws {
+        let expr = try parseExpression("5 - 3")
+        let expected = Expression.binary(.subtract, .literal(.integer(5)), .literal(.integer(3)))
+        #expect(expr == expected)
+    }
+    
+    @Test func testSimpleMultiplication() throws {
+        let expr = try parseExpression("4 * 5")
+        let expected = Expression.binary(.multiply, .literal(.integer(4)), .literal(.integer(5)))
+        #expect(expr == expected)
+    }
+    
+    @Test func testSimpleDivision() throws {
+        let expr = try parseExpression("10 / 2")
+        let expected = Expression.binary(.divide, .literal(.integer(10)), .literal(.integer(2)))
+        #expect(expr == expected)
+    }
+    
+    @Test func testModulo() throws {
+        let expr = try parseExpression("7 % 3")
+        let expected = Expression.binary(.modulo, .literal(.integer(7)), .literal(.integer(3)))
+        #expect(expr == expected)
+    }
+    
+    // MARK: - Precedence Tests
+    
+    @Test func testArithmeticPrecedence() throws {
+        // 3 + 4 * 5 should be parsed as 3 + (4 * 5) = 23
+        let expr = try parseExpression("3 + 4 * 5")
+        let expected = Expression.binary(
+            .add,
+            .literal(.integer(3)),
+            .binary(.multiply, .literal(.integer(4)), .literal(.integer(5)))
+        )
+        #expect(expr == expected)
+    }
+    
+    @Test func testParenthesesOverridePrecedence() throws {
+        // (3 + 4) * 5 should be parsed as (3 + 4) * 5 = 35
+        let expr = try parseExpression("(3 + 4) * 5")
+        let expected = Expression.binary(
+            .multiply,
+            .binary(.add, .literal(.integer(3)), .literal(.integer(4))),
+            .literal(.integer(5))
+        )
+        #expect(expr == expected)
+    }
+    
+    @Test func testMultiplicationDivisionPrecedence() throws {
+        // 8 / 2 * 3 should be parsed as (8 / 2) * 3 = 12 (left associative)
+        let expr = try parseExpression("8 / 2 * 3")
+        let expected = Expression.binary(
+            .multiply,
+            .binary(.divide, .literal(.integer(8)), .literal(.integer(2))),
+            .literal(.integer(3))
+        )
+        #expect(expr == expected)
+    }
+    
+    // MARK: - Left Associativity Tests
+    
+    @Test func testLeftAssociativityAddition() throws {
+        // 1 + 2 + 3 should be parsed as ((1 + 2) + 3) = 6
+        let expr = try parseExpression("1 + 2 + 3")
+        let expected = Expression.binary(
+            .add,
+            .binary(.add, .literal(.integer(1)), .literal(.integer(2))),
+            .literal(.integer(3))
+        )
+        #expect(expr == expected)
+    }
+    
+    @Test func testLeftAssociativityMultiplication() throws {
+        // 2 * 3 * 4 should be parsed as ((2 * 3) * 4) = 24
+        let expr = try parseExpression("2 * 3 * 4")
+        let expected = Expression.binary(
+            .multiply,
+            .binary(.multiply, .literal(.integer(2)), .literal(.integer(3))),
+            .literal(.integer(4))
+        )
+        #expect(expr == expected)
+    }
+    
+    @Test func testLeftAssociativitySubtraction() throws {
+        // 10 - 3 - 2 should be parsed as ((10 - 3) - 2) = 5
+        let expr = try parseExpression("10 - 3 - 2")
+        let expected = Expression.binary(
+            .subtract,
+            .binary(.subtract, .literal(.integer(10)), .literal(.integer(3))),
+            .literal(.integer(2))
+        )
+        #expect(expr == expected)
+    }
+    
+    // MARK: - Comparison Operator Tests
+    
+    @Test func testEqualityOperator() throws {
+        let expr = try parseExpression("x = 5")
+        let expected = Expression.binary(.equal, .identifier("x"), .literal(.integer(5)))
+        #expect(expr == expected)
+    }
+    
+    @Test func testInequalityOperator() throws {
+        let expr = try parseExpression("y ≠ 0")
+        let expected = Expression.binary(.notEqual, .identifier("y"), .literal(.integer(0)))
+        #expect(expr == expected)
+    }
+    
+    @Test func testComparisonOperators() throws {
+        let tests = [
+            ("a > b", BinaryOperator.greater),
+            ("a ≧ b", BinaryOperator.greaterEqual),
+            ("a < b", BinaryOperator.less),
+            ("a ≦ b", BinaryOperator.lessEqual)
+        ]
+        
+        for (input, expectedOp) in tests {
+            let expr = try parseExpression(input)
+            let expected = Expression.binary(expectedOp, .identifier("a"), .identifier("b"))
+            #expect(expr == expected)
+        }
+    }
+    
+    // MARK: - Logical Operator Tests
+    
+    @Test func testLogicalAnd() throws {
+        let expr = try parseExpression("x > 0 and y < 10")
+        let expected = Expression.binary(
+            .and,
+            .binary(.greater, .identifier("x"), .literal(.integer(0))),
+            .binary(.less, .identifier("y"), .literal(.integer(10)))
+        )
+        #expect(expr == expected)
+    }
+    
+    @Test func testLogicalOr() throws {
+        let expr = try parseExpression("a = 1 or b = 2")
+        let expected = Expression.binary(
+            .or,
+            .binary(.equal, .identifier("a"), .literal(.integer(1))),
+            .binary(.equal, .identifier("b"), .literal(.integer(2)))
+        )
+        #expect(expr == expected)
+    }
+    
+    @Test func testLogicalPrecedence() throws {
+        // a = b and c ≠ d should be parsed as (a = b) and (c ≠ d)
+        let expr = try parseExpression("a = b and c ≠ d")
+        let expected = Expression.binary(
+            .and,
+            .binary(.equal, .identifier("a"), .identifier("b")),
+            .binary(.notEqual, .identifier("c"), .identifier("d"))
+        )
+        #expect(expr == expected)
+    }
+    
+    // MARK: - Unary Operator Tests
+    
+    @Test func testUnaryNot() throws {
+        let expr = try parseExpression("not x")
+        let expected = Expression.unary(.not, .identifier("x"))
+        #expect(expr == expected)
+    }
+    
+    @Test func testUnaryPlus() throws {
+        let expr = try parseExpression("+42")
+        let expected = Expression.unary(.plus, .literal(.integer(42)))
+        #expect(expr == expected)
+    }
+    
+    @Test func testUnaryMinus() throws {
+        let expr = try parseExpression("-5")
+        let expected = Expression.unary(.minus, .literal(.integer(5)))
+        #expect(expr == expected)
+    }
+    
+    @Test func testUnaryPrecedence() throws {
+        // not x or y should be parsed as (not x) or y
+        let expr = try parseExpression("not x or y")
+        let expected = Expression.binary(
+            .or,
+            .unary(.not, .identifier("x")),
+            .identifier("y")
+        )
+        #expect(expr == expected)
+    }
+    
+    // MARK: - Array Access Tests
+    
+    @Test func testSimpleArrayAccess() throws {
+        let expr = try parseExpression("array[0]")
+        let expected = Expression.arrayAccess(.identifier("array"), .literal(.integer(0)))
+        #expect(expr == expected)
+    }
+    
+    @Test func testArrayAccessWithExpression() throws {
+        // array[i + 1] * 2 should be parsed as (array[(i + 1)]) * 2
+        let expr = try parseExpression("array[i + 1] * 2")
+        let expected = Expression.binary(
+            .multiply,
+            .arrayAccess(
+                .identifier("array"),
+                .binary(.add, .identifier("i"), .literal(.integer(1)))
+            ),
+            .literal(.integer(2))
+        )
+        #expect(expr == expected)
+    }
+    
+    // MARK: - Function Call Tests
+    
+    @Test func testSimpleFunctionCall() throws {
+        let expr = try parseExpression("max(a, b)")
+        let expected = Expression.functionCall("max", [.identifier("a"), .identifier("b")])
+        #expect(expr == expected)
+    }
+    
+    @Test func testFunctionCallWithExpressions() throws {
+        // func(a + b, c * d) should be parsed as func((a + b), (c * d))
+        let expr = try parseExpression("func(a + b, c * d)")
+        let expected = Expression.functionCall(
+            "func",
+            [
+                .binary(.add, .identifier("a"), .identifier("b")),
+                .binary(.multiply, .identifier("c"), .identifier("d"))
+            ]
+        )
+        #expect(expr == expected)
+    }
+    
+    @Test func testFunctionCallNoArguments() throws {
+        let expr = try parseExpression("getValue()")
+        let expected = Expression.functionCall("getValue", [])
+        #expect(expr == expected)
+    }
+    
+    // MARK: - Complex Expression Tests
+    
+    @Test func testComplexArithmeticExpression() throws {
+        // 1 + 2 * 3 - 4 / 2 should be parsed as (1 + (2 * 3)) - (4 / 2)
+        let expr = try parseExpression("1 + 2 * 3 - 4 / 2")
+        let expected = Expression.binary(
+            .subtract,
+            .binary(
+                .add,
+                .literal(.integer(1)),
+                .binary(.multiply, .literal(.integer(2)), .literal(.integer(3)))
+            ),
+            .binary(.divide, .literal(.integer(4)), .literal(.integer(2)))
+        )
+        #expect(expr == expected)
+    }
+    
+    @Test func testComplexLogicalExpression() throws {
+        // not (x > 0 and y < max(a, b))
+        let expr = try parseExpression("not (x > 0 and y < max(a, b))")
+        let expected = Expression.unary(
+            .not,
+            .binary(
+                .and,
+                .binary(.greater, .identifier("x"), .literal(.integer(0))),
+                .binary(
+                    .less,
+                    .identifier("y"),
+                    .functionCall("max", [.identifier("a"), .identifier("b")])
+                )
+            )
+        )
+        #expect(expr == expected)
+    }
+    
+    @Test func testMixedPrecedenceExpression() throws {
+        // x + y * z > a and b ≠ c or d
+        // Should be parsed as: (((x + (y * z)) > a) and (b ≠ c)) or d
+        let expr = try parseExpression("x + y * z > a and b ≠ c or d")
+        let expected = Expression.binary(
+            .or,
+            .binary(
+                .and,
+                .binary(
+                    .greater,
+                    .binary(
+                        .add,
+                        .identifier("x"),
+                        .binary(.multiply, .identifier("y"), .identifier("z"))
+                    ),
+                    .identifier("a")
+                ),
+                .binary(.notEqual, .identifier("b"), .identifier("c"))
+            ),
+            .identifier("d")
+        )
+        #expect(expr == expected)
+    }
+    
+    // MARK: - Error Handling Tests
+    
+    @Test func testUnexpectedEndOfInput() throws {
+        #expect(throws: ParsingError.self) {
+            try parseExpression("")
+        }
+    }
+    
+    @Test func testIncompleteExpression() throws {
+        #expect(throws: ParsingError.self) {
+            try parseExpression("3 +")
+        }
+    }
+    
+    @Test func testMismatchedParentheses() throws {
+        #expect(throws: ParsingError.self) {
+            try parseExpression("(3 + 4")
+        }
+    }
+    
+    @Test func testUnexpectedToken() throws {
+        #expect(throws: ParsingError.self) {
+            try parseExpression("3 + +")
+        }
+    }
+    
+    @Test func testInvalidFunctionCall() throws {
+        #expect(throws: ParsingError.self) {
+            try parseExpression("123()")
+        }
+    }
+    
+    // MARK: - Edge Cases
+    
+    @Test func testNestedParentheses() throws {
+        let expr = try parseExpression("((1 + 2) * (3 + 4))")
+        let expected = Expression.binary(
+            .multiply,
+            .binary(.add, .literal(.integer(1)), .literal(.integer(2))),
+            .binary(.add, .literal(.integer(3)), .literal(.integer(4)))
+        )
+        #expect(expr == expected)
+    }
+    
+    @Test func testChainedArrayAccess() throws {
+        let expr = try parseExpression("matrix[i][j]")
+        let expected = Expression.arrayAccess(
+            .arrayAccess(.identifier("matrix"), .identifier("i")),
+            .identifier("j")
+        )
+        #expect(expr == expected)
+    }
+    
+    @Test func testMixedPostfixOperations() throws {
+        // func(x)[0] should be parsed as (func(x))[0]
+        let expr = try parseExpression("getValue()[0]")
+        let expected = Expression.arrayAccess(
+            .functionCall("getValue", []),
+            .literal(.integer(0))
+        )
+        #expect(expr == expected)
+    }
+    
+    // MARK: - Performance Tests
+    
+    @Test func testLargeExpression() throws {
+        // Test parsing of a large expression with many terms
+        let input = Array(1...50).map(String.init).joined(separator: " + ")
+        let expr = try parseExpression(input)
+        
+        // Verify it's a left-associative addition chain
+        var current = expr
+        var count = 0
+        while case .binary(.add, let left, _) = current {
+            count += 1
+            current = left
+        }
+        
+        // The leftmost element should be a literal
+        #expect(current == .literal(.integer(1)))
+        #expect(count == 49) // 49 additions for 50 numbers
+    }
+    
+    // MARK: - Real-world Examples
+    
+    @Test func testRealWorldExample1() throws {
+        // Quadratic formula: (-b + sqrt(b * b - 4 * a * c)) / (2 * a)
+        let expr = try parseExpression("(-b + sqrt(b * b - 4 * a * c)) / (2 * a)")
+        
+        // Just verify it parses without error and has the expected top-level structure
+        guard case .binary(.divide, let numerator, let denominator) = expr else {
+            Issue.record("Expected division at top level")
+            return
+        }
+        
+        // Verify denominator is 2 * a
+        guard case .binary(.multiply, .literal(.integer(2)), .identifier("a")) = denominator else {
+            Issue.record("Expected '2 * a' as denominator")
+            return
+        }
+        
+        // Verify numerator is a parenthesized addition
+        guard case .binary(.add, .unary(.minus, .identifier("b")), .functionCall("sqrt", _)) = numerator else {
+            Issue.record("Expected '(-b + sqrt(...))' as numerator")
+            return
+        }
+    }
+    
+    @Test func testRealWorldExample2() throws {
+        // Conditional expression: x ≧ 0 and x ≦ 100 and y > min(a, b)
+        let expr = try parseExpression("x ≧ 0 and x ≦ 100 and y > min(a, b)")
+        
+        // Verify it parses as left-associative and operations
+        guard case .binary(.and, let left, let right) = expr else {
+            Issue.record("Expected 'and' at top level")
+            return
+        }
+        
+        guard case .binary(.and, _, _) = left else {
+            Issue.record("Expected nested 'and' on left side")
+            return
+        }
+        
+        guard case .binary(.greater, .identifier("y"), .functionCall("min", _)) = right else {
+            Issue.record("Expected 'y > min(a, b)' on right side")
+            return
+        }
+    }
+} 

--- a/Tests/FeLangCoreTests/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/ExpressionParserTests.swift
@@ -7,90 +7,90 @@ typealias FEExpression = FeLangCore.Expression
 
 @Suite("ExpressionParser Tests")
 struct ExpressionParserTests {
-    
+
     // MARK: - Helper Methods
-    
+
     /// Helper method to tokenize and parse an expression
     private func parseExpression(_ input: String) throws -> FEExpression {
         let tokens = try ParsingTokenizer.tokenize(input)
         let parser = ExpressionParser()
         return try parser.parseExpression(from: tokens)
     }
-    
+
     /// Helper method to create a source position for testing
     private func testPosition() -> SourcePosition {
         return SourcePosition(line: 1, column: 1, offset: 0)
     }
-    
+
     // MARK: - Basic Literal Tests
-    
+
     @Test func testIntegerLiteral() throws {
         let expr = try parseExpression("42")
         #expect(expr == .literal(Literal.integer(42)))
     }
-    
+
     @Test func testRealLiteral() throws {
         let expr = try parseExpression("3.14")
         #expect(expr == .literal(Literal.real(3.14)))
     }
-    
+
     @Test func testStringLiteral() throws {
         let expr = try parseExpression("'hello'")
         #expect(expr == .literal(Literal.string("hello")))
     }
-    
+
     @Test func testCharacterLiteral() throws {
         let expr = try parseExpression("'A'")
         #expect(expr == .literal(.character("A")))
     }
-    
+
     @Test func testBooleanLiterals() throws {
         let trueExpr = try parseExpression("true")
         let falseExpr = try parseExpression("false")
-        
+
         #expect(trueExpr == .literal(.boolean(true)))
         #expect(falseExpr == .literal(.boolean(false)))
     }
-    
+
     @Test func testIdentifier() throws {
         let expr = try parseExpression("variable")
         #expect(expr == .identifier("variable"))
     }
-    
+
     // MARK: - Basic Arithmetic Tests
-    
+
     @Test func testSimpleAddition() throws {
         let expr = try parseExpression("1 + 2")
         let expected = Expression.binary(.add, .literal(.integer(1)), .literal(.integer(2)))
         #expect(expr == expected)
     }
-    
+
     @Test func testSimpleSubtraction() throws {
         let expr = try parseExpression("5 - 3")
         let expected = Expression.binary(.subtract, .literal(.integer(5)), .literal(.integer(3)))
         #expect(expr == expected)
     }
-    
+
     @Test func testSimpleMultiplication() throws {
         let expr = try parseExpression("4 * 5")
         let expected = Expression.binary(.multiply, .literal(.integer(4)), .literal(.integer(5)))
         #expect(expr == expected)
     }
-    
+
     @Test func testSimpleDivision() throws {
         let expr = try parseExpression("10 / 2")
         let expected = Expression.binary(.divide, .literal(.integer(10)), .literal(.integer(2)))
         #expect(expr == expected)
     }
-    
+
     @Test func testModulo() throws {
         let expr = try parseExpression("7 % 3")
         let expected = Expression.binary(.modulo, .literal(.integer(7)), .literal(.integer(3)))
         #expect(expr == expected)
     }
-    
+
     // MARK: - Precedence Tests
-    
+
     @Test func testArithmeticPrecedence() throws {
         // 3 + 4 * 5 should be parsed as 3 + (4 * 5) = 23
         let expr = try parseExpression("3 + 4 * 5")
@@ -101,7 +101,7 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     @Test func testParenthesesOverridePrecedence() throws {
         // (3 + 4) * 5 should be parsed as (3 + 4) * 5 = 35
         let expr = try parseExpression("(3 + 4) * 5")
@@ -112,7 +112,7 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     @Test func testMultiplicationDivisionPrecedence() throws {
         // 8 / 2 * 3 should be parsed as (8 / 2) * 3 = 12 (left associative)
         let expr = try parseExpression("8 / 2 * 3")
@@ -123,9 +123,9 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     // MARK: - Left Associativity Tests
-    
+
     @Test func testLeftAssociativityAddition() throws {
         // 1 + 2 + 3 should be parsed as ((1 + 2) + 3) = 6
         let expr = try parseExpression("1 + 2 + 3")
@@ -136,7 +136,7 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     @Test func testLeftAssociativityMultiplication() throws {
         // 2 * 3 * 4 should be parsed as ((2 * 3) * 4) = 24
         let expr = try parseExpression("2 * 3 * 4")
@@ -147,7 +147,7 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     @Test func testLeftAssociativitySubtraction() throws {
         // 10 - 3 - 2 should be parsed as ((10 - 3) - 2) = 5
         let expr = try parseExpression("10 - 3 - 2")
@@ -158,21 +158,21 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     // MARK: - Comparison Operator Tests
-    
+
     @Test func testEqualityOperator() throws {
         let expr = try parseExpression("x = 5")
         let expected = Expression.binary(.equal, .identifier("x"), .literal(.integer(5)))
         #expect(expr == expected)
     }
-    
+
     @Test func testInequalityOperator() throws {
         let expr = try parseExpression("y ≠ 0")
         let expected = Expression.binary(.notEqual, .identifier("y"), .literal(.integer(0)))
         #expect(expr == expected)
     }
-    
+
     @Test func testComparisonOperators() throws {
         let tests = [
             ("a > b", BinaryOperator.greater),
@@ -180,16 +180,16 @@ struct ExpressionParserTests {
             ("a < b", BinaryOperator.less),
             ("a ≦ b", BinaryOperator.lessEqual)
         ]
-        
+
         for (input, expectedOp) in tests {
             let expr = try parseExpression(input)
             let expected = Expression.binary(expectedOp, .identifier("a"), .identifier("b"))
             #expect(expr == expected)
         }
     }
-    
+
     // MARK: - Logical Operator Tests
-    
+
     @Test func testLogicalAnd() throws {
         let expr = try parseExpression("x > 0 and y < 10")
         let expected = Expression.binary(
@@ -199,7 +199,7 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     @Test func testLogicalOr() throws {
         let expr = try parseExpression("a = 1 or b = 2")
         let expected = Expression.binary(
@@ -209,7 +209,7 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     @Test func testLogicalPrecedence() throws {
         // a = b and c ≠ d should be parsed as (a = b) and (c ≠ d)
         let expr = try parseExpression("a = b and c ≠ d")
@@ -220,27 +220,27 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     // MARK: - Unary Operator Tests
-    
+
     @Test func testUnaryNot() throws {
         let expr = try parseExpression("not x")
         let expected = Expression.unary(.not, .identifier("x"))
         #expect(expr == expected)
     }
-    
+
     @Test func testUnaryPlus() throws {
         let expr = try parseExpression("+42")
         let expected = Expression.unary(.plus, .literal(.integer(42)))
         #expect(expr == expected)
     }
-    
+
     @Test func testUnaryMinus() throws {
         let expr = try parseExpression("-5")
         let expected = Expression.unary(.minus, .literal(.integer(5)))
         #expect(expr == expected)
     }
-    
+
     @Test func testUnaryPrecedence() throws {
         // not x or y should be parsed as (not x) or y
         let expr = try parseExpression("not x or y")
@@ -251,15 +251,15 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     // MARK: - Array Access Tests
-    
+
     @Test func testSimpleArrayAccess() throws {
         let expr = try parseExpression("array[0]")
         let expected = Expression.arrayAccess(.identifier("array"), .literal(.integer(0)))
         #expect(expr == expected)
     }
-    
+
     @Test func testArrayAccessWithExpression() throws {
         // array[i + 1] * 2 should be parsed as (array[(i + 1)]) * 2
         let expr = try parseExpression("array[i + 1] * 2")
@@ -273,15 +273,15 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     // MARK: - Function Call Tests
-    
+
     @Test func testSimpleFunctionCall() throws {
         let expr = try parseExpression("max(a, b)")
         let expected = Expression.functionCall("max", [.identifier("a"), .identifier("b")])
         #expect(expr == expected)
     }
-    
+
     @Test func testFunctionCallWithExpressions() throws {
         // func(a + b, c * d) should be parsed as func((a + b), (c * d))
         let expr = try parseExpression("func(a + b, c * d)")
@@ -294,15 +294,15 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     @Test func testFunctionCallNoArguments() throws {
         let expr = try parseExpression("getValue()")
         let expected = Expression.functionCall("getValue", [])
         #expect(expr == expected)
     }
-    
+
     // MARK: - Complex Expression Tests
-    
+
     @Test func testComplexArithmeticExpression() throws {
         // 1 + 2 * 3 - 4 / 2 should be parsed as (1 + (2 * 3)) - (4 / 2)
         let expr = try parseExpression("1 + 2 * 3 - 4 / 2")
@@ -317,7 +317,7 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     @Test func testComplexLogicalExpression() throws {
         // not (x > 0 and y < max(a, b))
         let expr = try parseExpression("not (x > 0 and y < max(a, b))")
@@ -335,7 +335,7 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     @Test func testMixedPrecedenceExpression() throws {
         // x + y * z > a and b ≠ c or d
         // Should be parsed as: (((x + (y * z)) > a) and (b ≠ c)) or d
@@ -359,41 +359,41 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     // MARK: - Error Handling Tests
-    
+
     @Test func testUnexpectedEndOfInput() throws {
         #expect(throws: ParsingError.self) {
             try parseExpression("")
         }
     }
-    
+
     @Test func testIncompleteExpression() throws {
         #expect(throws: ParsingError.self) {
             try parseExpression("3 +")
         }
     }
-    
+
     @Test func testMismatchedParentheses() throws {
         #expect(throws: ParsingError.self) {
             try parseExpression("(3 + 4")
         }
     }
-    
+
     @Test func testUnexpectedToken() throws {
         #expect(throws: ParsingError.self) {
             try parseExpression("3 + +")
         }
     }
-    
+
     @Test func testInvalidFunctionCall() throws {
         #expect(throws: ParsingError.self) {
             try parseExpression("123()")
         }
     }
-    
+
     // MARK: - Edge Cases
-    
+
     @Test func testNestedParentheses() throws {
         let expr = try parseExpression("((1 + 2) * (3 + 4))")
         let expected = Expression.binary(
@@ -403,7 +403,7 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     @Test func testChainedArrayAccess() throws {
         let expr = try parseExpression("matrix[i][j]")
         let expected = Expression.arrayAccess(
@@ -412,7 +412,7 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     @Test func testMixedPostfixOperations() throws {
         // func(x)[0] should be parsed as (func(x))[0]
         let expr = try parseExpression("getValue()[0]")
@@ -422,14 +422,14 @@ struct ExpressionParserTests {
         )
         #expect(expr == expected)
     }
-    
+
     // MARK: - Performance Tests
-    
+
     @Test func testLargeExpression() throws {
         // Test parsing of a large expression with many terms
         let input = Array(1...50).map(String.init).joined(separator: " + ")
         let expr = try parseExpression(input)
-        
+
         // Verify it's a left-associative addition chain
         var current = expr
         var count = 0
@@ -437,55 +437,55 @@ struct ExpressionParserTests {
             count += 1
             current = left
         }
-        
+
         // The leftmost element should be a literal
         #expect(current == .literal(.integer(1)))
         #expect(count == 49) // 49 additions for 50 numbers
     }
-    
+
     // MARK: - Real-world Examples
-    
+
     @Test func testRealWorldExample1() throws {
         // Quadratic formula: (-b + sqrt(b * b - 4 * a * c)) / (2 * a)
         let expr = try parseExpression("(-b + sqrt(b * b - 4 * a * c)) / (2 * a)")
-        
+
         // Just verify it parses without error and has the expected top-level structure
         guard case .binary(.divide, let numerator, let denominator) = expr else {
             Issue.record("Expected division at top level")
             return
         }
-        
+
         // Verify denominator is 2 * a
         guard case .binary(.multiply, .literal(.integer(2)), .identifier("a")) = denominator else {
             Issue.record("Expected '2 * a' as denominator")
             return
         }
-        
+
         // Verify numerator is a parenthesized addition
         guard case .binary(.add, .unary(.minus, .identifier("b")), .functionCall("sqrt", _)) = numerator else {
             Issue.record("Expected '(-b + sqrt(...))' as numerator")
             return
         }
     }
-    
+
     @Test func testRealWorldExample2() throws {
         // Conditional expression: x ≧ 0 and x ≦ 100 and y > min(a, b)
         let expr = try parseExpression("x ≧ 0 and x ≦ 100 and y > min(a, b)")
-        
+
         // Verify it parses as left-associative and operations
         guard case .binary(.and, let left, let right) = expr else {
             Issue.record("Expected 'and' at top level")
             return
         }
-        
+
         guard case .binary(.and, _, _) = left else {
             Issue.record("Expected nested 'and' on left side")
             return
         }
-        
+
         guard case .binary(.greater, .identifier("y"), .functionCall("min", _)) = right else {
             Issue.record("Expected 'y > min(a, b)' on right side")
             return
         }
     }
-} 
+}


### PR DESCRIPTION
Introduced the Expression enum to represent various expression types, including literals, identifiers, binary and unary operations, and function calls. Implemented the ExpressionParser to handle parsing of expressions using a precedence climbing algorithm, ensuring correct operator precedence and left-associativity. Added comprehensive tests for the ExpressionParser to validate parsing behavior across various scenarios, including literals, arithmetic operations, logical expressions, and error handling.