### PR TITLE
feat(tokenizer): add elseif keyword support

### DIFF
--- a/Sources/FeLangCore/Parser/ParsingBoundaryDetection.swift
+++ b/Sources/FeLangCore/Parser/ParsingBoundaryDetection.swift
@@ -18,6 +18,7 @@ public enum ParsingBoundaryDetection {
         case .thenKeyword,      // IF condition ends, THEN block begins
              .elseKeyword,      // Previous block ends, ELSE block begins
              .elifKeyword,      // Previous block ends, ELIF condition begins
+             .elseifKeyword,    // Previous block ends, ELSEIF condition begins
              .doKeyword:        // WHILE/FOR condition ends, DO block begins
             return true
 

--- a/Sources/FeLangCore/Parser/StatementParser.swift
+++ b/Sources/FeLangCore/Parser/StatementParser.swift
@@ -117,17 +117,17 @@ public struct StatementParser {
         let condition = try parseExpression(&parser)
         try expectToken(&parser, .thenKeyword) // consume 'then'
 
-        let thenBody = try parseBlock(&parser, until: [.elseKeyword, .elifKeyword, .endifKeyword], nestingDepth: nestingDepth)
+        let thenBody = try parseBlock(&parser, until: [.elseKeyword, .elifKeyword, .elseifKeyword, .endifKeyword], nestingDepth: nestingDepth)
 
         var elseIfs: [IfStatement.ElseIf] = []
         var elseBody: [Statement]?
 
-        // Handle ELIF clauses
-        while parser.peek()?.type == .elifKeyword {
-            _ = parser.advance() // consume 'elif'
+        // Handle ELIF/ELSEIF clauses
+        while parser.peek()?.type == .elifKeyword || parser.peek()?.type == .elseifKeyword {
+            _ = parser.advance() // consume 'elif' or 'elseif'
             let elifCondition = try parseExpression(&parser)
             try expectToken(&parser, .thenKeyword) // consume 'then'
-            let elifBody = try parseBlock(&parser, until: [.elseKeyword, .elifKeyword, .endifKeyword], nestingDepth: nestingDepth)
+            let elifBody = try parseBlock(&parser, until: [.elseKeyword, .elifKeyword, .elseifKeyword, .endifKeyword], nestingDepth: nestingDepth)
             elseIfs.append(IfStatement.ElseIf(condition: elifCondition, body: elifBody))
         }
 
@@ -703,6 +703,7 @@ public struct StatementParser {
         case .thenKeyword,      // IF condition ends, THEN block begins
              .elseKeyword,      // Previous block ends, ELSE block begins
              .elifKeyword,      // Previous block ends, ELIF condition begins
+             .elseifKeyword,    // Previous block ends, ELSEIF condition begins
              .doKeyword:        // WHILE/FOR condition ends, DO block begins
             return true
 

--- a/Sources/FeLangCore/Tokenizer/TokenType.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenType.swift
@@ -16,6 +16,7 @@ public enum TokenType: String, CaseIterable, Equatable, Codable, Sendable {
     case thenKeyword = "then"
     case elseKeyword = "else"
     case elifKeyword = "elif"
+    case elseifKeyword = "elseif"
     case endifKeyword = "endif"
     case whileKeyword = "while"
     case doKeyword = "do"
@@ -103,7 +104,7 @@ extension TokenType {
     public var isKeyword: Bool {
         switch self {
         case .integerType, .realType, .characterType, .stringType, .booleanType,
-             .recordType, .arrayType, .ifKeyword, .thenKeyword, .elseKeyword, .elifKeyword, .endifKeyword,
+             .recordType, .arrayType, .ifKeyword, .thenKeyword, .elseKeyword, .elifKeyword, .elseifKeyword, .endifKeyword,
              .whileKeyword, .doKeyword, .endwhileKeyword, .forKeyword, .toKeyword, .stepKeyword, .inKeyword, .endforKeyword,
              .functionKeyword, .endfunctionKeyword, .procedureKeyword, .endprocedureKeyword,
              .andKeyword, .orKeyword, .notKeyword, .returnKeyword, .breakKeyword, .continueKeyword,

--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -28,6 +28,7 @@ public enum TokenizerUtilities {
         ("continue", .continueKeyword),
 
         // 6 characters
+        ("elseif", .elseifKeyword),
         ("return", .returnKeyword),
         ("endfor", .endforKeyword),
 

--- a/Sources/FeLangServer/CompletionProvider.swift
+++ b/Sources/FeLangServer/CompletionProvider.swift
@@ -12,6 +12,7 @@ public struct CompletionProvider: Sendable {
         CompletionItem(label: "then", kind: .keyword, detail: "Then clause"),
         CompletionItem(label: "else", kind: .keyword, detail: "Else clause"),
         CompletionItem(label: "elif", kind: .keyword, detail: "Else-if clause", insertText: "elif "),
+        CompletionItem(label: "elseif", kind: .keyword, detail: "Else-if clause", insertText: "elseif "),
         CompletionItem(label: "endif", kind: .keyword, detail: "End if statement"),
 
         // Loops
@@ -269,7 +270,7 @@ public struct CompletionProvider: Sendable {
     private func isKeyword(_ word: String) -> Bool {
         let keywords = Set([
             // English keywords
-            "if", "then", "else", "elif", "endif",
+            "if", "then", "else", "elif", "elseif", "endif",
             "while", "do", "endwhile",
             "for", "to", "step", "endfor", "in",
             "function", "endfunction", "procedure", "endprocedure",

--- a/Sources/FeLangServer/DefinitionProvider.swift
+++ b/Sources/FeLangServer/DefinitionProvider.swift
@@ -153,7 +153,7 @@ public struct DefinitionProvider: Sendable {
 
         // Keywords
         let keywords = Set([
-            "if", "then", "else", "elif", "endif",
+            "if", "then", "else", "elif", "elseif", "endif",
             "while", "do", "endwhile",
             "for", "to", "step", "endfor", "in",
             "function", "endfunction", "procedure", "endprocedure",

--- a/Sources/FeLangServer/HoverProvider.swift
+++ b/Sources/FeLangServer/HoverProvider.swift
@@ -12,6 +12,7 @@ public struct HoverProvider: Sendable {
         "then": "**then** - Then clause\n\nMarks the beginning of the true branch in an if statement.",
         "else": "**else** - Else clause\n\nMarks the false branch in an if statement.",
         "elif": "**elif** - Else-if clause\n\nAdditional condition check in an if statement.",
+        "elseif": "**elseif** - Else-if clause\n\nAdditional condition check in an if statement. Equivalent to 'elif'.",
         "endif": "**endif** - End if\n\nMarks the end of an if statement.",
 
         // Loops

--- a/Tests/FeLangCoreTests/Parser/StatementParserTests.swift
+++ b/Tests/FeLangCoreTests/Parser/StatementParserTests.swift
@@ -118,6 +118,34 @@ struct StatementParserTests {
         #expect(ifStmt.elseBody?.count == 1)
     }
 
+    @Test("IF-ELSEIF-ELSE Statement")
+    func testIfElseifElseStatement() throws {
+        let statements = try parseStatements("if x > 0 then writeLine(\"positive\") elseif x < 0 then writeLine(\"negative\") else writeLine(\"zero\") endif")
+
+        #expect(statements.count == 1)
+        guard case .ifStatement(let ifStmt) = statements[0] else {
+            #expect(Bool(false), "Expected IF statement")
+            return
+        }
+
+        #expect(ifStmt.elseIfs.count == 1)
+        #expect(ifStmt.elseBody?.count == 1)
+    }
+
+    @Test("IF with mixed ELIF and ELSEIF")
+    func testIfWithMixedElifElseif() throws {
+        let statements = try parseStatements("if x > 0 then writeLine(\"a\") elif x < 0 then writeLine(\"b\") elseif x = 0 then writeLine(\"c\") else writeLine(\"d\") endif")
+
+        #expect(statements.count == 1)
+        guard case .ifStatement(let ifStmt) = statements[0] else {
+            #expect(Bool(false), "Expected IF statement")
+            return
+        }
+
+        #expect(ifStmt.elseIfs.count == 2)
+        #expect(ifStmt.elseBody?.count == 1)
+    }
+
     // MARK: - WHILE Statement Tests
 
     @Test("Basic WHILE Statement")

--- a/Tests/FeLangCoreTests/Tokenizer/ParsingTokenizerTests.swift
+++ b/Tests/FeLangCoreTests/Tokenizer/ParsingTokenizerTests.swift
@@ -44,6 +44,28 @@ struct ParsingTokenizerTests {
         #expect(tokens[10].type == .eof)
     }
 
+    @Test func testElseifKeyword() throws {
+        let input = "elseif"
+        let tokens = try ParsingTokenizer.tokenize(input)
+
+        #expect(tokens.count == 2) // elseif + eof
+        #expect(tokens[0].type == .elseifKeyword)
+        #expect(tokens[0].lexeme == "elseif")
+        #expect(tokens[1].type == .eof)
+    }
+
+    @Test func testElifAndElseifKeywords() throws {
+        let input = "elif elseif"
+        let tokens = try ParsingTokenizer.tokenize(input)
+
+        #expect(tokens.count == 3) // elif + elseif + eof
+        #expect(tokens[0].type == .elifKeyword)
+        #expect(tokens[0].lexeme == "elif")
+        #expect(tokens[1].type == .elseifKeyword)
+        #expect(tokens[1].lexeme == "elseif")
+        #expect(tokens[2].type == .eof)
+    }
+
     @Test func testUnicodeOperators() throws {
         let input = "← ≠ ≧ ≦"
         let tokens = try ParsingTokenizer.tokenize(input)


### PR DESCRIPTION
## Summary

Adds support for the `elseif` keyword as an alternative to `elif` for FE pseudo-language specification compliance (別紙2). Both keywords now work equivalently in conditional statements.

**Changes:**
- Added `elseifKeyword` case to `TokenType` enum
- Added "elseif" to keyword mapping in `TokenizerUtilities`
- Updated `StatementParser` to handle both `elif` and `elseif` in if-statements
- Updated `ParsingBoundaryDetection` to recognize `elseif` as a statement terminator
- Added LSP support (hover documentation and code completion) for `elseif`
- Added tokenizer and parser tests

## Review & Testing Checklist for Human

- [ ] Verify that mixing `elif` and `elseif` in the same if-statement works correctly (test case added but worth manual verification)
- [ ] Test a real FE program using `elseif` syntax to ensure end-to-end functionality
- [ ] Confirm no other files reference `.elifKeyword` that should also handle `.elseifKeyword` (grep for `elifKeyword` in the codebase)

**Suggested test:**
```fe
if x > 0 then
  y ← 1
elseif x < 0 then
  y ← -1
else
  y ← 0
endif
```

### Notes
- All 1227 existing tests pass, plus 4 new tests added
- The keyword mapping uses `TokenizerUtilities.keywordMap` which is auto-generated, so all tokenizer implementations (Fast, Incremental, Parallel, etc.) should work automatically

Closes #353

---
Link to Devin run: https://app.devin.ai/sessions/23ab31820c154972a669c3979fb81f77
Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/369">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * プログラミング言語に「elseif」キーワードを追加。既存の「elif」と同等の条件分岐として動作し、パーサー・トークナイザー・言語サーバーで認識されます。

* **ドキュメント**
  * 「elseif」のホバー説明と補完候補を追加。

* **テスト**
  * トークナイザーとパーサー向けの「elseif」関連の単体テストを追加。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->