### PR TITLE
Add test for non-integer array index error handling

### DIFF
--- a/Tests/FeLangE2ETests/ErrorE2ETests.swift
+++ b/Tests/FeLangE2ETests/ErrorE2ETests.swift
@@ -119,16 +119,6 @@ struct ErrorE2ETests {
         #expect(!result.succeeded)
     }
 
-    @Test("Non-integer array index returns error")
-    func testNonIntegerArrayIndex() throws {
-        let code = """
-        変数 arr: 配列 of 整数 ← [1, 2, 3]
-        println(arr["0"])
-        """
-        let result = InProcessTestHelper.execute(code)
-        #expect(!result.succeeded)
-    }
-
     @Test("Wrong number of function arguments returns error")
     func testWrongArgumentCount() throws {
         let code = """
@@ -164,6 +154,16 @@ struct ErrorE2ETests {
     @Test("String used in arithmetic returns error")
     func testStringInArithmetic() throws {
         let result = InProcessTestHelper.execute("println(\"hello\" * 2)")
+        #expect(!result.succeeded)
+    }
+
+    @Test("Non-integer array index returns error")
+    func testNonIntegerArrayIndex() throws {
+        let code = """
+        変数 arr: 配列 of 整数 ← [1, 2, 3]
+        println(arr["0"])
+        """
+        let result = InProcessTestHelper.execute(code)
         #expect(!result.succeeded)
     }
 

--- a/Tests/FeLangE2ETests/ErrorE2ETests.swift
+++ b/Tests/FeLangE2ETests/ErrorE2ETests.swift
@@ -119,6 +119,16 @@ struct ErrorE2ETests {
         #expect(!result.succeeded)
     }
 
+    @Test("Non-integer array index returns error")
+    func testNonIntegerArrayIndex() throws {
+        let code = """
+        変数 arr: 配列 of 整数 ← [1, 2, 3]
+        println(arr["0"])
+        """
+        let result = InProcessTestHelper.execute(code)
+        #expect(!result.succeeded)
+    }
+
     @Test("Wrong number of function arguments returns error")
     func testWrongArgumentCount() throws {
         let code = """


### PR DESCRIPTION
## Summary
Added a new end-to-end test to verify that the FeLang compiler properly rejects array indexing with non-integer values and returns an error.

## Changes
- Added `testNonIntegerArrayIndex()` test case to `ErrorE2ETests`
- Test verifies that attempting to index an array with a string value (e.g., `arr["0"]`) fails with an error
- Uses existing test infrastructure (`InProcessTestHelper.execute()`) to validate error behavior
- Test placed in "Type Mismatch Error Tests" section (as this is a type error, not a runtime boundary condition)

## Details
This test ensures type safety for array indexing operations by confirming that the compiler enforces integer-only indices. The test case uses Japanese language syntax consistent with the FeLang language design (変数 for variable, 配列 for array, 整数 for integer).

## Updates since last revision
- Moved test from "Runtime Error Tests" section to "Type Mismatch Error Tests" section per Copilot review feedback (4f8a218)

## Review & Testing Checklist for Human
- [ ] Verify the test is correctly placed in the Type Mismatch Error Tests section
- [ ] Confirm CI passes with all existing tests

### Notes
- Link to Devin run: https://app.devin.ai/sessions/351b3c0285334b12a8de5a0e662d9b00
- Requested by: @fumiya-kume

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/334">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->