### PR TITLE
Add test for procedure return value error handling

### DIFF
--- a/Tests/FeLangE2ETests/ErrorE2ETests.swift
+++ b/Tests/FeLangE2ETests/ErrorE2ETests.swift
@@ -243,6 +243,7 @@ struct ErrorE2ETests {
         procedure bad()
             return 1
         endprocedure
+        bad()
         """
         let result = InProcessTestHelper.execute(code)
         // Procedures should not return values (void-function-returns-value)

--- a/Tests/FeLangE2ETests/ErrorE2ETests.swift
+++ b/Tests/FeLangE2ETests/ErrorE2ETests.swift
@@ -234,4 +234,18 @@ struct ErrorE2ETests {
         // Runtime error when trying to multiply string by integer
         #expect(!result.succeeded)
     }
+
+    // MARK: - Procedure Error Tests
+
+    @Test("Procedure returning a value causes error")
+    func testProcedureReturnsValue() throws {
+        let code = """
+        procedure bad()
+            return 1
+        endprocedure
+        """
+        let result = InProcessTestHelper.execute(code)
+        // Procedures should not return values (void-function-returns-value)
+        #expect(!result.succeeded)
+    }
 }


### PR DESCRIPTION
## Summary
Added a new end-to-end test to verify that procedures returning values are properly caught as errors during execution.

## Changes
- Added `testProcedureReturnsValue()` test case in the "Procedure Error Tests" section
- Test validates that attempting to return a value from a procedure (which should be void) results in a failed execution
- Covers the `void-function-returns-value` error case

## Details
This test ensures the FeLang compiler/runtime correctly rejects procedures that attempt to return values, maintaining the language's distinction between procedures (void) and functions (return values).

## Updates since last revision
- Fixed test to actually call the procedure with `bad()` - the runtime error is only triggered when the procedure is executed, not when it's defined
- Resolved merge conflict with master branch (integrated alongside the new "Missing Return Value Tests" section)

## Review & Testing Checklist for Human
- [ ] Verify the test correctly triggers `RuntimeError.returnInVoidContext` when the procedure is called
- [ ] Confirm the test would fail if `bad()` call is removed (error only occurs at runtime execution)

### Notes
- Link to Devin run: https://app.devin.ai/sessions/f0f46ba5b123445e9aafdbba55d2dd99
- Requested by: k "焼酎お湯割り250ml 30%引き" (@fumiya-kume)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * プロシージャの戻り値に関するエラーハンドリングの検証テストを追加しました。プロシージャが値を返さないことを確認するテストケースを実装し、アプリケーションの動作保証を強化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->