### PR TITLE
enhancement: add time-based randomness to worktree branch names

### DIFF
--- a/claude.sh
+++ b/claude.sh
@@ -152,7 +152,7 @@ extract_issue_info() {
         OWNER="${BASH_REMATCH[1]}"
         REPO="${BASH_REMATCH[2]}"
         ISSUE_NUMBER="${BASH_REMATCH[3]}"
-        BRANCH_NAME="issue-${ISSUE_NUMBER}-$(date +%Y%m%d)"
+        BRANCH_NAME="issue-${ISSUE_NUMBER}-$(date +%Y%m%d-%H%M%S)"
         WORKTREE_PATH="${WORKTREE_BASE_DIR}/${BRANCH_NAME}"
         ISSUE_DATA_FILE="${WORKTREE_PATH}/.issue-data.json"
         ANALYSIS_FILE="${WORKTREE_PATH}/.analysis-data.json"


### PR DESCRIPTION
## Summary
- Add hour, minute, and second to worktree branch names for uniqueness
- Prevents conflicts when working on the same issue multiple times per day
- Enables better parallel development workflow

## Changes
- **Before**: `issue-67-20250529`
- **After**: `issue-67-20250529-212904` (includes HHMMSS)

## Benefits
- **Avoid Conflicts**: Multiple sessions on same issue won't collide
- **Better Tracking**: Easier to identify when each worktree was created
- **Parallel Development**: Support multiple developers working on same issue

## Example
```bash
./claude.sh https://github.com/owner/repo/issues/67
# Creates: issue-67-20250529-212904
```

🤖 Generated with [Claude Code](https://claude.ai/code)