### PR TITLE
feat: add PostToolUse hook for async SwiftLint auto-formatting

### DIFF
--- a/.claude/hooks/format-swift.sh
+++ b/.claude/hooks/format-swift.sh
@@ -3,7 +3,13 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+FILE_PATH=""
+
+if command -v jq &>/dev/null; then
+    FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || printf '')
+else
+    exit 0
+fi
 
 if [ -z "$FILE_PATH" ]; then
     exit 0

--- a/.claude/hooks/format-swift.sh
+++ b/.claude/hooks/format-swift.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$(cat)
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+    exit 0
+fi
+
+case "$FILE_PATH" in
+    *.swift) ;;
+    *) exit 0 ;;
+esac
+
+if [ ! -f "$FILE_PATH" ]; then
+    exit 0
+fi
+
+if ! command -v swiftlint &>/dev/null; then
+    exit 0
+fi
+
+swiftlint lint --fix --quiet --path "$FILE_PATH" &>/dev/null &
+disown
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+    "hooks": {
+        "PostToolUse": [
+            {
+                "matcher": "Edit|Write|MultiEdit",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-swift.sh",
+                        "timeout": 10
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- Claude Code の PostToolUse hook を追加し、コード編集後に `swiftlint lint --fix` を非同期で自動実行する仕組みを導入
- Edit/Write/MultiEdit ツール使用後に Swift ファイルのみを対象にフォーマットを実行

## Background & Context
- **Original Issue:** コード編集時に手動で SwiftLint を実行する必要があり、フォーマットの適用漏れが発生しやすい
- **User Impact:** 編集後のフォーマット忘れにより、CI でのリント違反が後から検出される
- **Requirements:** 編集完了後に自動的かつ非同期（ノンブロッキング）でフォーマットを実行すること

## Solution Approach
- **Core Solution:** Claude Code の `PostToolUse` hook イベントを利用し、ファイル編集ツール完了後にフォーマットスクリプトを呼び出す
- **Technical Strategy:** Hook スクリプトが stdin の JSON から `file_path` を抽出し、Swift ファイルのみ `swiftlint lint --fix` をバックグラウンド実行
- **Architecture Changes:** `.claude/settings.json` にプロジェクトレベルの hook 設定を新規追加

## Implementation Details
- **`.claude/hooks/format-swift.sh`**: Hook スクリプト（新規作成）
  - `jq` で stdin JSON から `tool_input.file_path` を抽出
  - `.swift` 拡張子チェック、ファイル存在確認、swiftlint インストール確認
  - `& disown` でバックグラウンド実行（Claude をブロックしない）
- **`.claude/settings.json`**: Hook 設定（新規作成）
  - `PostToolUse` イベントで `Edit|Write|MultiEdit` にマッチ
  - timeout 10 秒（スクリプト自体は即座に返る）

## Updates since last revision
- **jq 依存関係チェックを追加** (Copilot レビューフィードバック対応)
  - `command -v jq` ガードを追加し、jq 未インストール時は graceful に終了 (exit 0)
  - JSON パースエラーを非致命的に変更 (`2>/dev/null || printf ''`)
  - これにより `set -euo pipefail` 環境でもフックが失敗しなくなった

## Testing & Validation
- **Test Strategy:** スクリプト単体テストで 3 パターンを検証済み
  - Swift ファイル入力 → swiftlint 実行（exit 0）
  - 非 Swift ファイル入力 → スキップ（exit 0）
  - file_path なし → スキップ（exit 0）
- **Edge Cases:** ファイル不存在、swiftlint 未インストール、jq 未インストール、非 Swift ファイルを安全にスキップ

## Review & Testing Checklist for Human
- [ ] Claude Code で Swift ファイルを編集し、フックが実際に実行されることを確認
- [ ] jq がインストールされていない環境でフックがエラーなく終了することを確認
- [ ] 非 Swift ファイル（.ts, .json 等）編集時にフックがスキップされることを確認

### Notes
- フックはバックグラウンドで非同期実行されるため、実行結果の確認は難しい
- 本番環境では jq と swiftlint の両方がインストールされていることを前提としている

**Requested by:** @fumiya-kume
**Devin session:** https://app.devin.ai/sessions/dd1b2b8b9ba54062b52488b809192cd4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/341">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->