### PR TITLE
Fix SwiftLint violations: duplicate_conditions and function_parameter_count

### DIFF
--- a/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
+++ b/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
@@ -503,7 +503,8 @@ public struct PrettyPrinter {
         return true
     }
 
-    /// Prints a callable declaration (function or procedure) with shared formatting logic.
+    // Prints a callable declaration (function or procedure) with shared formatting logic.
+    // swiftlint:disable:next function_parameter_count
     private func printCallableDeclaration(
         name: String,
         parameters: [Parameter],

--- a/Sources/FeLangCore/Tokenizer/Tokenizer.swift
+++ b/Sources/FeLangCore/Tokenizer/Tokenizer.swift
@@ -123,7 +123,7 @@ public final class Tokenizer {
             if match("=") {
                 return Token(type: .notEqual, lexeme: "!=", position: position)
             } else {
-                throw TokenizerError.unexpectedCharacter(char, position)
+                return Token(type: .notKeyword, lexeme: "!", position: position)
             }
         case "≠":
             return Token(type: .notEqual, lexeme: "≠", position: position)
@@ -155,8 +155,6 @@ public final class Tokenizer {
             return Token(type: .semicolon, lexeme: ";", position: position)
         case ":":
             return Token(type: .colon, lexeme: ":", position: position)
-        case "!":
-            return Token(type: .notKeyword, lexeme: "!", position: position)
         case "'":
             return try scanStringOrCharacterLiteral(position, startIndex: startIndex)
         default:


### PR DESCRIPTION
## Summary
- Fix 2 `duplicate_conditions` errors in `Tokenizer.swift` by merging duplicate `case "!"` branches
- Suppress `function_parameter_count` warning in `PrettyPrinter.swift` for a private helper function

## Background & Context
- **Original Issue:** `swiftlint lint` reported 3 violations (2 serious errors, 1 warning) preventing clean lint passes
- **Root Cause:** `Tokenizer.swift` had two `case "!"` branches in the same switch statement — the second was unreachable dead code. `PrettyPrinter.swift` had a private function with 8 parameters exceeding the 5-parameter limit.

## Solution Approach
- **Tokenizer.swift:** Merged the two `case "!"` branches into one. When `!` is followed by `=`, returns `!=` (notEqual); otherwise returns `!` (notKeyword). Removed the duplicate dead-code branch.
- **PrettyPrinter.swift:** Added `// swiftlint:disable:next function_parameter_count` since the function is private with only 2 call sites — introducing a wrapper struct would be over-engineering.

## Implementation Details
- **Files Modified:**
  - `Sources/FeLangCore/Tokenizer/Tokenizer.swift`: Merged duplicate `case "!"`, changed error throw to `notKeyword` token return
  - `Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift`: Added swiftlint disable comment for `printCallableDeclaration`

## Testing & Validation
- `swiftlint lint` → 0 violations, 0 serious
- `swift build` → Build succeeded
- `swift test` → All 1175 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/339">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
