### PR TITLE
Resolve #321: E2E: 日本語『の』構文で多重配列型を検証

### DIFF
--- a/Tests/FeLangE2ETests/EdgeCaseE2ETests.swift
+++ b/Tests/FeLangE2ETests/EdgeCaseE2ETests.swift
@@ -195,7 +195,7 @@ struct EdgeCaseE2ETests {
         """
         let result = try CLITestHelper.run(arguments: ["run", "--code", code])
         #expect(result.exitCode == 0)
-        #expect(result.stdout.contains("2"))
+        #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "2")
     }
 
     // MARK: - Special Syntax

--- a/Tests/FeLangE2ETests/EdgeCaseE2ETests.swift
+++ b/Tests/FeLangE2ETests/EdgeCaseE2ETests.swift
@@ -186,6 +186,18 @@ struct EdgeCaseE2ETests {
         }
     }
 
+    @Test("nested array with Japanese の particle")
+    func testNestedArrayWithJapaneseParticle() throws {
+        // Test multi-dimensional array type with Japanese の particle
+        let code = """
+        変数 arr: 配列 の 配列 の 整数 ← [[1, 2], [3, 4]]
+        println(arr[0][1])
+        """
+        let result = try CLITestHelper.run(arguments: ["run", "--code", code])
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("2"))
+    }
+
     // MARK: - Special Syntax
 
     @Test("empty procedure body")


### PR DESCRIPTION
## Summary
- 日本語助詞「の」を用いた多重配列型指定のE2Eテストを追加
- `配列 の 配列 の 整数` 形式の構文が正しく解釈されることを検証

## Background & Context
- **Original Issue:** 日本語助詞 `の` を用いた多重配列型指定のE2E検証がなかった
- **Root Cause:** 既存テストは `配列 of 配列 of 整数`（英語 "of"）形式のみをカバー
- **User Impact:** 日本語構文での多重配列が正しく動作することの保証がなかった
- **Previous State:** パーサーは既に「の」をサポート済み（`StatementParser.swift:550-577`）、E2Eテストのみ欠如
- **Requirements:** `配列 の 配列 の 整数 ← [[1, 2], [3, 4]]` が正しくパースされ、`arr[0][1]` で `2` が取得できること

## Solution Approach
- **Core Solution:** EdgeCaseE2ETests.swift の Multi-dimensional Arrays セクションに新しいテストを追加
- **Technical Strategy:** 既存テストパターン（CLITestHelper）を活用
- **Logic & Reasoning:** 既存の `配列 of 配列` テストと同様のアプローチで、日本語構文をカバー
- **Architecture Changes:** なし（テスト追加のみ）

## Implementation Details
- **Files Modified:**
  - `Tests/FeLangE2ETests/EdgeCaseE2ETests.swift` - 新しいテスト関数を追加
- **New Functionality:** `testNestedArrayWithJapaneseParticle()` テスト関数
- **Integration Points:** 既存の CLITestHelper を使用
- **Error Handling:** exitCode と stdout の検証

## Technical Logic
- **Algorithm/Logic:**
  1. FeLang コード `変数 arr: 配列 の 配列 の 整数 ← [[1, 2], [3, 4]]` を定義
  2. `println(arr[0][1])` で要素アクセスをテスト
  3. CLI経由で実行し、exitCode == 0 と出力が正確に "2" であることを検証
- **Data Flow:** コード → CLITestHelper → felang CLI → 出力検証
- **Backwards Compatibility:** 影響なし（テスト追加のみ）

## Updates since last revision
- **Assertion precision improved:** `contains("2")` から `trimmingCharacters(in: .whitespacesAndNewlines) == "2"` に変更し、より厳密な出力検証を実現（Copilotレビュー指摘対応）

## Review & Testing Checklist for Human
- [ ] `swift test --filter "testNestedArrayWithJapaneseParticle"` でテストが成功することを確認
- [ ] 他のネスト配列テストが条件分岐パターンを使用しているのに対し、このテストが直接 `exitCode == 0` をアサートしていることが意図通りか確認（理由：この機能は既にサポート済みのため回帰テストとして実装）

### Notes
- このテストは「制限事項の記録」ではなく、既知の動作機能の回帰テストとして実装
- Copilotからの2つのレビューコメントに対応済み：
  - 条件分岐パターンについて：意図的に直接アサートを維持（機能は動作確認済み）
  - アサーション精度について：`trimmingCharacters == "2"` に修正済み

---
**Requested by:** @fumiya-kume  
**Devin session:** https://app.devin.ai/sessions/f9656374b0584a3ea3301e826d0cf1c1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/329">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 多次元配列と日本語キーワードを組み合わせた新しいエッジケーステストを追加しました。ネストされた配列の複雑な操作と二次元インデックスアクセスが正しく実行され、予期された出力結果が正確に得られることを検証しています。これにより言語機能の安定性と信頼性が向上し、より堅牢なシステムが実現します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->