### PR TITLE
Implement visitor pattern infrastructure for AST traversal

### DIFF
--- a/Sources/FeLangCore/Visitor/ASTWalker.swift
+++ b/Sources/FeLangCore/Visitor/ASTWalker.swift
@@ -1,0 +1,244 @@
+import Foundation
+
+/// ASTWalker provides automatic recursive traversal of AST structures.
+/// This is useful for visitors that need to process entire AST trees recursively.
+public struct ASTWalker: Sendable {
+    
+    /// Recursively walks an expression tree, applying the visitor to each node
+    /// and combining results using the provided accumulator function.
+    public static func walkExpression<Result>(
+        _ expression: Expression,
+        visitor: ExpressionVisitor<Result>,
+        accumulator: @Sendable (Result, Result) -> Result,
+        identity: Result
+    ) -> Result {
+        let currentResult = visitor.visit(expression)
+        
+        // Recursively process child expressions
+        let childResults = getChildExpressions(expression).map { childExpr in
+            walkExpression(childExpr, visitor: visitor, accumulator: accumulator, identity: identity)
+        }
+        
+        // Combine current result with child results
+        return childResults.reduce(currentResult, accumulator)
+    }
+    
+    /// Recursively walks a statement tree, applying the visitor to each node
+    /// and combining results using the provided accumulator function.
+    public static func walkStatement<Result>(
+        _ statement: Statement,
+        statementVisitor: StatementVisitor<Result>,
+        expressionVisitor: ExpressionVisitor<Result>,
+        accumulator: @Sendable (Result, Result) -> Result,
+        identity: Result
+    ) -> Result {
+        let currentResult = statementVisitor.visit(statement)
+        
+        // Process child expressions
+        let expressionResults = getChildExpressions(statement).map { expr in
+            walkExpression(expr, visitor: expressionVisitor, accumulator: accumulator, identity: identity)
+        }
+        
+        // Process child statements
+        let statementResults = getChildStatements(statement).map { stmt in
+            walkStatement(stmt, statementVisitor: statementVisitor, expressionVisitor: expressionVisitor, accumulator: accumulator, identity: identity)
+        }
+        
+        // Combine all results
+        let allResults = expressionResults + statementResults
+        return allResults.reduce(currentResult, accumulator)
+    }
+    
+    /// Collects all expressions in an expression tree using a collecting visitor
+    public static func collectExpressions<T>(
+        _ expression: Expression,
+        collector: @Sendable (Expression) -> [T]
+    ) -> [T] {
+        let visitor = ExpressionVisitor<[T]>(
+            visitLiteral: { _ in collector(expression) },
+            visitIdentifier: { _ in collector(expression) },
+            visitBinary: { _, _, _ in collector(expression) },
+            visitUnary: { _, _ in collector(expression) },
+            visitArrayAccess: { _, _ in collector(expression) },
+            visitFieldAccess: { _, _ in collector(expression) },
+            visitFunctionCall: { _, _ in collector(expression) }
+        )
+        
+        return walkExpression(expression, visitor: visitor, accumulator: +, identity: [])
+    }
+    
+    /// Collects all statements in a statement tree using a collecting visitor
+    public static func collectStatements<T>(
+        _ statement: Statement,
+        statementCollector: @Sendable (Statement) -> [T],
+        expressionCollector: @Sendable (Expression) -> [T] = { _ in [] }
+    ) -> [T] {
+        let statementVisitor = StatementVisitor<[T]>(
+            visitIfStatement: { _ in statementCollector(statement) },
+            visitWhileStatement: { _ in statementCollector(statement) },
+            visitForStatement: { _ in statementCollector(statement) },
+            visitAssignment: { _ in statementCollector(statement) },
+            visitVariableDeclaration: { _ in statementCollector(statement) },
+            visitConstantDeclaration: { _ in statementCollector(statement) },
+            visitFunctionDeclaration: { _ in statementCollector(statement) },
+            visitProcedureDeclaration: { _ in statementCollector(statement) },
+            visitReturnStatement: { _ in statementCollector(statement) },
+            visitExpressionStatement: { _ in statementCollector(statement) },
+            visitBreakStatement: { statementCollector(statement) },
+            visitBlock: { _ in statementCollector(statement) }
+        )
+        
+        let expressionVisitor = ExpressionVisitor<[T]>(
+            visitLiteral: { _ in [] },
+            visitIdentifier: { _ in [] },
+            visitBinary: { _, _, _ in [] },
+            visitUnary: { _, _ in [] },
+            visitArrayAccess: { _, _ in [] },
+            visitFieldAccess: { _, _ in [] },
+            visitFunctionCall: { _, _ in [] }
+        )
+        
+        return walkStatement(statement, statementVisitor: statementVisitor, expressionVisitor: expressionVisitor, accumulator: +, identity: [])
+    }
+    
+    /// Transforms an expression tree by applying a transformation function to each node
+    public static func transformExpression(
+        _ expression: Expression,
+        transform: @Sendable (Expression) -> Expression
+    ) -> Expression {
+        // First transform child expressions
+        let transformedExpression: Expression
+        switch expression {
+        case .literal:
+            transformedExpression = expression
+        case .identifier:
+            transformedExpression = expression
+        case .binary(let op, let left, let right):
+            let transformedLeft = transformExpression(left, transform: transform)
+            let transformedRight = transformExpression(right, transform: transform)
+            transformedExpression = .binary(op, transformedLeft, transformedRight)
+        case .unary(let op, let expr):
+            let transformedExpr = transformExpression(expr, transform: transform)
+            transformedExpression = .unary(op, transformedExpr)
+        case .arrayAccess(let array, let index):
+            let transformedArray = transformExpression(array, transform: transform)
+            let transformedIndex = transformExpression(index, transform: transform)
+            transformedExpression = .arrayAccess(transformedArray, transformedIndex)
+        case .fieldAccess(let expr, let field):
+            let transformedExpr = transformExpression(expr, transform: transform)
+            transformedExpression = .fieldAccess(transformedExpr, field)
+        case .functionCall(let name, let args):
+            let transformedArgs = args.map { transformExpression($0, transform: transform) }
+            transformedExpression = .functionCall(name, transformedArgs)
+        }
+        
+        // Then apply transformation to the current node
+        return transform(transformedExpression)
+    }
+    
+    // MARK: - Helper methods for extracting child nodes
+    
+    /// Extracts child expressions from an expression
+    private static func getChildExpressions(_ expression: Expression) -> [Expression] {
+        switch expression {
+        case .literal, .identifier:
+            return []
+        case .binary(_, let left, let right):
+            return [left, right]
+        case .unary(_, let expr):
+            return [expr]
+        case .arrayAccess(let array, let index):
+            return [array, index]
+        case .fieldAccess(let expr, _):
+            return [expr]
+        case .functionCall(_, let args):
+            return args
+        }
+    }
+    
+    /// Extracts child expressions from a statement
+    private static func getChildExpressions(_ statement: Statement) -> [Expression] {
+        switch statement {
+        case .ifStatement(let ifStmt):
+            var expressions = [ifStmt.condition]
+            expressions.append(contentsOf: ifStmt.elseIfs.map { $0.condition })
+            return expressions
+        case .whileStatement(let whileStmt):
+            return [whileStmt.condition]
+        case .forStatement(let forStmt):
+            switch forStmt {
+            case .range(let rangeFor):
+                var expressions = [rangeFor.start, rangeFor.end]
+                if let step = rangeFor.step {
+                    expressions.append(step)
+                }
+                return expressions
+            case .forEach(let forEachLoop):
+                return [forEachLoop.iterable]
+            }
+        case .assignment(let assignment):
+            switch assignment {
+            case .variable(_, let expr):
+                return [expr]
+            case .arrayElement(let arrayAccess, let expr):
+                return [arrayAccess.array, arrayAccess.index, expr]
+            }
+        case .variableDeclaration(let varDecl):
+            return varDecl.initialValue.map { [$0] } ?? []
+        case .constantDeclaration(let constDecl):
+            return [constDecl.initialValue]
+        case .functionDeclaration:
+            return []
+        case .procedureDeclaration:
+            return []
+        case .returnStatement(let returnStmt):
+            return returnStmt.expression.map { [$0] } ?? []
+        case .expressionStatement(let expr):
+            return [expr]
+        case .breakStatement:
+            return []
+        case .block:
+            return []
+        }
+    }
+    
+    /// Extracts child statements from a statement
+    private static func getChildStatements(_ statement: Statement) -> [Statement] {
+        switch statement {
+        case .ifStatement(let ifStmt):
+            var statements = ifStmt.thenBody
+            statements.append(contentsOf: ifStmt.elseIfs.flatMap { $0.body })
+            if let elseBody = ifStmt.elseBody {
+                statements.append(contentsOf: elseBody)
+            }
+            return statements
+        case .whileStatement(let whileStmt):
+            return whileStmt.body
+        case .forStatement(let forStmt):
+            switch forStmt {
+            case .range(let rangeFor):
+                return rangeFor.body
+            case .forEach(let forEachLoop):
+                return forEachLoop.body
+            }
+        case .assignment:
+            return []
+        case .variableDeclaration:
+            return []
+        case .constantDeclaration:
+            return []
+        case .functionDeclaration(let funcDecl):
+            return funcDecl.body
+        case .procedureDeclaration(let procDecl):
+            return procDecl.body
+        case .returnStatement:
+            return []
+        case .expressionStatement:
+            return []
+        case .breakStatement:
+            return []
+        case .block(let statements):
+            return statements
+        }
+    }
+}

