### PR TITLE
E2E: Add English type aliases test (double/float/str/char/bool)

### DIFF
--- a/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
+++ b/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
@@ -131,7 +131,8 @@ struct TypeConversionE2ETests {
             .components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
 
-        #expect(lines.count >= 4)
+        #expect(lines.count >= 4, "Expected 4 output lines, got \(lines.count): \(lines)")
+        guard lines.count >= 4 else { return }
         #expect(lines[0] == "4" || lines[0] == "4.0")
         #expect(lines[1] == "ok")
         #expect(lines[2] == "A")

--- a/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
+++ b/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
@@ -109,4 +109,26 @@ struct TypeConversionE2ETests {
         let output = try InProcessTestHelper.run("println(concat(\"Value: \", toString(42)))")
         #expect(output.contains("Value: 42"))
     }
+
+    // MARK: - English Type Alias Tests
+
+    @Test("English type aliases: double/float/str/char/bool")
+    func testEnglishTypeAliases() throws {
+        let code = """
+        変数 r: double ← 1.5
+        変数 f: float ← 2.5
+        変数 s: str ← "ok"
+        変数 c: char ← 'A'
+        変数 b: bool ← true
+        println(r + f)
+        println(s)
+        println(c)
+        println(b)
+        """
+        let output = try InProcessTestHelper.run(code)
+        #expect(output.contains("4"))
+        #expect(output.contains("ok"))
+        #expect(output.contains("A"))
+        #expect(output.lowercased().contains("true"))
+    }
 }

--- a/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
+++ b/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
@@ -126,9 +126,15 @@ struct TypeConversionE2ETests {
         println(b)
         """
         let output = try InProcessTestHelper.run(code)
-        #expect(output.contains("4"))
-        #expect(output.contains("ok"))
-        #expect(output.contains("A"))
-        #expect(output.lowercased().contains("true"))
+        let lines = output
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+        #expect(lines.count >= 4)
+        #expect(lines[0] == "4" || lines[0] == "4.0")
+        #expect(lines[1] == "ok")
+        #expect(lines[2] == "A")
+        #expect(lines[3].lowercased() == "true")
     }
 }


### PR DESCRIPTION
## Summary

Adds an E2E test to verify that English type aliases (`double`, `float`, `str`, `char`, `bool`) are correctly interpreted by the FeLang runtime. The test follows the exact specification from issue #317.

The test declares variables using each English type alias, performs arithmetic on the real types, and verifies the output using precise line-based assertions with a guard statement to prevent index out of bounds crashes.

## Updates since last revision

- Replaced loose `contains` assertions with precise line-by-line checks
- Added guard statement after count check to fail gracefully if output has fewer than expected lines
- Resolved merge conflict with master branch (preserved Japanese type keywords test)

## Review & Testing Checklist for Human

- [ ] Verify the assertion `lines[0] == "4" || lines[0] == "4.0"` correctly handles the expected output format for `1.5 + 2.5`
- [ ] Confirm CI passes on all matrix configurations (macOS/Ubuntu, debug/release)

### Notes

Closes #317

Link to Devin run: https://app.devin.ai/sessions/f7dbbabde2c54547b00b0f828fbb04ac
Requested by: @fumiya-kume