### PR TITLE
fix: correct PROJECT_ROOT path calculation for root-level claude.sh

### DIFF
--- a/claude.sh
+++ b/claude.sh
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
 
 # Configuration
 WORKTREE_BASE_DIR="${PROJECT_ROOT}"


### PR DESCRIPTION
## Summary
- Fix PROJECT_ROOT calculation since claude.sh is now at repository root
- Ensure worktrees are created inside repository to eliminate trust prompts
- Correct path logic for proper Claude Code integration

## Root Cause Analysis
When claude.sh was moved to repository root, the PROJECT_ROOT calculation became incorrect:

**Before (Broken)**:
```bash
# claude.sh at: /Users/kuu/ghq/github.com/fumiya-kume/FeLangKit/claude.sh
SCRIPT_DIR="/Users/kuu/ghq/github.com/fumiya-kume/FeLangKit"
PROJECT_ROOT="$SCRIPT_DIR/.."  # = /Users/kuu/ghq/github.com/fumiya-kume/
```

**Result**: Worktree created at `/Users/kuu/ghq/github.com/fumiya-kume/issue-67-...` (outside repo, triggers trust prompt)

**After (Fixed)**:
```bash
# claude.sh at: /Users/kuu/ghq/github.com/fumiya-kume/FeLangKit/claude.sh  
SCRIPT_DIR="/Users/kuu/ghq/github.com/fumiya-kume/FeLangKit"
PROJECT_ROOT="$SCRIPT_DIR"     # = /Users/kuu/ghq/github.com/fumiya-kume/FeLangKit
```

**Result**: Worktree created at `/Users/kuu/ghq/github.com/fumiya-kume/FeLangKit/issue-67-...` (inside repo, no trust prompt)

## Benefits
- ✅ **Eliminates Trust Prompts**: Worktrees created inside trusted repository
- ✅ **Correct Directory Structure**: Files in proper repository context
- ✅ **No Security Bypasses**: Uses natural Claude Code trust boundaries
- ✅ **Better Integration**: Direct access to repository structure

🤖 Generated with [Claude Code](https://claude.ai/code)