--- a/Sources/FeLangCore/Visitor/ExpressionVisitor.swift
+++ b/Sources/FeLangCore/Visitor/ExpressionVisitor.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// A function-based visitor for traversing Expression AST nodes.
+/// This implementation uses closures for maximum flexibility and Swift idiomaticity.
+public struct ExpressionVisitor<Result>: Sendable {
+    /// Closure for visiting literal expressions
+    public let visitLiteral: @Sendable (Literal) -> Result
+    
+    /// Closure for visiting identifier expressions
+    public let visitIdentifier: @Sendable (String) -> Result
+    
+    /// Closure for visiting binary expressions
+    public let visitBinary: @Sendable (BinaryOperator, Expression, Expression) -> Result
+    
+    /// Closure for visiting unary expressions
+    public let visitUnary: @Sendable (UnaryOperator, Expression) -> Result
+    
+    /// Closure for visiting array access expressions
+    public let visitArrayAccess: @Sendable (Expression, Expression) -> Result
+    
+    /// Closure for visiting field access expressions
+    public let visitFieldAccess: @Sendable (Expression, String) -> Result
+    
+    /// Closure for visiting function call expressions
+    public let visitFunctionCall: @Sendable (String, [Expression]) -> Result
+    
+    /// Initializes a new ExpressionVisitor with the provided closures
+    public init(
+        visitLiteral: @escaping @Sendable (Literal) -> Result,
+        visitIdentifier: @escaping @Sendable (String) -> Result,
+        visitBinary: @escaping @Sendable (BinaryOperator, Expression, Expression) -> Result,
+        visitUnary: @escaping @Sendable (UnaryOperator, Expression) -> Result,
+        visitArrayAccess: @escaping @Sendable (Expression, Expression) -> Result,
+        visitFieldAccess: @escaping @Sendable (Expression, String) -> Result,
+        visitFunctionCall: @escaping @Sendable (String, [Expression]) -> Result
+    ) {
+        self.visitLiteral = visitLiteral
+        self.visitIdentifier = visitIdentifier
+        self.visitBinary = visitBinary
+        self.visitUnary = visitUnary
+        self.visitArrayAccess = visitArrayAccess
+        self.visitFieldAccess = visitFieldAccess
+        self.visitFunctionCall = visitFunctionCall
+    }
+    
+    /// Visits an expression and returns the result using the appropriate closure
+    public func visit(_ expression: Expression) -> Result {
+        switch expression {
+        case .literal(let literal):
+            return visitLiteral(literal)
+        case .identifier(let name):
+            return visitIdentifier(name)
+        case .binary(let op, let left, let right):
+            return visitBinary(op, left, right)
+        case .unary(let op, let expr):
+            return visitUnary(op, expr)
+        case .arrayAccess(let array, let index):
+            return visitArrayAccess(array, index)
+        case .fieldAccess(let expr, let field):
+            return visitFieldAccess(expr, field)
+        case .functionCall(let name, let args):
+            return visitFunctionCall(name, args)
+        }
+    }
+}
+
+/// Convenience extension for creating common visitor patterns
+extension ExpressionVisitor {
+    /// Creates a visitor that converts expressions to strings for debugging
+    public static func makeDebugVisitor() -> ExpressionVisitor<String> {
+        return ExpressionVisitor<String>(
+            visitLiteral: { literal in
+                switch literal {
+                case .integer(let value):
+                    return "\(value)"
+                case .real(let value):
+                    return "\(value)"
+                case .string(let value):
+                    return "\"\(value)\""
+                case .character(let value):
+                    return "'\(value)'"
+                case .boolean(let value):
+                    return "\(value)"
+                }
+            },
+            visitIdentifier: { name in
+                return name
+            },
+            visitBinary: { op, left, right in
+                let leftStr = ExpressionVisitor.makeDebugVisitor().visit(left)
+                let rightStr = ExpressionVisitor.makeDebugVisitor().visit(right)
+                return "(\(leftStr) \(op.rawValue) \(rightStr))"
+            },
+            visitUnary: { op, expr in
+                let exprStr = ExpressionVisitor.makeDebugVisitor().visit(expr)
+                return "\(op.rawValue)\(exprStr)"
+            },
+            visitArrayAccess: { array, index in
+                let arrayStr = ExpressionVisitor.makeDebugVisitor().visit(array)
+                let indexStr = ExpressionVisitor.makeDebugVisitor().visit(index)
+                return "\(arrayStr)[\(indexStr)]"
+            },
+            visitFieldAccess: { expr, field in
+                let exprStr = ExpressionVisitor.makeDebugVisitor().visit(expr)
+                return "\(exprStr).\(field)"
+            },
+            visitFunctionCall: { name, args in
+                let argsStr = args.map { ExpressionVisitor.makeDebugVisitor().visit($0) }.joined(separator: ", ")
+                return "\(name)(\(argsStr))"
+            }
+        )
+    }
+}

