### PR TITLE
feat(e2e): add Japanese type keywords test

### DIFF
--- a/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
+++ b/Tests/FeLangE2ETests/TypeConversionE2ETests.swift
@@ -109,4 +109,33 @@ struct TypeConversionE2ETests {
         let output = try InProcessTestHelper.run("println(concat(\"Value: \", toString(42)))")
         #expect(output.contains("Value: 42"))
     }
+
+    // MARK: - Japanese Type Keywords Tests
+
+    @Test("Japanese type keywords (整数型/実数型/文字列型/文字型/論理型)")
+    func testJapaneseTypeKeywords() throws {
+        let code = """
+        変数 i: 整数型 ← 1
+        変数 r: 実数型 ← 1.5
+        変数 s: 文字列型 ← "ok"
+        変数 c: 文字型 ← 'A'
+        変数 b: 論理型 ← true
+        println(i)
+        println(r)
+        println(s)
+        println(c)
+        println(b)
+        """
+        let output = try InProcessTestHelper.run(code)
+        let lines = output.split(separator: "\n").map {
+            String($0).trimmingCharacters(in: .whitespaces)
+        }
+        #expect(lines.count >= 5, "Expected 5 output lines, got \(lines.count): \(lines)")
+        guard lines.count >= 5 else { return }
+        #expect(lines[0] == "1")
+        #expect(lines[1] == "1.5")
+        #expect(lines[2] == "ok")
+        #expect(lines[3] == "A")
+        #expect(lines[4].lowercased() == "true")
+    }
 }


### PR DESCRIPTION
## Summary
Adds an E2E test to verify that Japanese type keywords (`整数型`/`実数型`/`文字列型`/`文字型`/`論理型`) are correctly interpreted by the FeLang runtime.

The test declares variables using each Japanese type keyword and verifies the output matches expected values.

Closes #318

## Review & Testing Checklist for Human
- [ ] Verify the test assertions match the expected behavior for each type (integer outputs `1`, real outputs `1.5`, string outputs `ok`, character outputs `A`, boolean outputs `true`)
- [ ] Run `swift test --filter testJapaneseTypeKeywords` locally to confirm the test passes

### Notes
- Link to Devin run: https://app.devin.ai/sessions/fedb7e4a4f8b45799db377f8bb1d8a52
- Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/345">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
