### PR TITLE
Resolve #324: E2E: ASCII not-equal '!=' を検証

### DIFF
--- a/Sources/FeLangCore/Tokenizer/Tokenizer.swift
+++ b/Sources/FeLangCore/Tokenizer/Tokenizer.swift
@@ -119,6 +119,12 @@ public final class Tokenizer {
             return Token(type: .assign, lexeme: "←", position: position)
         case "=":
             return Token(type: .equal, lexeme: "=", position: position)
+        case "!":
+            if match("=") {
+                return Token(type: .notEqual, lexeme: "!=", position: position)
+            } else {
+                throw TokenizerError.unexpectedCharacter(char, position)
+            }
         case "≠":
             return Token(type: .notEqual, lexeme: "≠", position: position)
         case "≧":

--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -79,6 +79,7 @@ public enum TokenizerUtilities {
     /// Ordered with longer operators first to ensure proper matching
     public static let operators: [(String, TokenType)] = [
         ("←", .assign),
+        ("!=", .notEqual),
         ("≠", .notEqual),
         ("≧", .greaterEqual),
         ("≦", .lessEqual),

--- a/Tests/FeLangCoreTests/Tokenizer/TokenizerConsistencyTests.swift
+++ b/Tests/FeLangCoreTests/Tokenizer/TokenizerConsistencyTests.swift
@@ -14,7 +14,7 @@ struct TokenizerConsistencyTests {
             "配列名[添字] レコード名.フィールド名",
             "'Hello' 'A' 123 3.14 .5",  // Removed negative number
             "変数名 function123 _private",
-            "← = ≠ > ≧ < ≦ + - * / %",
+            "← = != ≠ > ≧ < ≦ + - * / %",
             "( ) [ ] { } , . ; :"
         ]
 
@@ -161,6 +161,24 @@ struct TokenizerConsistencyTests {
             #expect(originalTokens[0].lexeme == string)
             #expect(parsingTokens[0].lexeme == string)
         }
+    }
+
+    @Test func testASCIINotEqualOperator() throws {
+        // Test that both tokenizers handle ASCII != operator consistently
+        let testCase = "a != b"
+
+        let originalTokenizer = Tokenizer(input: testCase)
+        let parsingTokenizer = ParsingTokenizer()
+
+        let originalTokens = try originalTokenizer.tokenize()
+        let parsingTokens = try parsingTokenizer.tokenize(testCase)
+
+        // Both should produce the same tokens
+        #expect(originalTokens.count == parsingTokens.count)
+        #expect(originalTokens[1].type == .notEqual)
+        #expect(parsingTokens[1].type == .notEqual)
+        #expect(originalTokens[1].lexeme == "!=")
+        #expect(parsingTokens[1].lexeme == "!=")
     }
 
     @Test func testErrorHandlingConsistency() throws {

--- a/Tests/FeLangE2ETests/NumericE2ETests.swift
+++ b/Tests/FeLangE2ETests/NumericE2ETests.swift
@@ -175,4 +175,26 @@ struct NumericE2ETests {
         let output = try InProcessTestHelper.run("println(10 + 7 % 3)")
         #expect(output.trimmingCharacters(in: .whitespacesAndNewlines) == "11")
     }
+
+    // MARK: - ASCII Not-Equal Operator Tests
+
+    @Test("ASCII not-equal operator: 1 != 2 should be true")
+    func testASCIINotEqualTrue() throws {
+        let output = try InProcessTestHelper.run("println(1 != 2)")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("ASCII not-equal operator: 1 != 1 should be false")
+    func testASCIINotEqualFalse() throws {
+        let output = try InProcessTestHelper.run("println(1 != 1)")
+        #expect(output.lowercased().contains("false"))
+    }
+
+    @Test("ASCII not-equal should work same as Unicode ≠")
+    func testASCIINotEqualEquivalence() throws {
+        let asciiOutput = try InProcessTestHelper.run("println(5 != 3)")
+        let unicodeOutput = try InProcessTestHelper.run("println(5 ≠ 3)")
+        #expect(asciiOutput.trimmingCharacters(in: .whitespacesAndNewlines) ==
+                unicodeOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
 }


### PR DESCRIPTION
## Summary
- ASCII `!=` 演算子のサポートを追加し、Unicode `≠` と同等に動作することをE2Eテストで検証
- トークナイザー（Tokenizer, ParsingTokenizer）の両方で `!=` が正しくトークナイズされることを確認

## Background & Context
- **Original Issue:** Issue #324 では「`!=` はトークナイズで notEqual として扱われるが、E2E未検証」と記載されていた
- **Root Cause:** 実際には `!=` は **サポートされていなかった**。`ParsingTokenizer`（Interpreter が使用）は `!` を "Unexpected character" として拒否していた
- **User Impact:** ユーザーが ASCII `!=` を使用すると解析エラーが発生していた
- **Previous State:** Unicode `≠` のみがサポートされていた
- **Requirements:** `!=` が `≠` と同等に動作し、E2Eテストで検証されること

## Solution Approach
- **Core Solution:** `TokenizerUtilities.operators` リストと `Tokenizer.scanToken()` に `!=` サポートを追加
- **Technical Strategy:** 既存のパターンに従い、最小限の変更で機能を追加
- **Logic & Reasoning:** `!=` は2文字演算子なので、operators リストでは単一文字演算子より前に配置
- **Alternative Approaches:** `!` を独立したトークンとして扱う案もあったが、FE言語では `not` キーワードが論理否定に使われるため不要

## Implementation Details
- **Key Components:** Tokenizer, TokenizerUtilities, E2E Tests
- **Code Changes:**
  - `TokenizerUtilities.swift`: operators リストに `("!=", .notEqual)` 追加
  - `Tokenizer.swift`: `scanToken()` に `!` ケース追加、`match("=")` で `!=` を検出
- **Files Modified:**
  - `Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift` (+1 line)
  - `Sources/FeLangCore/Tokenizer/Tokenizer.swift` (+6 lines)
  - `Tests/FeLangE2ETests/NumericE2ETests.swift` (+22 lines)
  - `Tests/FeLangCoreTests/Tokenizer/TokenizerConsistencyTests.swift` (+19 lines, 1 modified)
- **Error Handling:** `!` の後に `=` がない場合は `TokenizerError.unexpectedCharacter` をスロー

## Technical Logic
- **Algorithm/Logic:**
  1. `TokenizerUtilities.operators` で `!=` を最長一致でマッチング（ParsingTokenizer用）
  2. `Tokenizer.scanToken()` で `!` を検出したら `match("=")` で次の文字を確認
  3. `=` があれば `.notEqual` トークンを生成、なければエラー
- **Data Flow:** Input → Tokenizer → `!=` を `.notEqual` トークンに変換 → Parser → AST
- **Backwards Compatibility:** 既存の `≠` の動作に影響なし

## Testing & Validation
- **Test Strategy:** E2Eテストとユニットテストの両方でカバー
- **Test Coverage:**
  - `testASCIINotEqualTrue`: `1 != 2` が `true` を返す
  - `testASCIINotEqualFalse`: `1 != 1` が `false` を返す
  - `testASCIINotEqualEquivalence`: `!=` と `≠` が同等に動作
  - `testASCIINotEqualOperator`: 両トークナイザー間の一貫性
- **Manual Testing:**
  ```
  $ echo 'println(1 != 2)' > test.fe && swift run felang test.fe
  true
  $ echo 'println(1 != 1)' > test.fe && swift run felang test.fe
  false
  ```
- **Quality Assurance:** SwiftLint, Build, 1163 tests 全てパス

## Impact & Future Work
- **Breaking Changes:** なし
- **Performance Impact:** なし（定数テーブル検索のみ）
- **Future Enhancements:** 他のASCII代替演算子（`>=`, `<=` など）も同様に追加可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
