### PR TITLE
revert: restore Claude Code safety checks by removing --dangerously-skip-permissions

### DIFF
--- a/claude.sh
+++ b/claude.sh
@@ -357,9 +357,9 @@ EOF
     info "You can reference this file during your Claude Code session"
     echo
     
-    # Launch Claude Code interactively with safety checks bypassed for worktree
-    info "Launching Claude Code with permissions bypass for worktree..."
-    if ! claude --dangerously-skip-permissions; then
+    # Launch Claude Code interactively
+    info "Launching Claude Code (you may need to approve permissions)..."
+    if ! claude; then
         error "Claude Code session failed or was interrupted"
         exit 1
     fi


### PR DESCRIPTION
## Summary
- Remove `--dangerously-skip-permissions` flag from Claude Code launch
- Restore normal safety checks and permission prompts
- Maintain secure development workflow

## Rationale
- **Security First**: Preserve Claude Code's built-in safety mechanisms
- **User Control**: Let users manually approve permissions as intended
- **Best Practices**: Follow recommended Claude Code usage patterns
- **Transparency**: Users see and control what permissions are granted

## Changes
- **Before**: `claude --dangerously-skip-permissions` (bypassed all checks)
- **After**: `claude` (normal permission prompts)
- **User Experience**: May need to approve permissions during session

## Benefits
- ✅ **Enhanced Security**: Full permission validation
- ✅ **User Awareness**: Clear visibility of tool access
- ✅ **Compliance**: Follows Claude Code security guidelines
- ✅ **Flexibility**: Users can deny specific permissions if needed

## Usage
```bash
./claude.sh https://github.com/owner/repo/issues/123
# Claude Code will prompt for permissions as needed
```

Users will see permission prompts and can approve them as appropriate for their workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)