### PR TITLE
feat(e2e): add English type aliases test

### DIFF
--- a/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
+++ b/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
@@ -162,7 +162,7 @@ struct TypeConversionE2ETests {
             return concat(prefix, toString(value))
         endfunction
 
-        println(formatValue(3.14, "x"))
+        println(formatValue(3.14, 'x'))
         """
         let output = try InProcessTestHelper.run(code)
         #expect(output.contains("x3.14"))
@@ -175,7 +175,7 @@ struct TypeConversionE2ETests {
         変数 pi: real ← 3.14
         変数 name: string ← "test"
         変数 flag: bool ← true
-        変数 ch: char ← "A"
+        変数 ch: char ← 'A'
 
         println(x)
         println(pi)

--- a/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
+++ b/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
@@ -109,4 +109,22 @@ struct TypeConversionE2ETests {
         let output = try InProcessTestHelper.run("println(concat(\"Value: \", toString(42)))")
         #expect(output.contains("Value: 42"))
     }
+
+    // MARK: - English Type Aliases
+
+    @Test("English type aliases in function declaration")
+    func testEnglishTypeAliases() throws {
+        let code = """
+        function describe(x: int, ok: bool): string
+            if ok then
+                return toString(x)
+            endif
+            return "no"
+        endfunction
+
+        println(describe(3, true))
+        """
+        let output = try InProcessTestHelper.run(code)
+        #expect(output.contains("3"))
+    }
 }

--- a/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
+++ b/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
@@ -127,4 +127,40 @@ struct TypeConversionE2ETests {
         let output = try InProcessTestHelper.run(code)
         #expect(output.contains("3"))
     }
+
+    @Test("English type aliases: real and char in function")
+    func testEnglishTypeAliasesRealAndChar() throws {
+        let code = """
+        function formatValue(value: real, prefix: char): string
+            return concat(prefix, toString(value))
+        endfunction
+
+        println(formatValue(3.14, "x"))
+        """
+        let output = try InProcessTestHelper.run(code)
+        #expect(output.contains("x3.14"))
+    }
+
+    @Test("English type aliases in variable declarations")
+    func testEnglishTypeAliasesInVariables() throws {
+        let code = """
+        変数 x: int ← 42
+        変数 pi: real ← 3.14
+        変数 name: string ← "test"
+        変数 flag: bool ← true
+        変数 ch: char ← "A"
+
+        println(x)
+        println(pi)
+        println(name)
+        println(flag)
+        println(ch)
+        """
+        let output = try InProcessTestHelper.run(code)
+        #expect(output.contains("42"))
+        #expect(output.contains("3.14"))
+        #expect(output.contains("test"))
+        #expect(output.lowercased().contains("true"))
+        #expect(output.contains("A"))
+    }
 }


### PR DESCRIPTION
## Summary
Adds E2E tests to verify that English type aliases (`int`, `real`, `string`, `char`, `bool`) work correctly in function declarations and variable declarations, as specified in issue #314.

Closes #314

### Tests Added
- `testEnglishTypeAliasesInFunction`: Tests `int`, `bool`, `string` in function parameters and return type
- `testEnglishTypeAliasesRealAndChar`: Tests `real` and `char` in function parameters
- `testEnglishTypeAliasesInVariables`: Tests all 5 type aliases in variable declarations

### Updates since last revision
- Addressed Copilot review feedback: added tests for `real` and `char` type aliases
- Added variable declaration tests with all 5 English type aliases
- Resolved merge conflict with master (PR #346) by renaming conflicting function

## Review & Testing Checklist for Human
- [ ] Verify the tests cover the expected behavior from issue #314 (exitCode == 0, stdout contains "3")
- [ ] Note: Variable declarations use Japanese `変数` keyword with English type aliases - this is intentional as FeLangKit only supports Japanese keyword for variable declarations

### Notes
- Link to Devin run: https://app.devin.ai/sessions/750cfa7cbc2040d59e85ee4ca8d769e0
- Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/343">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 英語スタイルの型エイリアス（整数、浮動小数点、文字列、真偽値、文字）が関数の引数・戻り値および変数宣言で正しく扱われることを確認するテストを追加しました。
  * 既存のテスト名を整理・更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->