--- a/Sources/FeLangCore/Visitor/StatementVisitor.swift
+++ b/Sources/FeLangCore/Visitor/StatementVisitor.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+/// A function-based visitor for traversing Statement AST nodes.
+/// This implementation uses closures for maximum flexibility and Swift idiomaticity.
+public struct StatementVisitor<Result>: Sendable {
+    /// Closure for visiting if statements
+    public let visitIfStatement: @Sendable (IfStatement) -> Result
+    
+    /// Closure for visiting while statements
+    public let visitWhileStatement: @Sendable (WhileStatement) -> Result
+    
+    /// Closure for visiting for statements
+    public let visitForStatement: @Sendable (ForStatement) -> Result
+    
+    /// Closure for visiting assignment statements
+    public let visitAssignment: @Sendable (Assignment) -> Result
+    
+    /// Closure for visiting variable declarations
+    public let visitVariableDeclaration: @Sendable (VariableDeclaration) -> Result
+    
+    /// Closure for visiting constant declarations
+    public let visitConstantDeclaration: @Sendable (ConstantDeclaration) -> Result
+    
+    /// Closure for visiting function declarations
+    public let visitFunctionDeclaration: @Sendable (FunctionDeclaration) -> Result
+    
+    /// Closure for visiting procedure declarations
+    public let visitProcedureDeclaration: @Sendable (ProcedureDeclaration) -> Result
+    
+    /// Closure for visiting return statements
+    public let visitReturnStatement: @Sendable (ReturnStatement) -> Result
+    
+    /// Closure for visiting expression statements
+    public let visitExpressionStatement: @Sendable (Expression) -> Result
+    
+    /// Closure for visiting break statements
+    public let visitBreakStatement: @Sendable () -> Result
+    
+    /// Closure for visiting block statements
+    public let visitBlock: @Sendable ([Statement]) -> Result
+    
+    /// Initializes a new StatementVisitor with the provided closures
+    public init(
+        visitIfStatement: @escaping @Sendable (IfStatement) -> Result,
+        visitWhileStatement: @escaping @Sendable (WhileStatement) -> Result,
+        visitForStatement: @escaping @Sendable (ForStatement) -> Result,
+        visitAssignment: @escaping @Sendable (Assignment) -> Result,
+        visitVariableDeclaration: @escaping @Sendable (VariableDeclaration) -> Result,
+        visitConstantDeclaration: @escaping @Sendable (ConstantDeclaration) -> Result,
+        visitFunctionDeclaration: @escaping @Sendable (FunctionDeclaration) -> Result,
+        visitProcedureDeclaration: @escaping @Sendable (ProcedureDeclaration) -> Result,
+        visitReturnStatement: @escaping @Sendable (ReturnStatement) -> Result,
+        visitExpressionStatement: @escaping @Sendable (Expression) -> Result,
+        visitBreakStatement: @escaping @Sendable () -> Result,
+        visitBlock: @escaping @Sendable ([Statement]) -> Result
+    ) {
+        self.visitIfStatement = visitIfStatement
+        self.visitWhileStatement = visitWhileStatement
+        self.visitForStatement = visitForStatement
+        self.visitAssignment = visitAssignment
+        self.visitVariableDeclaration = visitVariableDeclaration
+        self.visitConstantDeclaration = visitConstantDeclaration
+        self.visitFunctionDeclaration = visitFunctionDeclaration
+        self.visitProcedureDeclaration = visitProcedureDeclaration
+        self.visitReturnStatement = visitReturnStatement
+        self.visitExpressionStatement = visitExpressionStatement
+        self.visitBreakStatement = visitBreakStatement
+        self.visitBlock = visitBlock
+    }
+    
+    /// Visits a statement and returns the result using the appropriate closure
+    public func visit(_ statement: Statement) -> Result {
+        switch statement {
+        case .ifStatement(let ifStmt):
+            return visitIfStatement(ifStmt)
+        case .whileStatement(let whileStmt):
+            return visitWhileStatement(whileStmt)
+        case .forStatement(let forStmt):
+            return visitForStatement(forStmt)
+        case .assignment(let assignment):
+            return visitAssignment(assignment)
+        case .variableDeclaration(let varDecl):
+            return visitVariableDeclaration(varDecl)
+        case .constantDeclaration(let constDecl):
+            return visitConstantDeclaration(constDecl)
+        case .functionDeclaration(let funcDecl):
+            return visitFunctionDeclaration(funcDecl)
+        case .procedureDeclaration(let procDecl):
+            return visitProcedureDeclaration(procDecl)
+        case .returnStatement(let returnStmt):
+            return visitReturnStatement(returnStmt)
+        case .expressionStatement(let expr):
+            return visitExpressionStatement(expr)
+        case .breakStatement:
+            return visitBreakStatement()
+        case .block(let statements):
+            return visitBlock(statements)
+        }
+    }
+}
+
+/// Convenience extension for creating common visitor patterns
+extension StatementVisitor {
+    /// Creates a visitor that converts statements to strings for debugging
+    public static func makeDebugVisitor() -> StatementVisitor<String> {
+        return StatementVisitor<String>(
+            visitIfStatement: { ifStmt in
+                let conditionStr = ExpressionVisitor<String>.makeDebugVisitor().visit(ifStmt.condition)
+                let thenStr = ifStmt.thenBody.map { StatementVisitor.makeDebugVisitor().visit($0) }.joined(separator: "; ")
+                let elseIfStr = ifStmt.elseIfs.map { elseIf in
+                    let condStr = ExpressionVisitor<String>.makeDebugVisitor().visit(elseIf.condition)
+                    let bodyStr = elseIf.body.map { StatementVisitor.makeDebugVisitor().visit($0) }.joined(separator: "; ")
+                    return "elif \(condStr) then [\(bodyStr)]"
+                }.joined(separator: " ")
+                let elseStr = ifStmt.elseBody?.map { StatementVisitor.makeDebugVisitor().visit($0) }.joined(separator: "; ") ?? ""
+                return "if \(conditionStr) then [\(thenStr)]\(elseIfStr.isEmpty ? "" : " \(elseIfStr)")\(elseStr.isEmpty ? "" : " else [\(elseStr)]")"
+            },
+            visitWhileStatement: { whileStmt in
+                let conditionStr = ExpressionVisitor<String>.makeDebugVisitor().visit(whileStmt.condition)
+                let bodyStr = whileStmt.body.map { StatementVisitor.makeDebugVisitor().visit($0) }.joined(separator: "; ")
+                return "while \(conditionStr) do [\(bodyStr)]"
+            },
+            visitForStatement: { forStmt in
+                switch forStmt {
+                case .range(let rangeFor):
+                    let startStr = ExpressionVisitor<String>.makeDebugVisitor().visit(rangeFor.start)
+                    let endStr = ExpressionVisitor<String>.makeDebugVisitor().visit(rangeFor.end)
+                    let stepStr = rangeFor.step.map { ExpressionVisitor<String>.makeDebugVisitor().visit($0) } ?? "1"
+                    let bodyStr = rangeFor.body.map { StatementVisitor.makeDebugVisitor().visit($0) }.joined(separator: "; ")
+                    return "for \(rangeFor.variable) := \(startStr) to \(endStr) step \(stepStr) do [\(bodyStr)]"
+                case .forEach(let forEachLoop):
+                    let iterableStr = ExpressionVisitor<String>.makeDebugVisitor().visit(forEachLoop.iterable)
+                    let bodyStr = forEachLoop.body.map { StatementVisitor.makeDebugVisitor().visit($0) }.joined(separator: "; ")
+                    return "for \(forEachLoop.variable) in \(iterableStr) do [\(bodyStr)]"
+                }
+            },
+            visitAssignment: { assignment in
+                switch assignment {
+                case .variable(let name, let expr):
+                    let exprStr = ExpressionVisitor<String>.makeDebugVisitor().visit(expr)
+                    return "\(name) := \(exprStr)"
+                case .arrayElement(let arrayAccess, let expr):
+                    let arrayStr = ExpressionVisitor<String>.makeDebugVisitor().visit(arrayAccess.array)
+                    let indexStr = ExpressionVisitor<String>.makeDebugVisitor().visit(arrayAccess.index)
+                    let exprStr = ExpressionVisitor<String>.makeDebugVisitor().visit(expr)
+                    return "\(arrayStr)[\(indexStr)] := \(exprStr)"
+                }
+            },
+            visitVariableDeclaration: { varDecl in
+                let initialStr = varDecl.initialValue.map { ExpressionVisitor<String>.makeDebugVisitor().visit($0) } ?? ""
+                return "var \(varDecl.name): \(varDecl.type)\(initialStr.isEmpty ? "" : " := \(initialStr)")"
+            },
+            visitConstantDeclaration: { constDecl in
+                let initialStr = ExpressionVisitor<String>.makeDebugVisitor().visit(constDecl.initialValue)
+                return "const \(constDecl.name): \(constDecl.type) := \(initialStr)"
+            },
+            visitFunctionDeclaration: { funcDecl in
+                let paramsStr = funcDecl.parameters.map { "\($0.name): \($0.type)" }.joined(separator: ", ")
+                let returnStr = funcDecl.returnType.map { ": \($0)" } ?? ""
+                let bodyStr = funcDecl.body.map { StatementVisitor.makeDebugVisitor().visit($0) }.joined(separator: "; ")
+                return "function \(funcDecl.name)(\(paramsStr))\(returnStr) [\(bodyStr)]"
+            },
+            visitProcedureDeclaration: { procDecl in
+                let paramsStr = procDecl.parameters.map { "\($0.name): \($0.type)" }.joined(separator: ", ")
+                let bodyStr = procDecl.body.map { StatementVisitor.makeDebugVisitor().visit($0) }.joined(separator: "; ")
+                return "procedure \(procDecl.name)(\(paramsStr)) [\(bodyStr)]"
+            },
+            visitReturnStatement: { returnStmt in
+                let exprStr = returnStmt.expression.map { ExpressionVisitor<String>.makeDebugVisitor().visit($0) } ?? ""
+                return "return\(exprStr.isEmpty ? "" : " \(exprStr)")"
+            },
+            visitExpressionStatement: { expr in
+                return ExpressionVisitor<String>.makeDebugVisitor().visit(expr)
+            },
+            visitBreakStatement: {
+                return "break"
+            },
+            visitBlock: { statements in
+                let stmtsStr = statements.map { StatementVisitor.makeDebugVisitor().visit($0) }.joined(separator: "; ")
+                return "{\(stmtsStr)}"
+            }
+        )
+    }
+}

--- a/Sources/FeLangCore/Visitor/Visitable.swift
+++ b/Sources/FeLangCore/Visitor/Visitable.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Protocol for AST nodes that can be visited by visitors.
+/// This provides a unified interface for traversing different AST node types.
+public protocol Visitable: Sendable {
+    /// Accepts a visitor and returns a result.
+    /// This method should dispatch to the appropriate visitor method based on the node type.
+    func accept<V: ASTVisitor>(_ visitor: V) -> V.Result
+}
+
+/// Base protocol for all AST visitors.
+/// This allows for generic visitor handling and composition.
+public protocol ASTVisitor: Sendable {
+    /// The result type produced by this visitor
+    associatedtype Result
+}
+
+/// A visitor that can handle both expressions and statements
+public protocol UnifiedVisitor: ASTVisitor {
+    /// Visit an expression node
+    func visitExpression(_ expression: Expression) -> Result
+    
+    /// Visit a statement node
+    func visitStatement(_ statement: Statement) -> Result
+}
+
+/// Extension to make Expression conform to Visitable
+extension Expression: Visitable {
+    public func accept<V: ASTVisitor>(_ visitor: V) -> V.Result {
+        if let expressionVisitor = visitor as? any ExpressionVisitorProtocol {
+            return expressionVisitor.visitExpressionNode(self) as! V.Result
+        } else if let unifiedVisitor = visitor as? any UnifiedVisitor {
+            return unifiedVisitor.visitExpression(self)
+        } else {
+            fatalError("Visitor does not support Expression nodes")
+        }
+    }
+}
+
+/// Extension to make Statement conform to Visitable
+extension Statement: Visitable {
+    public func accept<V: ASTVisitor>(_ visitor: V) -> V.Result {
+        if let statementVisitor = visitor as? any StatementVisitorProtocol {
+            return statementVisitor.visitStatementNode(self) as! V.Result
+        } else if let unifiedVisitor = visitor as? any UnifiedVisitor {
+            return unifiedVisitor.visitStatement(self)
+        } else {
+            fatalError("Visitor does not support Statement nodes")
+        }
+    }
+}
+
+/// Protocol for visitors that can handle expressions
+public protocol ExpressionVisitorProtocol: ASTVisitor {
+    func visitExpressionNode(_ expression: Expression) -> Result
+}
+
+/// Protocol for visitors that can handle statements
+public protocol StatementVisitorProtocol: ASTVisitor {
+    func visitStatementNode(_ statement: Statement) -> Result
+}
+
+/// Wrapper to make ExpressionVisitor conform to ExpressionVisitorProtocol
+public struct ExpressionVisitorWrapper<Result>: ExpressionVisitorProtocol {
+    private let visitor: ExpressionVisitor<Result>
+    
+    public init(_ visitor: ExpressionVisitor<Result>) {
+        self.visitor = visitor
+    }
+    
+    public func visitExpressionNode(_ expression: Expression) -> Result {
+        return visitor.visit(expression)
+    }
+}
+
+/// Wrapper to make StatementVisitor conform to StatementVisitorProtocol
+public struct StatementVisitorWrapper<Result>: StatementVisitorProtocol {
+    private let visitor: StatementVisitor<Result>
+    
+    public init(_ visitor: StatementVisitor<Result>) {
+        self.visitor = visitor
+    }
+    
+    public func visitStatementNode(_ statement: Statement) -> Result {
+        return visitor.visit(statement)
+    }
+}
+
+/// Convenience functions for using the visitor pattern with Visitable protocol
+extension Visitable {
+    /// Visits this node with an ExpressionVisitor
+    public func accept<Result>(_ visitor: ExpressionVisitor<Result>) -> Result {
+        let wrapper = ExpressionVisitorWrapper(visitor)
+        return accept(wrapper)
+    }
+    
+    /// Visits this node with a StatementVisitor
+    public func accept<Result>(_ visitor: StatementVisitor<Result>) -> Result {
+        let wrapper = StatementVisitorWrapper(visitor)
+        return accept(wrapper)
+    }
+}

