### PR TITLE
Add comprehensive E2E tests for string comparison operators

### DIFF
--- a/Tests/FeLangE2ETests/StringComparisonE2ETests.swift
+++ b/Tests/FeLangE2ETests/StringComparisonE2ETests.swift
@@ -101,7 +101,8 @@ struct StringComparisonE2ETests {
 
     @Test("String comparison with empty string")
     func testEmptyStringComparison() throws {
-        let output = try InProcessTestHelper.run("println(\"\" < \"a\")")
+        // Use multi-char string to avoid Character type mismatch
+        let output = try InProcessTestHelper.run("println(\"\" < \"abc\")")
         #expect(output.lowercased().contains("true"))
     }
 
@@ -113,8 +114,8 @@ struct StringComparisonE2ETests {
 
     @Test("String comparison case sensitivity")
     func testCaseSensitiveComparison() throws {
-        // ASCII: 'A' (65) < 'a' (97)
-        let output = try InProcessTestHelper.run("println(\"A\" < \"a\")")
+        // ASCII: 'A' (65) < 'a' (97), using multi-char strings to avoid Character type
+        let output = try InProcessTestHelper.run("println(\"Apple\" < \"apple\")")
         #expect(output.lowercased().contains("true"))
     }
 
@@ -135,11 +136,11 @@ struct StringComparisonE2ETests {
     func testStringComparisonInConditional() throws {
         let code = """
         変数 fruit: 文字列 ← "apple"
-        もし fruit < "banana" ならば
+        if fruit < "banana" then
             println("apple comes first")
-        そうでなければ
+        else
             println("banana comes first")
-        終わり
+        endif
         """
         let output = try InProcessTestHelper.run(code)
         #expect(output.contains("apple comes first"))

--- a/Tests/FeLangE2ETests/StringComparisonE2ETests.swift
+++ b/Tests/FeLangE2ETests/StringComparisonE2ETests.swift
@@ -1,0 +1,147 @@
+import FeLangRuntime
+import Foundation
+import Testing
+
+@Suite("String Comparison E2E Tests", .serialized)
+struct StringComparisonE2ETests {
+
+    // MARK: - Basic Lexicographic Comparison
+
+    @Test("String less than: \"apple\" < \"banana\" = true")
+    func testStringLessThan() throws {
+        let output = try InProcessTestHelper.run("println(\"apple\" < \"banana\")")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("String less than (false): \"banana\" < \"apple\" = false")
+    func testStringLessThanFalse() throws {
+        let output = try InProcessTestHelper.run("println(\"banana\" < \"apple\")")
+        #expect(output.lowercased().contains("false"))
+    }
+
+    @Test("String greater than: \"banana\" > \"apple\" = true")
+    func testStringGreaterThan() throws {
+        let output = try InProcessTestHelper.run("println(\"banana\" > \"apple\")")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("String greater than (false): \"apple\" > \"banana\" = false")
+    func testStringGreaterThanFalse() throws {
+        let output = try InProcessTestHelper.run("println(\"apple\" > \"banana\")")
+        #expect(output.lowercased().contains("false"))
+    }
+
+    // MARK: - Equality Comparison
+
+    @Test("String equality: \"hello\" = \"hello\" = true")
+    func testStringEquality() throws {
+        let output = try InProcessTestHelper.run("println(\"hello\" = \"hello\")")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("String equality (false): \"hello\" = \"world\" = false")
+    func testStringEqualityFalse() throws {
+        let output = try InProcessTestHelper.run("println(\"hello\" = \"world\")")
+        #expect(output.lowercased().contains("false"))
+    }
+
+    @Test("String inequality: \"hello\" ≠ \"world\" = true")
+    func testStringInequality() throws {
+        let output = try InProcessTestHelper.run("println(\"hello\" ≠ \"world\")")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("String inequality (false): \"hello\" ≠ \"hello\" = false")
+    func testStringInequalityFalse() throws {
+        let output = try InProcessTestHelper.run("println(\"hello\" ≠ \"hello\")")
+        #expect(output.lowercased().contains("false"))
+    }
+
+    // MARK: - Less Than or Equal
+
+    @Test("String less or equal (less): \"apple\" <= \"banana\" = true")
+    func testStringLessOrEqualLess() throws {
+        let output = try InProcessTestHelper.run("println(\"apple\" <= \"banana\")")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("String less or equal (equal): \"apple\" <= \"apple\" = true")
+    func testStringLessOrEqualEqual() throws {
+        let output = try InProcessTestHelper.run("println(\"apple\" <= \"apple\")")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("String less or equal (false): \"banana\" <= \"apple\" = false")
+    func testStringLessOrEqualFalse() throws {
+        let output = try InProcessTestHelper.run("println(\"banana\" <= \"apple\")")
+        #expect(output.lowercased().contains("false"))
+    }
+
+    // MARK: - Greater Than or Equal
+
+    @Test("String greater or equal (greater): \"banana\" >= \"apple\" = true")
+    func testStringGreaterOrEqualGreater() throws {
+        let output = try InProcessTestHelper.run("println(\"banana\" >= \"apple\")")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("String greater or equal (equal): \"apple\" >= \"apple\" = true")
+    func testStringGreaterOrEqualEqual() throws {
+        let output = try InProcessTestHelper.run("println(\"apple\" >= \"apple\")")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("String greater or equal (false): \"apple\" >= \"banana\" = false")
+    func testStringGreaterOrEqualFalse() throws {
+        let output = try InProcessTestHelper.run("println(\"apple\" >= \"banana\")")
+        #expect(output.lowercased().contains("false"))
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("String comparison with empty string")
+    func testEmptyStringComparison() throws {
+        let output = try InProcessTestHelper.run("println(\"\" < \"a\")")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("String comparison with same prefix")
+    func testSamePrefixComparison() throws {
+        let output = try InProcessTestHelper.run("println(\"app\" < \"apple\")")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("String comparison case sensitivity")
+    func testCaseSensitiveComparison() throws {
+        // ASCII: 'A' (65) < 'a' (97)
+        let output = try InProcessTestHelper.run("println(\"A\" < \"a\")")
+        #expect(output.lowercased().contains("true"))
+    }
+
+    // MARK: - String Comparison with Variables
+
+    @Test("String comparison with variables")
+    func testStringComparisonWithVariables() throws {
+        let code = """
+        変数 s1: 文字列 ← "apple"
+        変数 s2: 文字列 ← "banana"
+        println(s1 < s2)
+        """
+        let output = try InProcessTestHelper.run(code)
+        #expect(output.lowercased().contains("true"))
+    }
+
+    @Test("String comparison in conditional")
+    func testStringComparisonInConditional() throws {
+        let code = """
+        変数 fruit: 文字列 ← "apple"
+        もし fruit < "banana" ならば
+            println("apple comes first")
+        そうでなければ
+            println("banana comes first")
+        終わり
+        """
+        let output = try InProcessTestHelper.run(code)
+        #expect(output.contains("apple comes first"))
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a comprehensive end-to-end test suite for string comparison operations in FeLang, covering all comparison operators and edge cases.

## Key Changes
- Added `StringComparisonE2ETests.swift` with 19 test cases covering:
  - **Basic lexicographic comparisons**: `<` and `>` operators with true/false cases
  - **Equality comparisons**: `=` and `≠` operators
  - **Range comparisons**: `<=` and `>=` operators with multiple scenarios (less, equal, greater)
  - **Edge cases**: empty strings, same prefixes, and case sensitivity
  - **Variable usage**: string comparisons with variables and in conditional statements

## Notable Implementation Details
- Tests use `InProcessTestHelper.run()` to execute FeLang code and verify output
- All comparison operators are tested in both positive and negative scenarios
- Edge cases include empty string comparisons, prefix matching, and ASCII-based case sensitivity
- Integration tests demonstrate real-world usage patterns with variables and control flow
- Tests use Japanese keywords for variable declarations (変数, 文字列) and English keywords for control flow (if/then/else/endif)

## Test Coverage
The test suite ensures that string comparison operators work correctly across:
- All six comparison operators (`<`, `>`, `=`, `≠`, `<=`, `>=`)
- Literal string values
- String variables
- Conditional expressions
- Edge cases and boundary conditions

## Updates Since Last Revision
- Fixed CI failures by using multi-character strings in edge case tests to avoid Character type mismatch (single-char strings are parsed as Character type, not String)
- Changed conditional test to use English control flow keywords (if/then/else/endif) since Japanese control flow keywords are not implemented in the tokenizer

## Review & Testing Checklist for Human
- [ ] Verify string comparison operators behave correctly with the runtime (lexicographic ordering)
- [ ] Confirm the Character vs String type distinction for single-character literals is intentional runtime behavior
- [ ] Run `swift test --filter "StringComparisonE2ETests"` locally to verify all 19 tests pass

### Notes
- The runtime treats single-character string literals as `Character` type rather than `String`, which causes type mismatch errors in comparisons. Tests work around this by using multi-character strings.
- Japanese control flow keywords (もし, ならば, そうでなければ, 終わり) are defined in FeLangServer for completion/hover but are not implemented in the tokenizer.

**Requested by:** @fumiya-kume  
**Devin session:** https://app.devin.ai/sessions/f242e4bef2da4ef8b137ddf8074a7514
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/336">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->