### PR TITLE
test(e2e): add procedure returning value error test

### DIFF
--- a/Tests/FeLangE2ETests/ErrorE2ETests.swift
+++ b/Tests/FeLangE2ETests/ErrorE2ETests.swift
@@ -263,6 +263,22 @@ struct ErrorE2ETests {
         #expect(!result.succeeded)
     }
 
+    // MARK: - Procedure Return Value Tests
+
+    @Test("Procedure returning value causes error")
+    func testProcedureReturnsValue() throws {
+        // Procedure should not return a value
+        let code = """
+        procedure bad()
+            return 1
+        endprocedure
+        bad()
+        """
+        let result = InProcessTestHelper.execute(code)
+        // Should fail with void-function-returns-value error
+        #expect(!result.succeeded)
+    }
+
     // MARK: - Missing Return Value Tests
 
     @Test("Missing return value in function causes error")

--- a/Tests/FeLangE2ETests/ErrorE2ETests.swift
+++ b/Tests/FeLangE2ETests/ErrorE2ETests.swift
@@ -275,7 +275,7 @@ struct ErrorE2ETests {
         bad()
         """
         let result = InProcessTestHelper.execute(code)
-        // Should fail with void-function-returns-value error
+        // Should fail when procedure attempts to return a value
         #expect(!result.succeeded)
     }
 


### PR DESCRIPTION
## Summary

Closes #309

Adds an E2E test to verify that a procedure returning a value causes a runtime error.

The test declares a procedure with `return 1` and calls it, expecting execution to fail with an error.

## Review & Testing Checklist for Human

- [ ] Verify the test correctly validates the expected behavior (procedure with value return should fail)
- [ ] Confirm the test follows existing patterns in `ErrorE2ETests.swift`

### Notes

The test verifies the runtime behavior where `RuntimeError.returnInVoidContext` is thrown when a procedure attempts to return a value (see `StatementExecutor.swift` line 639-641). The issue mentioned `void-function-returns-value` which is the semantic analysis error code, but the runtime error achieves the same validation goal.

Link to Devin run: https://app.devin.ai/sessions/e78b814b663446658a8588362d510547
Requested by: @fumiya-kume