--- a/Sources/FeLangCore/Visitor/VisitorModule.swift
+++ b/Sources/FeLangCore/Visitor/VisitorModule.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+/// The Visitor module provides a comprehensive visitor pattern infrastructure
+/// for traversing and processing FeLangKit AST nodes.
+///
+/// This module implements the function-based visitor pattern as outlined in the design document,
+/// providing maximum flexibility and Swift idiomatic code while maintaining thread safety
+/// through Sendable compliance.
+///
+/// ## Core Components
+///
+/// - `ExpressionVisitor<Result>`: Function-based visitor for Expression AST nodes
+/// - `StatementVisitor<Result>`: Function-based visitor for Statement AST nodes
+/// - `Visitable`: Protocol for unified traversal interface
+/// - `ASTWalker`: Utilities for automatic recursive traversal
+///
+/// ## Usage Examples
+///
+/// ### Basic Expression Visitor
+/// ```swift
+/// let debugVisitor = ExpressionVisitor<String>.makeDebugVisitor()
+/// let expr = Expression.binary(.add, .literal(.integer(1)), .literal(.integer(2)))
+/// let result = debugVisitor.visit(expr) // "(1 + 2)"
+/// ```
+///
+/// ### Custom Statement Visitor
+/// ```swift
+/// let countingVisitor = StatementVisitor<Int>(
+///     visitIfStatement: { _ in 1 },
+///     visitWhileStatement: { _ in 1 },
+///     // ... other visitor methods
+/// )
+/// let count = countingVisitor.visit(someStatement)
+/// ```
+///
+/// ### Recursive AST Walking
+/// ```swift
+/// let nodeCount = ASTWalker.walkExpression(
+///     expr,
+///     visitor: countingVisitor,
+///     accumulator: +,
+///     identity: 0
+/// )
+/// ```
+///
+/// ### AST Transformation
+/// ```swift
+/// let transformed = ASTWalker.transformExpression(expr) { node in
+///     // Apply transformation logic here
+///     return transformedNode
+/// }
+/// ```
+///
+/// ## Thread Safety
+///
+/// All visitor types are designed to be `Sendable` and can be safely used
+/// in concurrent contexts. The visitor closures are marked with `@Sendable`
+/// to ensure thread safety.
+///
+/// ## Performance Considerations
+///
+/// The function-based visitor pattern provides excellent performance through
+/// Swift's optimization of closure dispatch. For maximum performance in
+/// critical code paths, consider using the specialized visitor methods
+/// directly rather than the generic `Visitable` protocol.
+public enum VisitorModule {
+    /// Version of the visitor pattern implementation
+    public static let version = "1.0.0"
+    
+    /// Indicates whether the visitor pattern is available and properly initialized
+    public static let isAvailable = true
+}
+
+// MARK: - Convenience Type Aliases
+
+/// Type alias for expression visitors that return strings (useful for debugging)
+public typealias StringExpressionVisitor = ExpressionVisitor<String>
+
+/// Type alias for statement visitors that return strings (useful for debugging)
+public typealias StringStatementVisitor = StatementVisitor<String>
+
+/// Type alias for expression visitors that count nodes
+public typealias CountingExpressionVisitor = ExpressionVisitor<Int>
+
+/// Type alias for statement visitors that count nodes
+public typealias CountingStatementVisitor = StatementVisitor<Int>
+
+// MARK: - Common Visitor Factory Methods
+
+extension ExpressionVisitor {
+    /// Creates a visitor that always returns a constant value for any expression
+    public static func makeConstantVisitor(_ constant: Result) -> ExpressionVisitor<Result> {
+        return ExpressionVisitor<Result>(
+            visitLiteral: { _ in constant },
+            visitIdentifier: { _ in constant },
+            visitBinary: { _, _, _ in constant },
+            visitUnary: { _, _ in constant },
+            visitArrayAccess: { _, _ in constant },
+            visitFieldAccess: { _, _ in constant },
+            visitFunctionCall: { _, _ in constant }
+        )
+    }
+}
+
+extension StatementVisitor {
+    /// Creates a visitor that always returns a constant value for any statement
+    public static func makeConstantVisitor(_ constant: Result) -> StatementVisitor<Result> {
+        return StatementVisitor<Result>(
+            visitIfStatement: { _ in constant },
+            visitWhileStatement: { _ in constant },
+            visitForStatement: { _ in constant },
+            visitAssignment: { _ in constant },
+            visitVariableDeclaration: { _ in constant },
+            visitConstantDeclaration: { _ in constant },
+            visitFunctionDeclaration: { _ in constant },
+            visitProcedureDeclaration: { _ in constant },
+            visitReturnStatement: { _ in constant },
+            visitExpressionStatement: { _ in constant },
+            visitBreakStatement: { constant },
+            visitBlock: { _ in constant }
+        )
+    }
+}
+
+// MARK: - Common Collection Operations
+
+extension ASTWalker {
+    /// Counts the total number of nodes in an expression tree
+    public static func countExpressionNodes(_ expression: Expression) -> Int {
+        let countingVisitor = ExpressionVisitor<Int>.makeConstantVisitor(1)
+        return walkExpression(expression, visitor: countingVisitor, accumulator: +, identity: 0)
+    }
+    
+    /// Counts the total number of nodes in a statement tree
+    public static func countStatementNodes(_ statement: Statement) -> Int {
+        let statementVisitor = StatementVisitor<Int>.makeConstantVisitor(1)
+        let expressionVisitor = ExpressionVisitor<Int>.makeConstantVisitor(1)
+        return walkStatement(statement, statementVisitor: statementVisitor, expressionVisitor: expressionVisitor, accumulator: +, identity: 0)
+    }
+    
+    /// Finds all identifiers used in an expression
+    public static func findIdentifiers(_ expression: Expression) -> [String] {
+        return collectExpressions(expression) { expr in
+            if case .identifier(let name) = expr {
+                return [name]
+            }
+            return []
+        }
+    }
+    
+    /// Finds all function calls in an expression
+    public static func findFunctionCalls(_ expression: Expression) -> [String] {
+        return collectExpressions(expression) { expr in
+            if case .functionCall(let name, _) = expr {
+                return [name]
+            }
+            return []
+        }
+    }
+}
+
+// MARK: - Validation Utilities
+
+extension VisitorModule {
+    /// Validates that an expression tree doesn't exceed maximum depth
+    public static func validateExpressionDepth(_ expression: Expression, maxDepth: Int = 100) -> Bool {
+        func getDepth(_ expr: Expression) -> Int {
+            let childDepths: [Int]
+            switch expr {
+            case .literal, .identifier:
+                return 1
+            case .binary(_, let left, let right):
+                childDepths = [getDepth(left), getDepth(right)]
+            case .unary(_, let inner):
+                childDepths = [getDepth(inner)]
+            case .arrayAccess(let array, let index):
+                childDepths = [getDepth(array), getDepth(index)]
+            case .fieldAccess(let inner, _):
+                childDepths = [getDepth(inner)]
+            case .functionCall(_, let args):
+                childDepths = args.map(getDepth)
+            }
+            
+            return 1 + (childDepths.max() ?? 0)
+        }
+        
+        return getDepth(expression) <= maxDepth
+    }
+    
+    /// Validates that a statement tree doesn't exceed maximum depth
+    public static func validateStatementDepth(_ statement: Statement, maxDepth: Int = 100) -> Bool {
+        func getDepth(_ stmt: Statement) -> Int {
+            let childDepths: [Int]
+            switch stmt {
+            case .ifStatement(let ifStmt):
+                var depths = ifStmt.thenBody.map(getDepth)
+                depths.append(contentsOf: ifStmt.elseIfs.flatMap { $0.body.map(getDepth) })
+                if let elseBody = ifStmt.elseBody {
+                    depths.append(contentsOf: elseBody.map(getDepth))
+                }
+                childDepths = depths
+            case .whileStatement(let whileStmt):
+                childDepths = whileStmt.body.map(getDepth)
+            case .forStatement(let forStmt):
+                switch forStmt {
+                case .range(let rangeFor):
+                    childDepths = rangeFor.body.map(getDepth)
+                case .forEach(let forEachLoop):
+                    childDepths = forEachLoop.body.map(getDepth)
+                }
+            case .functionDeclaration(let funcDecl):
+                childDepths = funcDecl.body.map(getDepth)
+            case .procedureDeclaration(let procDecl):
+                childDepths = procDecl.body.map(getDepth)
+            case .block(let statements):
+                childDepths = statements.map(getDepth)
+            default:
+                return 1
+            }
+            
+            return 1 + (childDepths.max() ?? 0)
+        }
+        
+        return getDepth(statement) <= maxDepth
+    }
+}

