### PR TITLE
fix(ui): improve debug mode performance stats display

### DIFF
--- a/ccw/types/models.go
+++ b/ccw/types/models.go
@@ -483,3 +483,26 @@ func (po *PerformanceOptimizer) AccessibleMetrics() *PerformanceMetrics {
 	metricsCopy := *po.Metrics
 	return &metricsCopy
 }
+
+// String returns a formatted string representation of PerformanceMetrics
+func (pm *PerformanceMetrics) String() string {
+	pm.mutex.RLock()
+	defer pm.mutex.RUnlock()
+	
+	// Handle the case where MinRenderTime is uninitialized (1 hour default)
+	minRenderTime := pm.MinRenderTime
+	if minRenderTime >= time.Hour {
+		minRenderTime = 0 // Show 0 if no renders have occurred
+	}
+	
+	return fmt.Sprintf("PerformanceStats{TotalRenders:%d, SkippedRenders:%d, AvgRenderTime:%s, MaxRenderTime:%s, MinRenderTime:%s, ChangeRate:%.2f, OptLevel:%d, Adjustments:%d}",
+		pm.TotalRenders,
+		pm.SkippedRenders,
+		pm.AverageRenderTime,
+		pm.MaxRenderTime,
+		minRenderTime,
+		pm.ContentChangeRate,
+		pm.OptimizationLevel,
+		pm.AdaptiveAdjustments,
+	)
+}

--- a/ccw/ui/ui_components.go
+++ b/ccw/ui/ui_components.go
@@ -257,7 +257,7 @@ func (ui *UIManager) startBackgroundHeaderUpdates() {
 				// Periodic performance stats logging
 				if ui.debugMode && time.Since(lastPerformanceCheck) > performanceCheckInterval {
 					stats := ui.performanceOptimizer.GetPerformanceStats()
-					ui.Debug(fmt.Sprintf("Performance stats: %+v", stats))
+					ui.Debug(fmt.Sprintf("Performance stats: %s", stats.String()))
 					lastPerformanceCheck = time.Now()
 				}
 			}


### PR DESCRIPTION
## Summary
Fix debug mode performance stats display by replacing raw struct dump with clean, formatted string representation.

## Background & Context
- **Original Issue:** Debug mode was showing verbose internal Go struct details including mutex information
- **User Impact:** Made debug logs difficult to read with excessive technical details
- **Previous State:** Debug output showed raw struct with internal fields: `&{TotalRenders:0 SkippedRenders:0 AverageRenderTime:0s MaxRenderTime:0s MinRenderTime:1h0m0s ContentChangeRate:0 OptimizationLevel:2 AdaptiveAdjustments:0 mutex:{w:{_:{} mu:{state:0 sema:0}} writerSem:0 readerSem:0 readerCount:{_:{} v:0} readerWait:{_:{} v:0}}}`
- **Requirements:** Provide clean, readable debug output while maintaining thread safety

## Solution Approach
- **Core Solution:** Add custom String() method to PerformanceMetrics struct for formatted output
- **Technical Strategy:** Replace `%+v` format specifier with custom string representation
- **Logic & Reasoning:** Implement proper string formatting that shows only relevant performance data
- **Architecture Changes:** Add method to existing struct without breaking existing functionality

## Implementation Details
- **Key Components:** 
  - Added `String()` method to `PerformanceMetrics` in `types/models.go`
  - Updated debug logging call in `ui/ui_components.go`
- **Code Changes:**
  - New formatted string method with mutex protection for thread safety
  - Fixed MinRenderTime display issue (was showing 1h0m0s due to initialization)
  - Changed debug format from `%+v` to use new String() method
- **Thread Safety:** Maintains proper mutex locking in String() method
- **Error Handling:** Handles uninitialized MinRenderTime gracefully

## Technical Logic
- **String Formatting:** Creates clean output format: `PerformanceStats{TotalRenders:X, SkippedRenders:Y, ...}`
- **Mutex Protection:** Uses RLock/RUnlock for safe concurrent access to metrics data
- **MinRenderTime Fix:** Detects uninitialized value (>= 1 hour) and displays as 0s instead
- **Performance Considerations:** Minimal overhead with efficient string formatting

## Testing & Validation
- **Test Strategy:** Manual testing in debug mode to verify clean output
- **Test Coverage:** Verified debug mode produces readable performance stats
- **Edge Cases:** Tested MinRenderTime handling for uninitialized state
- **Quality Assurance:** Confirmed thread safety and no breaking changes

## Impact & Future Work
- **Breaking Changes:** None - fully backward compatible addition
- **Performance Impact:** Minimal - only affects debug logging performance
- **Maintenance Impact:** Easier debugging with clean, readable performance stats
- **Future Enhancements:** Can extend formatting for additional metrics if needed
- **Technical Debt:** Resolves poor debug experience without introducing complexity

🤖 Generated with [Claude Code](https://claude.ai/code)