### PR TITLE
E2E: 英語配列型 'array of' を検証

### DIFF
--- a/Tests/FeLangE2ETests/StringArrayE2ETests.swift
+++ b/Tests/FeLangE2ETests/StringArrayE2ETests.swift
@@ -310,4 +310,16 @@ struct StringArrayE2ETests {
         let output = try InProcessTestHelper.run(code)
         #expect(output.contains("H"))
     }
+
+    // MARK: - English Array Type Syntax
+
+    @Test("English 'array of' type syntax with integer array")
+    func testEnglishArrayOfIntegerSyntax() throws {
+        let code = """
+        変数 arr: array of integer ← [1, 2, 3]
+        println(length(arr))
+        """
+        let output = try InProcessTestHelper.run(code)
+        #expect(output.trimmingCharacters(in: .whitespacesAndNewlines) == "3")
+    }
 }


### PR DESCRIPTION
## Summary

Adds an E2E test to verify that the English array type syntax `array of <type>` works correctly through parsing and execution. This addresses issue #316.

The test creates an integer array using `array of integer` syntax and verifies that `length(arr)` returns the expected value of `3`.

## Review & Testing Checklist for Human

- [ ] Verify the test correctly exercises the English `array of integer` syntax (not just the Japanese `配列 of 整数`)
- [ ] Confirm the test output expectation (`"3"`) matches the expected behavior

### Notes

Closes #316

Link to Devin run: https://app.devin.ai/sessions/a0c8cc3fa29c4e44a644fc223199c149
Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/346">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
