### PR TITLE
feat: add close-fixed-issue Claude Code skill

### DIFF
--- a/.claude/skills/close-fixed-issue/SKILL.md
+++ b/.claude/skills/close-fixed-issue/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: close-fixed-issue
+description: >
+  This skill should be used when the user asks to
+  "find fixed issues that are still open",
+  "close resolved issues",
+  "check open issues against merged PRs",
+  "clean up stale issues",
+  or wants to detect GitHub issues already addressed by merged pull requests.
+user-invocable: true
+disable-model-invocation: true
+context: fork
+allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion
+---
+
+# Close Fixed Issues
+
+Detect open GitHub issues that have already been resolved by merged pull requests, and close them after user confirmation.
+
+## Workflow
+
+### Step 1: Gather Open Issues
+
+Fetch all open issues from the repository:
+
+```bash
+gh issue list --state open --limit 100 --json number,title,labels
+```
+
+If no open issues exist, report that and stop.
+
+### Step 2: Gather Merged PRs
+
+Fetch recently merged pull requests:
+
+```bash
+gh pr list --state merged --limit 100 --json number,title,body,mergedAt
+```
+
+### Step 3: Cross-Reference Issues with PRs
+
+For each open issue, check whether a merged PR addresses it. Use two detection methods:
+
+#### Method A: PR Title Matching
+
+Scan merged PR titles for auto-close keywords referencing the issue number:
+- `Resolve #N`
+- `Fixes #N`
+- `Closes #N`
+- `Fix #N`
+- `Close #N`
+
+#### Method B: Timeline Event Analysis
+
+Run the bundled script to query GitHub GraphQL API for cross-referenced events:
+
+```bash
+bash scripts/check-issue-references.sh OWNER REPO ISSUE_NUMBER [ISSUE_NUMBER...]
+```
+
+Extract the repository owner and name from `gh repo view --json owner,name`.
+
+This script returns, for each issue, any pull requests that reference it and their merge status.
+
+### Step 4: Verify Fixes in Codebase
+
+For each issue with a candidate merged PR, verify the fix exists in the codebase:
+
+1. Read the issue body to understand the expected deliverable (test addition, bug fix, feature, etc.)
+2. Search the codebase for the expected artifact:
+   - For test issues: search for relevant test function names using `Grep`
+   - For feature issues: search for the implemented functionality
+   - For bug fixes: confirm the fix is present in the relevant source file
+3. Mark the issue as **confirmed fixed** only when both a merged PR reference AND codebase evidence exist.
+
+### Step 5: Present Findings
+
+Format results as a markdown table:
+
+```
+| Issue | Title | Fixed By | Evidence |
+|-------|-------|----------|----------|
+| #N    | ...   | PR #M    | test function / file path |
+```
+
+Separately list issues where evidence is ambiguous or partial.
+
+### Step 6: User Confirmation
+
+Use `AskUserQuestion` to ask which issues to close. Present the confirmed-fixed issues as selectable options with `multiSelect: true`.
+
+Never close issues without explicit user approval.
+
+### Step 7: Close Confirmed Issues
+
+For each approved issue, close with a descriptive comment linking to the PR:
+
+```bash
+gh issue close <NUMBER> --comment "Resolved by PR #<PR_NUMBER> (<brief description>)"
+```
+
+Report the final list of closed issues.
+
+## Important Rules
+
+- Never close an issue without user confirmation.
+- Always provide codebase evidence, not just PR references.
+- If an issue is only partially addressed, report it as ambiguous rather than confirmed.
+- Include the PR number in every close comment for traceability.

--- a/.claude/skills/close-fixed-issue/SKILL.md
+++ b/.claude/skills/close-fixed-issue/SKILL.md
@@ -37,6 +37,8 @@ Fetch recently merged pull requests:
 gh pr list --state merged --limit 100 --json number,title,body,mergedAt
 ```
 
+**Note:** This fetches only the 100 most recently merged PRs. For repositories with high PR volume, older issues may require manual verification or adjusting the limit.
+
 ### Step 3: Cross-Reference Issues with PRs
 
 For each open issue, check whether a merged PR addresses it. Use two detection methods:
@@ -58,7 +60,7 @@ bash .claude/skills/close-fixed-issue/scripts/check-issue-references.sh OWNER RE
 
 Extract the repository owner and name from `gh repo view --json owner,name`.
 
-This script returns, for each issue, any pull requests that reference it and their merge status.
+This script returns, for each issue, only the **merged** pull requests that reference it. The output is pre-filtered to include only PRs where `merged: true`.
 
 ### Step 4: Verify Fixes in Codebase
 
@@ -95,6 +97,11 @@ For each approved issue, close with a descriptive comment linking to the PR:
 
 ```bash
 gh issue close <NUMBER> --comment "Resolved by PR #<PR_NUMBER> (<brief description>)"