--- a/Tests/FeLangCoreTests/Visitor/ASTWalkerTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/ASTWalkerTests.swift
@@ -1,0 +1,306 @@
+import XCTest
+@testable import FeLangCore
+
+final class ASTWalkerTests: XCTestCase {
+    
+    func testWalkSimpleExpression() {
+        let visitor = ExpressionVisitor<Int>(
+            visitLiteral: { _ in 1 },
+            visitIdentifier: { _ in 1 },
+            visitBinary: { _, _, _ in 1 },
+            visitUnary: { _, _ in 1 },
+            visitArrayAccess: { _, _ in 1 },
+            visitFieldAccess: { _, _ in 1 },
+            visitFunctionCall: { _, _ in 1 }
+        )
+        
+        // Test simple literal
+        let result = ASTWalker.walkExpression(
+            .literal(.integer(42)),
+            visitor: visitor,
+            accumulator: +,
+            identity: 0
+        )
+        XCTAssertEqual(result, 1) // Only the literal itself
+    }
+    
+    func testWalkBinaryExpression() {
+        let visitor = ExpressionVisitor<Int>(
+            visitLiteral: { _ in 1 },
+            visitIdentifier: { _ in 1 },
+            visitBinary: { _, _, _ in 1 },
+            visitUnary: { _, _ in 1 },
+            visitArrayAccess: { _, _ in 1 },
+            visitFieldAccess: { _, _ in 1 },
+            visitFunctionCall: { _, _ in 1 }
+        )
+        
+        // Test binary expression: 1 + 2
+        let binaryExpr = Expression.binary(.add, .literal(.integer(1)), .literal(.integer(2)))
+        let result = ASTWalker.walkExpression(
+            binaryExpr,
+            visitor: visitor,
+            accumulator: +,
+            identity: 0
+        )
+        XCTAssertEqual(result, 3) // Binary node + left literal + right literal
+    }
+    
+    func testWalkNestedExpression() {
+        let visitor = ExpressionVisitor<Int>(
+            visitLiteral: { _ in 1 },
+            visitIdentifier: { _ in 1 },
+            visitBinary: { _, _, _ in 1 },
+            visitUnary: { _, _ in 1 },
+            visitArrayAccess: { _, _ in 1 },
+            visitFieldAccess: { _, _ in 1 },
+            visitFunctionCall: { _, _ in 1 }
+        )
+        
+        // Test nested expression: (1 + 2) * 3
+        let nestedExpr = Expression.binary(
+            .multiply,
+            .binary(.add, .literal(.integer(1)), .literal(.integer(2))),
+            .literal(.integer(3))
+        )
+        
+        let result = ASTWalker.walkExpression(
+            nestedExpr,
+            visitor: visitor,
+            accumulator: +,
+            identity: 0
+        )
+        XCTAssertEqual(result, 5) // Outer *, inner +, and three literals
+    }
+    
+    func testWalkFunctionCall() {
+        let visitor = ExpressionVisitor<Int>(
+            visitLiteral: { _ in 1 },
+            visitIdentifier: { _ in 1 },
+            visitBinary: { _, _, _ in 1 },
+            visitUnary: { _, _ in 1 },
+            visitArrayAccess: { _, _ in 1 },
+            visitFieldAccess: { _, _ in 1 },
+            visitFunctionCall: { _, _ in 1 }
+        )
+        
+        // Test function call: max(1, 2)
+        let funcCall = Expression.functionCall("max", [.literal(.integer(1)), .literal(.integer(2))])
+        let result = ASTWalker.walkExpression(
+            funcCall,
+            visitor: visitor,
+            accumulator: +,
+            identity: 0
+        )
+        XCTAssertEqual(result, 3) // Function call + two arguments
+    }
+    
+    func testWalkStatementWithExpressions() {
+        let statementVisitor = StatementVisitor<Int>(
+            visitIfStatement: { _ in 1 },
+            visitWhileStatement: { _ in 1 },
+            visitForStatement: { _ in 1 },
+            visitAssignment: { _ in 1 },
+            visitVariableDeclaration: { _ in 1 },
+            visitConstantDeclaration: { _ in 1 },
+            visitFunctionDeclaration: { _ in 1 },
+            visitProcedureDeclaration: { _ in 1 },
+            visitReturnStatement: { _ in 1 },
+            visitExpressionStatement: { _ in 1 },
+            visitBreakStatement: { 1 },
+            visitBlock: { _ in 1 }
+        )
+        
+        let expressionVisitor = ExpressionVisitor<Int>(
+            visitLiteral: { _ in 1 },
+            visitIdentifier: { _ in 1 },
+            visitBinary: { _, _, _ in 1 },
+            visitUnary: { _, _ in 1 },
+            visitArrayAccess: { _, _ in 1 },
+            visitFieldAccess: { _, _ in 1 },
+            visitFunctionCall: { _, _ in 1 }
+        )
+        
+        // Test variable declaration with initial value: var x: integer := 42
+        let varDecl = VariableDeclaration(name: "x", type: .integer, initialValue: .literal(.integer(42)))
+        let stmt = Statement.variableDeclaration(varDecl)
+        
+        let result = ASTWalker.walkStatement(
+            stmt,
+            statementVisitor: statementVisitor,
+            expressionVisitor: expressionVisitor,
+            accumulator: +,
+            identity: 0
+        )
+        XCTAssertEqual(result, 2) // Variable declaration + literal
+    }
+    
+    func testWalkIfStatement() {
+        let statementVisitor = StatementVisitor<Int>(
+            visitIfStatement: { _ in 1 },
+            visitWhileStatement: { _ in 1 },
+            visitForStatement: { _ in 1 },
+            visitAssignment: { _ in 1 },
+            visitVariableDeclaration: { _ in 1 },
+            visitConstantDeclaration: { _ in 1 },
+            visitFunctionDeclaration: { _ in 1 },
+            visitProcedureDeclaration: { _ in 1 },
+            visitReturnStatement: { _ in 1 },
+            visitExpressionStatement: { _ in 1 },
+            visitBreakStatement: { 1 },
+            visitBlock: { _ in 1 }
+        )
+        
+        let expressionVisitor = ExpressionVisitor<Int>(
+            visitLiteral: { _ in 1 },
+            visitIdentifier: { _ in 1 },
+            visitBinary: { _, _, _ in 1 },
+            visitUnary: { _, _ in 1 },
+            visitArrayAccess: { _, _ in 1 },
+            visitFieldAccess: { _, _ in 1 },
+            visitFunctionCall: { _, _ in 1 }
+        )
+        
+        // Test if statement: if true then break
+        let ifStmt = IfStatement(
+            condition: .literal(.boolean(true)),
+            thenBody: [.breakStatement]
+        )
+        let stmt = Statement.ifStatement(ifStmt)
+        
+        let result = ASTWalker.walkStatement(
+            stmt,
+            statementVisitor: statementVisitor,
+            expressionVisitor: expressionVisitor,
+            accumulator: +,
+            identity: 0
+        )
+        XCTAssertEqual(result, 3) // If statement + condition literal + break statement
+    }
+    
+    func testCollectExpressions() {
+        // Test collecting all literal values from an expression
+        let expr = Expression.binary(
+            .add,
+            .literal(.integer(1)),
+            .binary(.multiply, .literal(.integer(2)), .literal(.integer(3)))
+        )
+        
+        let literals = ASTWalker.collectExpressions(expr) { expr in
+            if case .literal(let literal) = expr {
+                return [literal]
+            }
+            return []
+        }
+        
+        XCTAssertEqual(literals.count, 3)
+        XCTAssertTrue(literals.contains(.integer(1)))
+        XCTAssertTrue(literals.contains(.integer(2)))
+        XCTAssertTrue(literals.contains(.integer(3)))
+    }
+    
+    func testCollectStatements() {
+        // Test collecting all break statements from a block
+        let blockStmt = Statement.block([
+            .breakStatement,
+            .assignment(.variable("x", .literal(.integer(1)))),
+            .breakStatement
+        ])
+        
+        let breakStatements = ASTWalker.collectStatements(blockStmt) { stmt in
+            if case .breakStatement = stmt {
+                return [1]
+            }
+            return []
+        }
+        
+        XCTAssertEqual(breakStatements.count, 2) // Two break statements found
+    }
+    
+    func testTransformExpression() {
+        // Test transforming all integer literals by doubling them
+        let expr = Expression.binary(
+            .add,
+            .literal(.integer(1)),
+            .literal(.integer(2))
+        )
+        
+        let transformed = ASTWalker.transformExpression(expr) { expr in
+            if case .literal(.integer(let value)) = expr {
+                return .literal(.integer(value * 2))
+            }
+            return expr
+        }
+        
+        // Verify the transformation
+        let debugVisitor = ExpressionVisitor<String>.makeDebugVisitor()
+        let result = debugVisitor.visit(transformed)
+        XCTAssertEqual(result, "(2 + 4)")
+    }
+    
+    func testTransformNestedExpression() {
+        // Test transforming nested expressions
+        let expr = Expression.functionCall("max", [
+            .literal(.integer(5)),
+            .binary(.add, .literal(.integer(10)), .literal(.integer(15)))
+        ])
+        
+        let transformed = ASTWalker.transformExpression(expr) { expr in
+            // Replace all additions with subtractions
+            if case .binary(.add, let left, let right) = expr {
+                return .binary(.subtract, left, right)
+            }
+            return expr
+        }
+        
+        let debugVisitor = ExpressionVisitor<String>.makeDebugVisitor()
+        let result = debugVisitor.visit(transformed)
+        XCTAssertEqual(result, "max(5, (10 - 15))")
+    }
+    
+    func testIdentityTransformation() {
+        // Test that identity transformation doesn't change the expression
+        let expr = Expression.binary(.multiply, .literal(.integer(3)), .literal(.integer(4)))
+        let transformed = ASTWalker.transformExpression(expr) { $0 }
+        
+        XCTAssertEqual(expr, transformed)
+    }
+    
+    func testWalkEmptyStatements() {
+        let statementVisitor = StatementVisitor<Int>(
+            visitIfStatement: { _ in 1 },
+            visitWhileStatement: { _ in 1 },
+            visitForStatement: { _ in 1 },
+            visitAssignment: { _ in 1 },
+            visitVariableDeclaration: { _ in 1 },
+            visitConstantDeclaration: { _ in 1 },
+            visitFunctionDeclaration: { _ in 1 },
+            visitProcedureDeclaration: { _ in 1 },
+            visitReturnStatement: { _ in 1 },
+            visitExpressionStatement: { _ in 1 },
+            visitBreakStatement: { 1 },
+            visitBlock: { _ in 1 }
+        )
+        
+        let expressionVisitor = ExpressionVisitor<Int>(
+            visitLiteral: { _ in 1 },
+            visitIdentifier: { _ in 1 },
+            visitBinary: { _, _, _ in 1 },
+            visitUnary: { _, _ in 1 },
+            visitArrayAccess: { _, _ in 1 },
+            visitFieldAccess: { _, _ in 1 },
+            visitFunctionCall: { _, _ in 1 }
+        )
+        
+        // Test empty block
+        let emptyBlock = Statement.block([])
+        let result = ASTWalker.walkStatement(
+            emptyBlock,
+            statementVisitor: statementVisitor,
+            expressionVisitor: expressionVisitor,
+            accumulator: +,
+            identity: 0
+        )
+        XCTAssertEqual(result, 1) // Only the block statement itself
+    }
+}

