### PR TITLE
chore: add .worktree-config.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ issue-*-*/
 ccw/ccw
 ccw/ccw-*
 ccw/main
+.worktree-config.json
 
 # Temporary summary and description files  
 completion_summary.txt


### PR DESCRIPTION
## Summary
Add .worktree-config.json to .gitignore to prevent CCW worktree metadata from being tracked in version control.

## Background & Context
- **Original Issue:** CCW tool generates .worktree-config.json metadata files for tracking worktree information
- **User Impact:** These metadata files were being included in git commits, cluttering the repository
- **Previous State:** .worktree-config.json files were tracked by git
- **Requirements:** Exclude CCW metadata files from version control

## Solution Approach
- **Core Solution:** Added .worktree-config.json pattern to the existing CCW section in .gitignore
- **Technical Strategy:** Used gitignore pattern matching to exclude the specific metadata file
- **Logic & Reasoning:** This prevents CCW worktree metadata from being accidentally committed while preserving other important files

## Implementation Details
- **Files Modified:** .gitignore - added .worktree-config.json to CCW section
- **Code Changes:** Single line addition to the "CCW tool generated files and directories" section
- **Integration Points:** Works with existing CCW tool functionality without disruption

## Testing & Validation
- **Manual Testing:** Verified the gitignore pattern correctly excludes .worktree-config.json files
- **Quality Assurance:** No build or test changes required for gitignore updates

🤖 Generated with [Claude Code](https://claude.ai/code)