### PR TITLE
Resolve #325: E2E: 単項否定 '!' を検証

### DIFF
--- a/Sources/FeLangCore/Tokenizer/Tokenizer.swift
+++ b/Sources/FeLangCore/Tokenizer/Tokenizer.swift
@@ -149,6 +149,8 @@ public final class Tokenizer {
             return Token(type: .semicolon, lexeme: ";", position: position)
         case ":":
             return Token(type: .colon, lexeme: ":", position: position)
+        case "!":
+            return Token(type: .notKeyword, lexeme: "!", position: position)
         case "'":
             return try scanStringOrCharacterLiteral(position, startIndex: startIndex)
         default:

--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -90,6 +90,8 @@ public enum TokenizerUtilities {
         ("=", .equal),
         (">", .greater),
         ("<", .less),
+        // NOTE: If multi-character operators starting with "!" (e.g., "!=") are added,
+        // they must appear before this single-character "!" entry to preserve longest-match behavior.
         ("!", .notKeyword)
     ]
 

--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -89,7 +89,8 @@ public enum TokenizerUtilities {
         ("%", .modulo),
         ("=", .equal),
         (">", .greater),
-        ("<", .less)
+        ("<", .less),
+        ("!", .notKeyword)
     ]
 
     /// Delimiter definitions with their token types

--- a/Tests/FeLangE2ETests/LogicalOperatorE2ETests.swift
+++ b/Tests/FeLangE2ETests/LogicalOperatorE2ETests.swift
@@ -110,6 +110,12 @@ struct LogicalOperatorE2ETests {
         #expect(lines[1].contains("true"))
     }
 
+    @Test("! with comparison: !(5 = 3)")
+    func testExclamationWithComparison() throws {
+        let output = try InProcessTestHelper.run("println(!(5 = 3))")
+        #expect(output.lowercased().contains("true"))
+    }
+
     // MARK: - Complex Logical Expressions
 
     @Test("logical with comparison: (5 > 3) and (2 < 4)")

--- a/Tests/FeLangE2ETests/LogicalOperatorE2ETests.swift
+++ b/Tests/FeLangE2ETests/LogicalOperatorE2ETests.swift
@@ -77,6 +77,39 @@ struct LogicalOperatorE2ETests {
         #expect(output.lowercased().contains("true"))
     }
 
+    // MARK: - Exclamation Mark (!) as NOT Operator Tests
+
+    @Test("! operator: !true = false")
+    func testExclamationTrue() throws {
+        let output = try InProcessTestHelper.run("println(!true)")
+        #expect(output.lowercased().contains("false"))
+    }
+
+    @Test("! operator: !false = true")
+    func testExclamationFalse() throws {
+        let output = try InProcessTestHelper.run("println(!false)")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("double ! negation: !!true = true")
+    func testDoubleExclamation() throws {
+        let output = try InProcessTestHelper.run("println(!!true)")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("combined ! output: println(!true) and println(!false)")
+    func testExclamationCombinedOutput() throws {
+        let code = """
+        println(!true)
+        println(!false)
+        """
+        let output = try InProcessTestHelper.run(code)
+        let lines = output.split(separator: "\n").map { $0.lowercased() }
+        #expect(lines.count >= 2)
+        #expect(lines[0].contains("false"))
+        #expect(lines[1].contains("true"))
+    }
+
     // MARK: - Complex Logical Expressions
 
     @Test("logical with comparison: (5 > 3) and (2 < 4)")


### PR DESCRIPTION
## Summary
- `!` 演算子を `not` キーワードのシノニムとしてトークナイザーに実装
- E2Eテストで `!true`, `!false`, `!!true`, `!(5 = 3)` の動作を検証
- ドキュメント (`Expression/docs/README.md`) と実装の整合性を確保

## Updates since last revision
PRレビューコメントに対応:
- `!(5 = 3)` のような比較式と組み合わせたテストを追加（Copilot提案）
- 将来の `!=` 演算子実装時の順序に関する警告コメントを `TokenizerUtilities.swift` に追加（Copilot提案）

## Background & Context
- **Original Issue:** `!` がトークナイザで `not` と同義として扱われるとIssueに記載されていたが、実際には未実装だった
- **Root Cause:** `TokenizerUtilities.operators` 配列と `Tokenizer.swift` のswitch文に `!` が含まれていなかった
- **User Impact:** `!true` のような構文がパースエラーになっていた
- **Requirements:** `println(!true)` と `println(!false)` が正しく `false`, `true` を出力すること

## Solution Approach
- **Core Solution:** `!` を `.notKeyword` トークンタイプとしてトークナイズすることで、既存の `not` キーワードと同等の動作を実現
- **Technical Strategy:** トークナイザー層のみの変更で完結。ExpressionParserは既に `.notKeyword` を `UnaryOperator.not` にマッピング済み

## Implementation Details
- **Files Modified:**
  - `Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift` (+5 lines)
  - `Sources/FeLangCore/Tokenizer/Tokenizer.swift` (+2 lines)
  - `Tests/FeLangE2ETests/LogicalOperatorE2ETests.swift` (+39 lines)

## Testing & Validation
- **Test Coverage:** 
  - `testExclamationTrue`: `!true` → `false`
  - `testExclamationFalse`: `!false` → `true`
  - `testDoubleExclamation`: `!!true` → `true`
  - `testExclamationCombinedOutput`: Issue要件の複数行出力テスト
  - `testExclamationWithComparison`: `!(5 = 3)` → `true`
- **Quality Assurance:** SwiftLint、ビルド、全1164テスト成功

## Review & Testing Checklist for Human
- [ ] `!true` と `!false` が期待通り動作することを確認
- [ ] `!!true` (二重否定) が正しく `true` を返すことを確認
- [ ] 将来 `!=` 演算子を追加する際は、`TokenizerUtilities.operators` の順序に注意（コメント参照）

**推奨テスト手順:**
```bash
swift test --filter "LogicalOperatorE2ETests"
```

### Notes
- 完全に後方互換。既存の `not` キーワードは引き続き動作
- `!=` 演算子は未実装のため、このPRのスコープ外

---
**Requested by:** @fumiya-kume  
**Devin session:** https://app.devin.ai/sessions/1b9d2ed627214850aeb824ecf73e0a59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/327">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->