--- a/Tests/FeLangCoreTests/Visitor/ExpressionVisitorTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/ExpressionVisitorTests.swift
@@ -1,0 +1,232 @@
+import XCTest
+@testable import FeLangCore
+
+final class ExpressionVisitorTests: XCTestCase {
+    
+    func testVisitLiteral() {
+        let visitor = ExpressionVisitor<String>(
+            visitLiteral: { literal in
+                switch literal {
+                case .integer(let value):
+                    return "int(\(value))"
+                case .real(let value):
+                    return "real(\(value))"
+                case .string(let value):
+                    return "string(\"\(value)\")"
+                case .character(let value):
+                    return "char('\(value)')"
+                case .boolean(let value):
+                    return "bool(\(value))"
+                }
+            },
+            visitIdentifier: { _ in "id" },
+            visitBinary: { _, _, _ in "binary" },
+            visitUnary: { _, _ in "unary" },
+            visitArrayAccess: { _, _ in "array_access" },
+            visitFieldAccess: { _, _ in "field_access" },
+            visitFunctionCall: { _, _ in "function_call" }
+        )
+        
+        XCTAssertEqual(visitor.visit(.literal(.integer(42))), "int(42)")
+        XCTAssertEqual(visitor.visit(.literal(.real(3.14))), "real(3.14)")
+        XCTAssertEqual(visitor.visit(.literal(.string("hello"))), "string(\"hello\")")
+        XCTAssertEqual(visitor.visit(.literal(.character("a"))), "char('a')")
+        XCTAssertEqual(visitor.visit(.literal(.boolean(true))), "bool(true)")
+    }
+    
+    func testVisitIdentifier() {
+        let visitor = ExpressionVisitor<String>(
+            visitLiteral: { _ in "literal" },
+            visitIdentifier: { name in "identifier(\(name))" },
+            visitBinary: { _, _, _ in "binary" },
+            visitUnary: { _, _ in "unary" },
+            visitArrayAccess: { _, _ in "array_access" },
+            visitFieldAccess: { _, _ in "field_access" },
+            visitFunctionCall: { _, _ in "function_call" }
+        )
+        
+        XCTAssertEqual(visitor.visit(.identifier("x")), "identifier(x)")
+        XCTAssertEqual(visitor.visit(.identifier("myVariable")), "identifier(myVariable)")
+    }
+    
+    func testVisitBinary() {
+        let visitor = ExpressionVisitor<String>(
+            visitLiteral: { _ in "literal" },
+            visitIdentifier: { _ in "id" },
+            visitBinary: { op, left, right in "binary(\(op.rawValue), \(left), \(right))" },
+            visitUnary: { _, _ in "unary" },
+            visitArrayAccess: { _, _ in "array_access" },
+            visitFieldAccess: { _, _ in "field_access" },
+            visitFunctionCall: { _, _ in "function_call" }
+        )
+        
+        let expr = Expression.binary(.add, .literal(.integer(1)), .literal(.integer(2)))
+        let result = visitor.visit(expr)
+        XCTAssertTrue(result.contains("binary(+"))
+        XCTAssertTrue(result.contains("literal(Literal.integer(1))"))
+        XCTAssertTrue(result.contains("literal(Literal.integer(2))"))
+    }
+    
+    func testVisitUnary() {
+        let visitor = ExpressionVisitor<String>(
+            visitLiteral: { _ in "literal" },
+            visitIdentifier: { _ in "id" },
+            visitBinary: { _, _, _ in "binary" },
+            visitUnary: { op, expr in "unary(\(op.rawValue), \(expr))" },
+            visitArrayAccess: { _, _ in "array_access" },
+            visitFieldAccess: { _, _ in "field_access" },
+            visitFunctionCall: { _, _ in "function_call" }
+        )
+        
+        let expr = Expression.unary(.not, .literal(.boolean(true)))
+        let result = visitor.visit(expr)
+        XCTAssertTrue(result.contains("unary(not"))
+        XCTAssertTrue(result.contains("literal(Literal.boolean(true))"))
+    }
+    
+    func testVisitArrayAccess() {
+        let visitor = ExpressionVisitor<String>(
+            visitLiteral: { _ in "literal" },
+            visitIdentifier: { _ in "id" },
+            visitBinary: { _, _, _ in "binary" },
+            visitUnary: { _, _ in "unary" },
+            visitArrayAccess: { array, index in "array_access(\(array), \(index))" },
+            visitFieldAccess: { _, _ in "field_access" },
+            visitFunctionCall: { _, _ in "function_call" }
+        )
+        
+        let expr = Expression.arrayAccess(.identifier("arr"), .literal(.integer(0)))
+        let result = visitor.visit(expr)
+        XCTAssertTrue(result.contains("array_access"))
+        XCTAssertTrue(result.contains("identifier(\"arr\")"))
+        XCTAssertTrue(result.contains("literal(Literal.integer(0))"))
+    }
+    
+    func testVisitFieldAccess() {
+        let visitor = ExpressionVisitor<String>(
+            visitLiteral: { _ in "literal" },
+            visitIdentifier: { _ in "id" },
+            visitBinary: { _, _, _ in "binary" },
+            visitUnary: { _, _ in "unary" },
+            visitArrayAccess: { _, _ in "array_access" },
+            visitFieldAccess: { expr, field in "field_access(\(expr), \(field))" },
+            visitFunctionCall: { _, _ in "function_call" }
+        )
+        
+        let expr = Expression.fieldAccess(.identifier("obj"), "prop")
+        let result = visitor.visit(expr)
+        XCTAssertTrue(result.contains("field_access"))
+        XCTAssertTrue(result.contains("identifier(\"obj\")"))
+        XCTAssertTrue(result.contains("prop"))
+    }
+    
+    func testVisitFunctionCall() {
+        let visitor = ExpressionVisitor<String>(
+            visitLiteral: { _ in "literal" },
+            visitIdentifier: { _ in "id" },
+            visitBinary: { _, _, _ in "binary" },
+            visitUnary: { _, _ in "unary" },
+            visitArrayAccess: { _, _ in "array_access" },
+            visitFieldAccess: { _, _ in "field_access" },
+            visitFunctionCall: { name, args in "function_call(\(name), \(args.count) args)" }
+        )
+        
+        let expr = Expression.functionCall("max", [.literal(.integer(1)), .literal(.integer(2))])
+        let result = visitor.visit(expr)
+        XCTAssertEqual(result, "function_call(max, 2 args)")
+    }
+    
+    func testDebugVisitor() {
+        let visitor = ExpressionVisitor<String>.makeDebugVisitor()
+        
+        // Test simple literal
+        XCTAssertEqual(visitor.visit(.literal(.integer(42))), "42")
+        XCTAssertEqual(visitor.visit(.literal(.string("hello"))), "\"hello\"")
+        XCTAssertEqual(visitor.visit(.literal(.boolean(true))), "true")
+        
+        // Test identifier
+        XCTAssertEqual(visitor.visit(.identifier("x")), "x")
+        
+        // Test binary expression
+        let binaryExpr = Expression.binary(.add, .literal(.integer(1)), .literal(.integer(2)))
+        XCTAssertEqual(visitor.visit(binaryExpr), "(1 + 2)")
+        
+        // Test unary expression
+        let unaryExpr = Expression.unary(.minus, .literal(.integer(5)))
+        XCTAssertEqual(visitor.visit(unaryExpr), "-5")
+        
+        // Test array access
+        let arrayExpr = Expression.arrayAccess(.identifier("arr"), .literal(.integer(0)))
+        XCTAssertEqual(visitor.visit(arrayExpr), "arr[0]")
+        
+        // Test field access
+        let fieldExpr = Expression.fieldAccess(.identifier("obj"), "prop")
+        XCTAssertEqual(visitor.visit(fieldExpr), "obj.prop")
+        
+        // Test function call
+        let funcExpr = Expression.functionCall("max", [.literal(.integer(1)), .literal(.integer(2))])
+        XCTAssertEqual(visitor.visit(funcExpr), "max(1, 2)")
+    }
+    
+    func testNestedExpressions() {
+        let visitor = ExpressionVisitor<String>.makeDebugVisitor()
+        
+        // Test nested binary expressions: (1 + 2) * 3
+        let nested = Expression.binary(
+            .multiply,
+            .binary(.add, .literal(.integer(1)), .literal(.integer(2))),
+            .literal(.integer(3))
+        )
+        XCTAssertEqual(visitor.visit(nested), "((1 + 2) * 3)")
+        
+        // Test complex nested expression: max(arr[0], obj.prop)
+        let complex = Expression.functionCall(
+            "max",
+            [
+                .arrayAccess(.identifier("arr"), .literal(.integer(0))),
+                .fieldAccess(.identifier("obj"), "prop")
+            ]
+        )
+        XCTAssertEqual(visitor.visit(complex), "max(arr[0], obj.prop)")
+    }
+    
+    func testSendableCompliance() {
+        // Test that ExpressionVisitor can be used in concurrent contexts
+        let visitor = ExpressionVisitor<Int>(
+            visitLiteral: { _ in 1 },
+            visitIdentifier: { _ in 1 },
+            visitBinary: { _, _, _ in 1 },
+            visitUnary: { _, _ in 1 },
+            visitArrayAccess: { _, _ in 1 },
+            visitFieldAccess: { _, _ in 1 },
+            visitFunctionCall: { _, _ in 1 }
+        )
+        
+        // This should compile without warnings if Sendable is properly implemented
+        Task {
+            let result = visitor.visit(.literal(.integer(42)))
+            XCTAssertEqual(result, 1)
+        }
+    }
+    
+    func testCountingVisitor() {
+        // Create a visitor that counts the number of nodes
+        let countingVisitor = ExpressionVisitor<Int>(
+            visitLiteral: { _ in 1 },
+            visitIdentifier: { _ in 1 },
+            visitBinary: { _, _, _ in 1 },
+            visitUnary: { _, _ in 1 },
+            visitArrayAccess: { _, _ in 1 },
+            visitFieldAccess: { _, _ in 1 },
+            visitFunctionCall: { _, _ in 1 }
+        )
+        
+        // Test simple expression
+        XCTAssertEqual(countingVisitor.visit(.literal(.integer(42))), 1)
+        XCTAssertEqual(countingVisitor.visit(.identifier("x")), 1)
+        
+        // Test compound expression
+        let binaryExpr = Expression.binary(.add, .literal(.integer(1)), .literal(.integer(2)))
+        XCTAssertEqual(countingVisitor.visit(binaryExpr), 1) // Only counts the top-level node
+    }
+}

