### PR TITLE
fix: resolve 'local' variable declaration error in extract-results.sh

### DIFF
--- a/scripts/container/extract-results.sh
+++ b/scripts/container/extract-results.sh
@@ -385,9 +385,9 @@ echo ""
 
 if [[ -f "$OUTPUT_DIR/execution-report.json" ]]; then
     echo "Execution Status:"
-    local success_status=$(jq -r '.success' "$OUTPUT_DIR/execution-report.json" 2>/dev/null || echo "unknown")
-    local pr_url=$(jq -r '.pr_url' "$OUTPUT_DIR/execution-report.json" 2>/dev/null || echo "none")
-    local duration=$(jq -r '.duration_seconds' "$OUTPUT_DIR/execution-report.json" 2>/dev/null || echo "unknown")
+    success_status=$(jq -r '.success' "$OUTPUT_DIR/execution-report.json" 2>/dev/null || echo "unknown")
+    pr_url=$(jq -r '.pr_url' "$OUTPUT_DIR/execution-report.json" 2>/dev/null || echo "none")
+    duration=$(jq -r '.duration_seconds' "$OUTPUT_DIR/execution-report.json" 2>/dev/null || echo "unknown")
     
     echo "  Success: $success_status"
     echo "  Duration: ${duration}s"


### PR DESCRIPTION
## Summary
- Remove 'local' keyword from variable declarations outside function scope  
- Fix script execution error preventing container result extraction
- Variables success_status, pr_url, and duration now properly declared in main script scope

## Test plan
- [x] Script syntax validation passes
- [x] No 'local' keyword used outside functions
- [x] Container result extraction should work without syntax errors

🤖 Generated with [Claude Code](https://claude.ai/code)