### PR TITLE
fix: place worktrees directly in repository root for better integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,5 @@ fastlane/test_output
 scripts/container-results
 execution-report.json
 
-# Claude worktrees
-worktrees/
+# Claude worktrees (in repo root)
+issue-*-*/

--- a/claude.sh
+++ b/claude.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Configuration
-WORKTREE_BASE_DIR="${PROJECT_ROOT}/worktrees"
+WORKTREE_BASE_DIR="${PROJECT_ROOT}"
 ISSUE_DATA_FILE=""
 ANALYSIS_FILE=""
 BRANCH_NAME=""


### PR DESCRIPTION
## Summary
- Place worktrees directly in repository root instead of `worktrees/` subdirectory
- Update .gitignore to ignore `issue-*-*/` pattern instead of `worktrees/`
- Provide direct access to repository context for Claude Code sessions

## Changes
- **Before**: `/path/to/repo/worktrees/issue-67-20250529-213711/`
- **After**: `/path/to/repo/issue-67-20250529-213711/` (directly in repo root)

## Benefits
- ✅ **No Trust Prompts**: Working directly in trusted repository
- ✅ **Better Context**: Immediate access to all repository files and structure
- ✅ **Simpler Paths**: Shorter, cleaner directory structure
- ✅ **Git Integration**: Worktrees feel more like natural part of repository

## Gitignore Update
- **Old**: `worktrees/` (subdirectory)
- **New**: `issue-*-*/` (pattern matching worktree directories)

## Example Usage
```bash
./claude.sh https://github.com/fumiya-kume/FeLangKit/issues/67
# Creates: /Users/kuu/ghq/github.com/fumiya-kume/FeLangKit/issue-67-20250529-213711/
```

This provides the most seamless integration with Claude Code while maintaining clean repository organization.

🤖 Generated with [Claude Code](https://claude.ai/code)