+```
+
+**Example:**
+```bash
+gh issue close 123 --comment "Resolved by PR #456 (Added user authentication feature)"
 ```
 
 Report the final list of closed issues.

--- a/.claude/skills/close-fixed-issue/SKILL.md
+++ b/.claude/skills/close-fixed-issue/SKILL.md
@@ -41,21 +41,19 @@ gh pr list --state merged --limit 100 --json number,title,body,mergedAt
 
 For each open issue, check whether a merged PR addresses it. Use two detection methods:
 
-#### Method A: PR Title Matching
+#### Method A: PR Auto-Close Keyword Matching
 
-Scan merged PR titles for auto-close keywords referencing the issue number:
-- `Resolve #N`
-- `Fixes #N`
-- `Closes #N`
-- `Fix #N`
-- `Close #N`
+Scan merged PR titles and bodies for GitHub's auto-close keywords followed by an issue reference (e.g., `#N` or `owner/repo#N`). GitHub treats these keywords case-insensitively in PR titles, bodies, and commit messages:
+- `close #N`, `closes #N`, `closed #N`
+- `fix #N`, `fixes #N`, `fixed #N`
+- `resolve #N`, `resolves #N`, `resolved #N`
 
 #### Method B: Timeline Event Analysis
 
-Run the bundled script to query GitHub GraphQL API for cross-referenced events:
+Run the bundled script from the repository root to query GitHub GraphQL API for cross-referenced events:
 
 ```bash
-bash scripts/check-issue-references.sh OWNER REPO ISSUE_NUMBER [ISSUE_NUMBER...]
+bash .claude/skills/close-fixed-issue/scripts/check-issue-references.sh OWNER REPO ISSUE_NUMBER [ISSUE_NUMBER...]
 ```
 
 Extract the repository owner and name from `gh repo view --json owner,name`.

--- a/.claude/skills/close-fixed-issue/scripts/check-issue-references.sh
+++ b/.claude/skills/close-fixed-issue/scripts/check-issue-references.sh
@@ -7,13 +7,31 @@
 #   bash check-issue-references.sh OWNER REPO ISSUE_NUMBER [ISSUE_NUMBER...]
 #
 # Output:
-#   JSON lines, one per issue, with referenced PR number, title, and state.
+#   JSON lines, one per issue, with structure:
+#     {
+#       "issue": <issue number>,
+#       "title": <issue title or null>,
+#       "error": <error message if issue not found, otherwise omitted>,
+#       "referenced_prs": [
+#         {
+#           "number": <PR number>,
+#           "title": <PR title>,
+#           "state": <PR state: "MERGED" or "CLOSED">,
+#           "merged": true
+#         },
+#         ...
+#       ]
+#     }
+#
+# Limitations:
+#   - Only returns the first 100 timeline items per issue. Issues with more
+#     cross-references may have some PRs missing from results.
 #
 # Requirements:
 #   - gh CLI authenticated
 #   - jq installed
 
-set -euo pipefail
+set -uo pipefail
 
 if [ $# -lt 3 ]; then
   echo "Usage: $0 OWNER REPO ISSUE_NUMBER [ISSUE_NUMBER...]" >&2
@@ -34,6 +52,7 @@ done
 
 for ISSUE_NUM in "$@"; do
   # Use GraphQL variables via -F flag to prevent injection
+  # Use || true to allow error handling despite set -u
   RESULT=$(gh api graphql \
     -F owner="$OWNER" \
     -F repo="$REPO" \
@@ -71,14 +90,21 @@ for ISSUE_NUM in "$@"; do
         }
       }
     }
-  ')
+  ' 2>&1) || true
 
-  if [ $? -ne 0 ] || [ -z "$RESULT" ]; then
+  if [ -z "$RESULT" ]; then
     echo "Error: Failed to fetch data for issue #$ISSUE_NUM" >&2
     continue
   fi
 
+  # Check if result contains GraphQL errors
+  if echo "$RESULT" | jq -e '.errors' > /dev/null 2>&1; then
+    echo "Error: GraphQL error for issue #$ISSUE_NUM: $(echo "$RESULT" | jq -r '.errors[0].message // "Unknown error"')" >&2
+    continue
+  fi
+
   # Extract merged PRs referencing this issue with null checking
