### PR TITLE
test(e2e): add E2E test for ブール boolean type alias

### DIFF
--- a/Tests/FeLangE2ETests/LogicalOperatorE2ETests.swift
+++ b/Tests/FeLangE2ETests/LogicalOperatorE2ETests.swift
@@ -249,4 +249,18 @@ struct LogicalOperatorE2ETests {
         #expect(lines[0].contains("false"))
         #expect(lines[1].contains("true"))
     }
+
+    // MARK: - Boolean Type Alias Tests
+
+    @Test("ブール type alias: variable declaration and not operator")
+    func testBoolTypeAliasWithNotOperator() throws {
+        let code = """
+        変数 b: ブール ← false
+        if not b then
+            println("ok")
+        endif
+        """
+        let output = try InProcessTestHelper.run(code)
+        #expect(output.contains("ok"))
+    }
 }


### PR DESCRIPTION
## Summary
Adds an E2E test to verify that the Japanese boolean type alias `ブール` is correctly interpreted as equivalent to `boolean`, as specified in issue #319.

The test declares a variable with `ブール` type, assigns `false`, and verifies the `not` operator works correctly with it.

## Review & Testing Checklist for Human
- [ ] Verify the test matches the exact input code and expected behavior from issue #319
- [ ] Consider if additional test cases for `ブール` are needed (e.g., with `and`/`or` operators, direct `true` assignment)

### Notes
- Test passed locally with `swift test --filter "testBoolTypeAliasWithNotOperator"`
- Closes #319

Link to Devin run: https://app.devin.ai/sessions/818c9efef9b74dcfbbfbca880b342188
Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/342">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