--- a/Tests/FeLangCoreTests/Visitor/StatementVisitorTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/StatementVisitorTests.swift
@@ -1,0 +1,366 @@
+import XCTest
+@testable import FeLangCore
+
+final class StatementVisitorTests: XCTestCase {
+    
+    func testVisitVariableDeclaration() {
+        let visitor = StatementVisitor<String>(
+            visitIfStatement: { _ in "if" },
+            visitWhileStatement: { _ in "while" },
+            visitForStatement: { _ in "for" },
+            visitAssignment: { _ in "assignment" },
+            visitVariableDeclaration: { varDecl in "var \(varDecl.name): \(varDecl.type)" },
+            visitConstantDeclaration: { _ in "const" },
+            visitFunctionDeclaration: { _ in "function" },
+            visitProcedureDeclaration: { _ in "procedure" },
+            visitReturnStatement: { _ in "return" },
+            visitExpressionStatement: { _ in "expression" },
+            visitBreakStatement: { "break" },
+            visitBlock: { _ in "block" }
+        )
+        
+        let varDecl = VariableDeclaration(name: "x", type: .integer)
+        let stmt = Statement.variableDeclaration(varDecl)
+        XCTAssertEqual(visitor.visit(stmt), "var x: DataType.integer")
+    }
+    
+    func testVisitConstantDeclaration() {
+        let visitor = StatementVisitor<String>(
+            visitIfStatement: { _ in "if" },
+            visitWhileStatement: { _ in "while" },
+            visitForStatement: { _ in "for" },
+            visitAssignment: { _ in "assignment" },
+            visitVariableDeclaration: { _ in "var" },
+            visitConstantDeclaration: { constDecl in "const \(constDecl.name): \(constDecl.type)" },
+            visitFunctionDeclaration: { _ in "function" },
+            visitProcedureDeclaration: { _ in "procedure" },
+            visitReturnStatement: { _ in "return" },
+            visitExpressionStatement: { _ in "expression" },
+            visitBreakStatement: { "break" },
+            visitBlock: { _ in "block" }
+        )
+        
+        let constDecl = ConstantDeclaration(name: "PI", type: .real, initialValue: .literal(.real(3.14)))
+        let stmt = Statement.constantDeclaration(constDecl)
+        XCTAssertEqual(visitor.visit(stmt), "const PI: DataType.real")
+    }
+    
+    func testVisitAssignment() {
+        let visitor = StatementVisitor<String>(
+            visitIfStatement: { _ in "if" },
+            visitWhileStatement: { _ in "while" },
+            visitForStatement: { _ in "for" },
+            visitAssignment: { assignment in
+                switch assignment {
+                case .variable(let name, _):
+                    return "assign to \(name)"
+                case .arrayElement(_, _):
+                    return "assign to array element"
+                }
+            },
+            visitVariableDeclaration: { _ in "var" },
+            visitConstantDeclaration: { _ in "const" },
+            visitFunctionDeclaration: { _ in "function" },
+            visitProcedureDeclaration: { _ in "procedure" },
+            visitReturnStatement: { _ in "return" },
+            visitExpressionStatement: { _ in "expression" },
+            visitBreakStatement: { "break" },
+            visitBlock: { _ in "block" }
+        )
+        
+        // Test variable assignment
+        let varAssignment = Assignment.variable("x", .literal(.integer(42)))
+        let varStmt = Statement.assignment(varAssignment)
+        XCTAssertEqual(visitor.visit(varStmt), "assign to x")
+        
+        // Test array element assignment
+        let arrayAccess = Assignment.ArrayAccess(array: .identifier("arr"), index: .literal(.integer(0)))
+        let arrayAssignment = Assignment.arrayElement(arrayAccess, .literal(.integer(10)))
+        let arrayStmt = Statement.assignment(arrayAssignment)
+        XCTAssertEqual(visitor.visit(arrayStmt), "assign to array element")
+    }
+    
+    func testVisitIfStatement() {
+        let visitor = StatementVisitor<String>(
+            visitIfStatement: { ifStmt in "if condition with \(ifStmt.thenBody.count) then statements" },
+            visitWhileStatement: { _ in "while" },
+            visitForStatement: { _ in "for" },
+            visitAssignment: { _ in "assignment" },
+            visitVariableDeclaration: { _ in "var" },
+            visitConstantDeclaration: { _ in "const" },
+            visitFunctionDeclaration: { _ in "function" },
+            visitProcedureDeclaration: { _ in "procedure" },
+            visitReturnStatement: { _ in "return" },
+            visitExpressionStatement: { _ in "expression" },
+            visitBreakStatement: { "break" },
+            visitBlock: { _ in "block" }
+        )
+        
+        let ifStmt = IfStatement(
+            condition: .literal(.boolean(true)),
+            thenBody: [.breakStatement, .breakStatement]
+        )
+        let stmt = Statement.ifStatement(ifStmt)
+        XCTAssertEqual(visitor.visit(stmt), "if condition with 2 then statements")
+    }
+    
+    func testVisitWhileStatement() {
+        let visitor = StatementVisitor<String>(
+            visitIfStatement: { _ in "if" },
+            visitWhileStatement: { whileStmt in "while loop with \(whileStmt.body.count) statements" },
+            visitForStatement: { _ in "for" },
+            visitAssignment: { _ in "assignment" },
+            visitVariableDeclaration: { _ in "var" },
+            visitConstantDeclaration: { _ in "const" },
+            visitFunctionDeclaration: { _ in "function" },
+            visitProcedureDeclaration: { _ in "procedure" },
+            visitReturnStatement: { _ in "return" },
+            visitExpressionStatement: { _ in "expression" },
+            visitBreakStatement: { "break" },
+            visitBlock: { _ in "block" }
+        )
+        
+        let whileStmt = WhileStatement(
+            condition: .literal(.boolean(true)),
+            body: [.breakStatement]
+        )
+        let stmt = Statement.whileStatement(whileStmt)
+        XCTAssertEqual(visitor.visit(stmt), "while loop with 1 statements")
+    }
+    
+    func testVisitForStatement() {
+        let visitor = StatementVisitor<String>(
+            visitIfStatement: { _ in "if" },
+            visitWhileStatement: { _ in "while" },
+            visitForStatement: { forStmt in
+                switch forStmt {
+                case .range(let rangeFor):
+                    return "range for \(rangeFor.variable)"
+                case .forEach(let forEachLoop):
+                    return "forEach for \(forEachLoop.variable)"
+                }
+            },
+            visitAssignment: { _ in "assignment" },
+            visitVariableDeclaration: { _ in "var" },
+            visitConstantDeclaration: { _ in "const" },
+            visitFunctionDeclaration: { _ in "function" },
+            visitProcedureDeclaration: { _ in "procedure" },
+            visitReturnStatement: { _ in "return" },
+            visitExpressionStatement: { _ in "expression" },
+            visitBreakStatement: { "break" },
+            visitBlock: { _ in "block" }
+        )
+        
+        // Test range for
+        let rangeFor = ForStatement.RangeFor(
+            variable: "i",
+            start: .literal(.integer(1)),
+            end: .literal(.integer(10)),
+            body: [.breakStatement]
+        )
+        let rangeStmt = Statement.forStatement(.range(rangeFor))
+        XCTAssertEqual(visitor.visit(rangeStmt), "range for i")
+        
+        // Test forEach
+        let forEachLoop = ForStatement.ForEachLoop(
+            variable: "item",
+            iterable: .identifier("items"),
+            body: [.breakStatement]
+        )
+        let forEachStmt = Statement.forStatement(.forEach(forEachLoop))
+        XCTAssertEqual(visitor.visit(forEachStmt), "forEach for item")
+    }
+    
+    func testVisitFunctionDeclaration() {
+        let visitor = StatementVisitor<String>(
+            visitIfStatement: { _ in "if" },
+            visitWhileStatement: { _ in "while" },
+            visitForStatement: { _ in "for" },
+            visitAssignment: { _ in "assignment" },
+            visitVariableDeclaration: { _ in "var" },
+            visitConstantDeclaration: { _ in "const" },
+            visitFunctionDeclaration: { funcDecl in "function \(funcDecl.name) with \(funcDecl.parameters.count) params" },
+            visitProcedureDeclaration: { _ in "procedure" },
+            visitReturnStatement: { _ in "return" },
+            visitExpressionStatement: { _ in "expression" },
+            visitBreakStatement: { "break" },
+            visitBlock: { _ in "block" }
+        )
+        
+        let param = Parameter(name: "x", type: .integer)
+        let funcDecl = FunctionDeclaration(
+            name: "add",
+            parameters: [param],
+            returnType: .integer,
+            body: [.breakStatement]
+        )
+        let stmt = Statement.functionDeclaration(funcDecl)
+        XCTAssertEqual(visitor.visit(stmt), "function add with 1 params")
+    }
+    
+    func testVisitReturnStatement() {
+        let visitor = StatementVisitor<String>(
+            visitIfStatement: { _ in "if" },
+            visitWhileStatement: { _ in "while" },
+            visitForStatement: { _ in "for" },
+            visitAssignment: { _ in "assignment" },
+            visitVariableDeclaration: { _ in "var" },
+            visitConstantDeclaration: { _ in "const" },
+            visitFunctionDeclaration: { _ in "function" },
+            visitProcedureDeclaration: { _ in "procedure" },
+            visitReturnStatement: { returnStmt in
+                return returnStmt.expression != nil ? "return with value" : "return void"
+            },
+            visitExpressionStatement: { _ in "expression" },
+            visitBreakStatement: { "break" },
+            visitBlock: { _ in "block" }
+        )
+        
+        // Test return with value
+        let returnWithValue = ReturnStatement(expression: .literal(.integer(42)))
+        let returnStmt = Statement.returnStatement(returnWithValue)
+        XCTAssertEqual(visitor.visit(returnStmt), "return with value")
+        
+        // Test return without value
+        let returnVoid = ReturnStatement()
+        let voidStmt = Statement.returnStatement(returnVoid)
+        XCTAssertEqual(visitor.visit(voidStmt), "return void")
+    }
+    
+    func testVisitExpressionStatement() {
+        let visitor = StatementVisitor<String>(
+            visitIfStatement: { _ in "if" },
+            visitWhileStatement: { _ in "while" },
+            visitForStatement: { _ in "for" },
+            visitAssignment: { _ in "assignment" },
+            visitVariableDeclaration: { _ in "var" },
+            visitConstantDeclaration: { _ in "const" },
+            visitFunctionDeclaration: { _ in "function" },
+            visitProcedureDeclaration: { _ in "procedure" },
+            visitReturnStatement: { _ in "return" },
+            visitExpressionStatement: { expr in "expression: \(expr)" },
+            visitBreakStatement: { "break" },
+            visitBlock: { _ in "block" }
+        )
+        
+        let exprStmt = Statement.expressionStatement(.literal(.integer(42)))
+        let result = visitor.visit(exprStmt)
+        XCTAssertTrue(result.contains("expression: literal(Literal.integer(42))"))
+    }
+    
+    func testVisitBreakStatement() {
+        let visitor = StatementVisitor<String>(
+            visitIfStatement: { _ in "if" },
+            visitWhileStatement: { _ in "while" },
+            visitForStatement: { _ in "for" },
+            visitAssignment: { _ in "assignment" },
+            visitVariableDeclaration: { _ in "var" },
+            visitConstantDeclaration: { _ in "const" },
+            visitFunctionDeclaration: { _ in "function" },
+            visitProcedureDeclaration: { _ in "procedure" },
+            visitReturnStatement: { _ in "return" },
+            visitExpressionStatement: { _ in "expression" },
+            visitBreakStatement: { "break statement" },
+            visitBlock: { _ in "block" }
+        )
+        
+        XCTAssertEqual(visitor.visit(.breakStatement), "break statement")
+    }
+    
+    func testVisitBlock() {
+        let visitor = StatementVisitor<String>(
+            visitIfStatement: { _ in "if" },
+            visitWhileStatement: { _ in "while" },
+            visitForStatement: { _ in "for" },
+            visitAssignment: { _ in "assignment" },
+            visitVariableDeclaration: { _ in "var" },
+            visitConstantDeclaration: { _ in "const" },
+            visitFunctionDeclaration: { _ in "function" },
+            visitProcedureDeclaration: { _ in "procedure" },
+            visitReturnStatement: { _ in "return" },
+            visitExpressionStatement: { _ in "expression" },
+            visitBreakStatement: { "break" },
+            visitBlock: { statements in "block with \(statements.count) statements" }
+        )
+        
+        let blockStmt = Statement.block([.breakStatement, .breakStatement, .breakStatement])
+        XCTAssertEqual(visitor.visit(blockStmt), "block with 3 statements")
+    }
+    
+    func testDebugVisitor() {
+        let visitor = StatementVisitor<String>.makeDebugVisitor()
+        
+        // Test simple statements
+        XCTAssertEqual(visitor.visit(.breakStatement), "break")
+        
+        let varDecl = VariableDeclaration(name: "x", type: .integer, initialValue: .literal(.integer(42)))
+        let varStmt = Statement.variableDeclaration(varDecl)
+        XCTAssertEqual(visitor.visit(varStmt), "var x: DataType.integer := 42")
+        
+        let constDecl = ConstantDeclaration(name: "PI", type: .real, initialValue: .literal(.real(3.14)))
+        let constStmt = Statement.constantDeclaration(constDecl)
+        XCTAssertEqual(visitor.visit(constStmt), "const PI: DataType.real := 3.14")
+        
+        // Test assignment
+        let assignment = Assignment.variable("x", .literal(.integer(10)))
+        let assignStmt = Statement.assignment(assignment)
+        XCTAssertEqual(visitor.visit(assignStmt), "x := 10")
+        
+        // Test return statement
+        let returnStmt = Statement.returnStatement(ReturnStatement(expression: .literal(.integer(42))))
+        XCTAssertEqual(visitor.visit(returnStmt), "return 42")
+        
+        // Test expression statement
+        let exprStmt = Statement.expressionStatement(.identifier("x"))
+        XCTAssertEqual(visitor.visit(exprStmt), "x")
+    }
+    
+    func testSendableCompliance() {
+        // Test that StatementVisitor can be used in concurrent contexts
+        let visitor = StatementVisitor<Int>(
+            visitIfStatement: { _ in 1 },
+            visitWhileStatement: { _ in 1 },
+            visitForStatement: { _ in 1 },
+            visitAssignment: { _ in 1 },
+            visitVariableDeclaration: { _ in 1 },
+            visitConstantDeclaration: { _ in 1 },
+            visitFunctionDeclaration: { _ in 1 },
+            visitProcedureDeclaration: { _ in 1 },
+            visitReturnStatement: { _ in 1 },
+            visitExpressionStatement: { _ in 1 },
+            visitBreakStatement: { 1 },
+            visitBlock: { _ in 1 }
+        )
+        
+        // This should compile without warnings if Sendable is properly implemented
+        Task {
+            let result = visitor.visit(.breakStatement)
+            XCTAssertEqual(result, 1)
+        }
+    }
+    
+    func testCountingVisitor() {
+        // Create a visitor that counts the number of statements
+        let countingVisitor = StatementVisitor<Int>(
+            visitIfStatement: { _ in 1 },
+            visitWhileStatement: { _ in 1 },
+            visitForStatement: { _ in 1 },
+            visitAssignment: { _ in 1 },
+            visitVariableDeclaration: { _ in 1 },
+            visitConstantDeclaration: { _ in 1 },
+            visitFunctionDeclaration: { _ in 1 },
+            visitProcedureDeclaration: { _ in 1 },
+            visitReturnStatement: { _ in 1 },
+            visitExpressionStatement: { _ in 1 },
+            visitBreakStatement: { 1 },
+            visitBlock: { statements in statements.count }
+        )
+        
+        // Test simple statement
+        XCTAssertEqual(countingVisitor.visit(.breakStatement), 1)
+        
+        // Test block statement
+        let blockStmt = Statement.block([.breakStatement, .breakStatement, .breakStatement])
+        XCTAssertEqual(countingVisitor.visit(blockStmt), 3)
+    }
+}


### PR DESCRIPTION
This PR implements a comprehensive visitor pattern infrastructure for FeLangKit AST nodes, following the function-based approach from the design document in issue #65.

## Key Components
- ExpressionVisitor<Result>: Function-based visitor for Expression nodes
- StatementVisitor<Result>: Function-based visitor for Statement nodes
- Visitable protocol: Unified interface for AST traversal
- ASTWalker: Utilities for recursive traversal and transformation
- VisitorModule: Main module with convenience methods

## Features
- Thread safety with @Sendable compliance
- Zero breaking changes to existing AST enums
- Swift idiomatic closure-based dispatch
- Built-in debug visitors for string representation
- Comprehensive test coverage
- Support for recursive tree walking and transformation

This infrastructure enables clean separation of concerns between AST structure and processing logic, making it easier to implement semantic analysis, code generation, and optimization passes.

Closes #65

Generated with [Claude Code](https://claude.ai/code)