+  # Only include PRs that are actually merged
   echo "$RESULT" | jq -c --arg issue_num "$ISSUE_NUM" '
     if .data.repository.issue == null then
       {
@@ -94,12 +120,13 @@ for ISSUE_NUM in "$@"; do
         referenced_prs: (
           (.data.repository.issue.timelineItems.nodes // [])
           | map(
-              if .source?.number then
+              if .source != null and .source.number != null then
                 { number: .source.number, title: .source.title, state: .source.state, merged: .source.merged }
-              elif .closer?.number then
-                { number: .closer.number, title: .closer.title, merged: .closer.merged, state: "CLOSED_BY" }
+              elif .closer != null and .closer.number != null then
+                { number: .closer.number, title: .closer.title, merged: .closer.merged, state: (if .closer.merged == true then "MERGED" else "CLOSED" end) }
               else empty end
             )
+          | map(select(.merged == true))
         )
       }
     end

--- a/.claude/skills/close-fixed-issue/scripts/check-issue-references.sh
+++ b/.claude/skills/close-fixed-issue/scripts/check-issue-references.sh
@@ -24,14 +24,27 @@ OWNER="$1"
 REPO="$2"
 shift 2
 
+# Validate that all ISSUE_NUMBER arguments are positive integers
+for ISSUE_ARG in "$@"; do
+  if ! [[ "$ISSUE_ARG" =~ ^[0-9]+$ ]] || [ "$ISSUE_ARG" -le 0 ]; then
+    echo "Error: ISSUE_NUMBER must be a positive integer: '$ISSUE_ARG'" >&2
+    exit 1
+  fi
+done
+
 for ISSUE_NUM in "$@"; do
-  RESULT=$(gh api graphql -f query='
-    {
-      repository(owner: "'"$OWNER"'", name: "'"$REPO"'") {
-        issue(number: '"$ISSUE_NUM"') {
+  # Use GraphQL variables via -F flag to prevent injection
+  RESULT=$(gh api graphql \
+    -F owner="$OWNER" \
+    -F repo="$REPO" \
+    -F issueNum:="$ISSUE_NUM" \
+    -f query='
+    query($owner: String!, $repo: String!, $issueNum: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $issueNum) {
           number
           title
-          timelineItems(itemTypes: [CROSS_REFERENCED_EVENT, CLOSED_EVENT, REFERENCED_EVENT], first: 20) {
+          timelineItems(itemTypes: [CROSS_REFERENCED_EVENT, CLOSED_EVENT], first: 100) {
             nodes {
               ... on CrossReferencedEvent {
                 source {
@@ -58,19 +71,37 @@ for ISSUE_NUM in "$@"; do
         }
       }
     }
-  ' 2>/dev/null)
+  ')
 
-  # Extract merged PRs referencing this issue
-  echo "$RESULT" | jq -c '{
-    issue: .data.repository.issue.number,
-    title: .data.repository.issue.title,
-    referenced_prs: [
-      .data.repository.issue.timelineItems.nodes[]
-      | if .source?.number then
-          { number: .source.number, title: .source.title, state: .source.state, merged: .source.merged }
-        elif .closer?.number then
-          { number: .closer.number, title: .closer.title, merged: .closer.merged, state: "CLOSED_BY" }
-        else empty end
-    ]
-  }'
+  if [ $? -ne 0 ] || [ -z "$RESULT" ]; then
+    echo "Error: Failed to fetch data for issue #$ISSUE_NUM" >&2
+    continue
+  fi
+
+  # Extract merged PRs referencing this issue with null checking
+  echo "$RESULT" | jq -c --arg issue_num "$ISSUE_NUM" '
+    if .data.repository.issue == null then
+      {
+        issue: ($issue_num | tonumber),
+        title: null,
+        error: "Issue not found",
+        referenced_prs: []
+      }
+    else
+      {
+        issue: .data.repository.issue.number,
+        title: .data.repository.issue.title,
+        referenced_prs: (
+          (.data.repository.issue.timelineItems.nodes // [])
+          | map(
+              if .source?.number then
+                { number: .source.number, title: .source.title, state: .source.state, merged: .source.merged }
+              elif .closer?.number then
+                { number: .closer.number, title: .closer.title, merged: .closer.merged, state: "CLOSED_BY" }
+              else empty end
+            )
+        )
+      }
+    end
+  '
 done

--- a/.claude/skills/close-fixed-issue/scripts/check-issue-references.sh
+++ b/.claude/skills/close-fixed-issue/scripts/check-issue-references.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# check-issue-references.sh
+#
+# Query GitHub GraphQL API to find merged PRs that reference open issues.
+#
+# Usage:
+#   bash check-issue-references.sh OWNER REPO ISSUE_NUMBER [ISSUE_NUMBER...]
+#
+# Output:
+#   JSON lines, one per issue, with referenced PR number, title, and state.
+#
+# Requirements:
+#   - gh CLI authenticated
+#   - jq installed
+
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+  echo "Usage: $0 OWNER REPO ISSUE_NUMBER [ISSUE_NUMBER...]" >&2
+  exit 1
+fi
+
+OWNER="$1"
+REPO="$2"
+shift 2
+
+for ISSUE_NUM in "$@"; do
+  RESULT=$(gh api graphql -f query='
+    {
+      repository(owner: "'"$OWNER"'", name: "'"$REPO"'") {
+        issue(number: '"$ISSUE_NUM"') {
+          number
+          title
+          timelineItems(itemTypes: [CROSS_REFERENCED_EVENT, CLOSED_EVENT, REFERENCED_EVENT], first: 20) {
+            nodes {
+              ... on CrossReferencedEvent {
+                source {
+                  ... on PullRequest {
+                    number
+                    title
+                    state
+                    merged
+                    mergedAt
+                  }
+                }
+              }
+              ... on ClosedEvent {
+                closer {
+                  ... on PullRequest {
+                    number
+                    title
+                    merged
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ' 2>/dev/null)
+
+  # Extract merged PRs referencing this issue
+  echo "$RESULT" | jq -c '{
+    issue: .data.repository.issue.number,
+    title: .data.repository.issue.title,
+    referenced_prs: [
+      .data.repository.issue.timelineItems.nodes[]
+      | if .source?.number then
+          { number: .source.number, title: .source.title, state: .source.state, merged: .source.merged }
+        elif .closer?.number then
+          { number: .closer.number, title: .closer.title, merged: .closer.merged, state: "CLOSED_BY" }
+        else empty end
+    ]
+  }'
+done


### PR DESCRIPTION
## Summary
- Add `/close-fixed-issue` Claude Code skill to detect open GitHub issues already resolved by merged PRs
- Includes a GraphQL-based shell script for cross-referencing issues with merged PRs
- Requires user confirmation before closing any issue

## Updates since last revision
Addressed additional PR review comments from Devin Review and Copilot:
- Fixed GraphQL injection vulnerability by using `-F` flag for variables instead of string interpolation
- Added validation for positive integer issue numbers
- Removed stderr suppression (`2>/dev/null`), added proper error handling
- Added null checking in jq for missing issue data
- Increased timeline items limit from 20 to 100
- Removed unused `REFERENCED_EVENT` from filter (no fragment was processing it)
- Fixed script path in SKILL.md to use full path from repo root
- Updated auto-close keywords list with all GitHub supported keywords
- Removed `set -e` to allow graceful error handling for failed API calls
- Added `|| true` to command substitution for proper error recovery
- Added explicit GraphQL error checking with informative messages
- Filter jq output to only include merged PRs (`select(.merged == true)`)
- Replaced invalid `CLOSED_BY` state with actual state based on merged field
- Used explicit null checks instead of optional chaining in jq
- Updated script header with detailed JSON output structure documentation
- Documented 100 timeline items limitation in script header
- Added note about 100 merged PRs limit in SKILL.md
- Added example with actual values for `gh issue close` command
- Clarified that script output is pre-filtered for merged PRs only

## Review & Testing Checklist for Human
- [ ] Test the shell script with actual GitHub issues: `bash .claude/skills/close-fixed-issue/scripts/check-issue-references.sh <owner> <repo> <issue_number>`
- [ ] Verify the GraphQL query returns expected PR references for issues with cross-references
- [ ] Test error handling by passing invalid issue numbers (e.g., non-existent issue, non-numeric input)
- [ ] Verify that only merged PRs appear in the output (unmerged PRs should be filtered out)
- [ ] Confirm the skill can be invoked in Claude Code and follows the documented workflow

### Notes
- The shell script requires `gh` CLI authenticated and `jq` installed
- This skill is user-invocable only (`disable-model-invocation: true`)
- The script now outputs detailed error messages to stderr for debugging

Link to Devin run: https://app.devin.ai/sessions/fe2d3a26497147799373f15bac2dbd98
Requested by: @fumiya-kume

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/340">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->