### PR TITLE
E2E: 日本語配列型『配列型 の <type>』を検証

### DIFF
--- a/Tests/FeLangE2ETests/StringArrayE2ETests.swift
+++ b/Tests/FeLangE2ETests/StringArrayE2ETests.swift
@@ -322,4 +322,16 @@ struct StringArrayE2ETests {
         let output = try InProcessTestHelper.run(code)
         #expect(output.trimmingCharacters(in: .whitespacesAndNewlines) == "3")
     }
+
+    // MARK: - Japanese Array Type Syntax
+
+    @Test("Japanese '配列型 の' type syntax with integer array")
+    func testJapaneseArrayTypeNoSyntax() throws {
+        let code = """
+        変数 arr: 配列型 の 整数 ← [1, 2, 3]
+        println(length(arr))
+        """
+        let output = try InProcessTestHelper.run(code)
+        #expect(output.trimmingCharacters(in: .whitespacesAndNewlines) == "3")
+    }
 }


### PR DESCRIPTION
## Summary

Adds an E2E test to verify that the Japanese array type syntax `配列型 の <type>` is correctly parsed and executed. This addresses issue #320.

The test validates:
- Input: `変数 arr: 配列型 の 整数 ← [1, 2, 3]` with `println(length(arr))`
- Expected: Output contains "3" with exit code 0

## Review & Testing Checklist for Human

- [ ] Verify the test name `testJapaneseArrayTypeNoSyntax` is acceptable (the "No" refers to the Japanese particle "の")
- [ ] Consider if additional test cases for other element types (e.g., `配列型 の 文字列`) are needed

### Notes

Closes #320

Link to Devin run: https://app.devin.ai/sessions/70d0968d157e44a985b2fd725c62191a
Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/347">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
