### PR TITLE
fix: remove remaining 'local' declaration outside function in extract-results.sh

### DIFF
--- a/scripts/container/extract-results.sh
+++ b/scripts/container/extract-results.sh
@@ -313,7 +313,7 @@ if docker exec "$CONTAINER_NAME" bash -c "cd /workspace && git diff --name-only 
     log "Extracting modified source files..."
     docker exec "$CONTAINER_NAME" bash -c "cd /workspace && git diff --name-only HEAD" | while read -r file; do
         if [[ -n "$file" ]]; then
-            local output_file="modified-files/$(basename "$file")"
+            output_file="modified-files/$(basename "$file")"
             mkdir -p "$OUTPUT_DIR/modified-files"
             extract_file "/workspace/$file" "$output_file" "Modified File: $file"
         fi


### PR DESCRIPTION
## Summary
- Remove 'local' keyword from output_file variable declaration in modified files extraction loop
- Fix additional script execution error preventing container result extraction  
- Variable is in a while loop subshell, not within a function scope

## Test plan
- [x] Script syntax validation passes
- [x] All 'local' keywords properly scoped within functions
- [x] Container result extraction should complete without errors

🤖 Generated with [Claude Code](https://claude.ai/code)