### PR TITLE
Add test for return statement outside function error

### DIFF
--- a/Tests/FeLangE2ETests/ErrorE2ETests.swift
+++ b/Tests/FeLangE2ETests/ErrorE2ETests.swift
@@ -26,6 +26,13 @@ struct ErrorE2ETests {
         #expect(!result.succeeded)
     }
 
+    @Test("Return outside function returns error")
+    func testReturnOutsideFunction() throws {
+        let code = "return 1"
+        let result = InProcessTestHelper.execute(code)
+        #expect(!result.succeeded)
+    }
+
     // MARK: - File Error Tests
     // These tests require CLI because they test file path handling
 


### PR DESCRIPTION
## Summary
Added a new end-to-end test to verify that using a `return` statement outside of a function context properly returns an error.

## Changes
- Added `testReturnOutsideFunction()` test case to `ErrorE2ETests`
  - Tests that executing code with a bare `return 1` statement fails as expected
  - Validates error handling for invalid return statement placement
  - Uses existing `InProcessTestHelper.execute()` for consistency with other error tests

## Details
This test ensures the compiler correctly rejects `return` statements that appear outside of function definitions, which is a fundamental language validation rule. The test follows the established pattern in the error test suite and verifies the error case without requiring CLI file path handling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/332">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 関数の外で return ステートメントが使用された場合のエラー処理を検証するテストケースを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->