### PR TITLE
feat: ビット論理積演算子 ∧ をサポートする

### DIFF
--- a/Sources/FeLangCore/Expression/Expression.swift
+++ b/Sources/FeLangCore/Expression/Expression.swift
@@ -147,6 +147,9 @@ public enum BinaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
     case less = "<"
     case lessEqual = "≦"
 
+    // Bitwise operators
+    case bitwiseAnd = "∧"
+
     // Logical operators
     case and = "and"
     // swiftlint:disable:next identifier_name
@@ -160,12 +163,14 @@ public enum BinaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
             return 1
         case .and:
             return 2
-        case .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual:
+        case .bitwiseAnd:
             return 3
-        case .add, .subtract:
+        case .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual:
             return 4
-        case .multiply, .divide, .modulo:
+        case .add, .subtract:
             return 5
+        case .multiply, .divide, .modulo:
+            return 6
         }
     }
 
@@ -183,9 +188,9 @@ public enum UnaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
     case minus = "-"
 
     /// Returns the precedence level of this operator.
-    /// Unary operators have high precedence (6).
+    /// Unary operators have high precedence (7).
     public var precedence: Int {
-        return 6
+        return 7
     }
 }
 
@@ -218,6 +223,8 @@ extension BinaryOperator {
             self = .less
         case .lessEqual:
             self = .lessEqual
+        case .bitwiseAnd:
+            self = .bitwiseAnd
         case .andKeyword:
             self = .and
         case .orKeyword:

--- a/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
+++ b/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
@@ -884,8 +884,8 @@ public final class SemanticAnalyzer: @unchecked Sendable {
             }
 
         case .bitwiseAnd:
-            // Bitwise AND only works with integers
-            if leftType.isCompatible(with: .integer) && rightType.isCompatible(with: .integer) {
+            // Bitwise AND only works with integers (strict check, no real allowed)
+            if case .integer = leftType, case .integer = rightType {
                 return .integer
             } else {
                 let position = SourcePosition(line: 0, column: 0, offset: 0)

--- a/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
+++ b/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
@@ -883,6 +883,16 @@ public final class SemanticAnalyzer: @unchecked Sendable {
                 return .error
             }
 
+        case .bitwiseAnd:
+            // Bitwise AND only works with integers
+            if leftType.isCompatible(with: .integer) && rightType.isCompatible(with: .integer) {
+                return .integer
+            } else {
+                let position = SourcePosition(line: 0, column: 0, offset: 0)
+                errorReporter.collect(.incompatibleTypes(leftType, rightType, operation: operatorType.rawValue, position: position))
+                return .error
+            }
+
         case .and, .or:
             // Logical operators work with boolean types
             if leftType.isCompatible(with: .boolean) && rightType.isCompatible(with: .boolean) {

--- a/Sources/FeLangCore/Tokenizer/TokenType.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenType.swift
@@ -77,6 +77,9 @@ public enum TokenType: String, CaseIterable, Equatable, Codable, Sendable {
     case less = "<"
     case lessEqual = "≦"
 
+    /// Bitwise operators
+    case bitwiseAnd = "∧"
+
     // MARK: - Delimiters
 
     case leftParen = "("
@@ -128,7 +131,8 @@ extension TokenType {
     public var isOperator: Bool {
         switch self {
         case .plus, .minus, .multiply, .divide, .modulo, .assign,
-             .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual:
+             .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual,
+             .bitwiseAnd:
             return true
         default:
             return false

--- a/Sources/FeLangCore/Tokenizer/Tokenizer.swift
+++ b/Sources/FeLangCore/Tokenizer/Tokenizer.swift
@@ -135,6 +135,8 @@ public final class Tokenizer {
             return Token(type: .greater, lexeme: ">", position: position)
         case "<":
             return Token(type: .less, lexeme: "<", position: position)
+        case "∧":
+            return Token(type: .bitwiseAnd, lexeme: "∧", position: position)
         case "(":
             return Token(type: .leftParen, lexeme: "(", position: position)
         case ")":

--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -93,6 +93,7 @@ public enum TokenizerUtilities {
         ("=", .equal),
         (">", .greater),
         ("<", .less),
+        ("∧", .bitwiseAnd),
         // NOTE: If multi-character operators starting with "!" (e.g., "!=") are added,
         // they must appear before this single-character "!" entry to preserve longest-match behavior.
         ("!", .notKeyword)

--- a/Sources/FeLangRuntime/ExpressionEvaluator.swift
+++ b/Sources/FeLangRuntime/ExpressionEvaluator.swift
@@ -129,6 +129,10 @@ public struct ExpressionEvaluator: Sendable {
         case .greaterEqual:
             return try evaluateComparison(left, right) { $0 >= $1 }
 
+        // Bitwise
+        case .bitwiseAnd:
+            return try evaluateBitwiseAnd(left, right)
+
         // Logical
         case .and:
             return try evaluateLogicalAnd(left, right)
@@ -157,6 +161,16 @@ public struct ExpressionEvaluator: Sendable {
             throw RuntimeError.typeMismatch(expected: "Boolean", actual: right.typeName, operation: "or")
         }
         return .boolean(leftBool || rightBool)
+    }
+
+    private func evaluateBitwiseAnd(_ left: RuntimeValue, _ right: RuntimeValue) throws -> RuntimeValue {
+        guard case .integer(let leftInt) = left else {
+            throw RuntimeError.typeMismatch(expected: "Integer", actual: left.typeName, operation: "∧")
+        }
+        guard case .integer(let rightInt) = right else {
+            throw RuntimeError.typeMismatch(expected: "Integer", actual: right.typeName, operation: "∧")
+        }
+        return .integer(leftInt & rightInt)
     }
 
     private func evaluateAdd(_ left: RuntimeValue, _ right: RuntimeValue) throws -> RuntimeValue {

--- a/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
@@ -212,6 +212,63 @@ struct ExpressionParserTests {
         #expect(expr == expected)
     }
 
+    // MARK: - Bitwise AND Operator Tests
+
+    @Test func testBitwiseAnd() throws {
+        let expr = try parseExpression("5 ∧ 3")
+        let expected = Expression.binary(.bitwiseAnd, .literal(.integer(5)), .literal(.integer(3)))
+        #expect(expr == expected)
+    }
+
+    @Test func testBitwiseAndPrecedenceWithComparison() throws {
+        // 5 ∧ 3 > 0 should be parsed as (5 ∧ 3) > 0 (bitwiseAnd has lower precedence than comparison)
+        let expr = try parseExpression("5 ∧ 3 > 0")
+        let expected = Expression.binary(
+            .bitwiseAnd,
+            .literal(.integer(5)),
+            .binary(.greater, .literal(.integer(3)), .literal(.integer(0)))
+        )
+        #expect(expr == expected)
+    }
+
+    @Test func testBitwiseAndPrecedenceWithLogicalAnd() throws {
+        // true and 5 ∧ 3 = 1 should be parsed as true and ((5 ∧ 3) = 1)
+        // bitwiseAnd (3) has higher precedence than logical and (2)
+        let expr = try parseExpression("true and 5 ∧ 3 = 1")
+        let expected = Expression.binary(
+            .and,
+            .literal(.boolean(true)),
+            .binary(
+                .bitwiseAnd,
+                .literal(.integer(5)),
+                .binary(.equal, .literal(.integer(3)), .literal(.integer(1)))
+            )
+        )
+        #expect(expr == expected)
+    }
+
+    @Test func testBitwiseAndPrecedenceWithArithmetic() throws {
+        // 1 + 2 ∧ 3 should be parsed as (1 + 2) ∧ 3 (add has higher precedence than bitwiseAnd)
+        let expr = try parseExpression("1 + 2 ∧ 3")
+        let expected = Expression.binary(
+            .bitwiseAnd,
+            .binary(.add, .literal(.integer(1)), .literal(.integer(2))),
+            .literal(.integer(3))
+        )
+        #expect(expr == expected)
+    }
+
+    @Test func testBitwiseAndLeftAssociativity() throws {
+        // 7 ∧ 3 ∧ 1 should be parsed as ((7 ∧ 3) ∧ 1)
+        let expr = try parseExpression("7 ∧ 3 ∧ 1")
+        let expected = Expression.binary(
+            .bitwiseAnd,
+            .binary(.bitwiseAnd, .literal(.integer(7)), .literal(.integer(3))),
+            .literal(.integer(1))
+        )
+        #expect(expr == expected)
+    }
+
     // MARK: - Unary Operator Tests
 
     @Test func testUnaryNot() throws {

--- a/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
@@ -221,7 +221,7 @@ struct ExpressionParserTests {
     }
 
     @Test func testBitwiseAndPrecedenceWithComparison() throws {
-        // 5 ∧ 3 > 0 should be parsed as (5 ∧ 3) > 0 (bitwiseAnd has lower precedence than comparison)
+        // 5 ∧ 3 > 0 should be parsed as 5 ∧ (3 > 0) (comparison has higher precedence than bitwiseAnd)
         let expr = try parseExpression("5 ∧ 3 > 0")
         let expected = Expression.binary(
             .bitwiseAnd,

--- a/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
+++ b/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
@@ -38,13 +38,13 @@ struct TokenizerTests {
     }
 
     @Test func testOperators() throws {
-        let input = "+ - * / % ← = ≠ > ≧ < ≦"
+        let input = "+ - * / % ← = ≠ > ≧ < ≦ ∧"
         let tokenizer = Tokenizer(input: input)
         let tokens = try tokenizer.tokenize()
 
         let expectedTypes: [TokenType] = [
             .plus, .minus, .multiply, .divide, .modulo, .assign,
-            .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual, .eof
+            .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual, .bitwiseAnd, .eof
         ]
 
         #expect(tokens.count == expectedTypes.count)

--- a/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
@@ -436,6 +436,45 @@ struct ExpressionEvaluatorTests {
         #expect(try evaluator.evaluate(falseOrFalse) == .boolean(false))
     }
 
+    // MARK: - Bitwise Operations
+
+    @Test func testBitwiseAnd() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.bitwiseAnd, .literal(.integer(5)), .literal(.integer(3)))
+        let result = try evaluator.evaluate(expr)
+        #expect(result == .integer(1))
+    }
+
+    @Test func testBitwiseAndWithZero() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.bitwiseAnd, .literal(.integer(255)), .literal(.integer(0)))
+        let result = try evaluator.evaluate(expr)
+        #expect(result == .integer(0))
+    }
+
+    @Test func testBitwiseAndWithAllOnes() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.bitwiseAnd, .literal(.integer(15)), .literal(.integer(15)))
+        let result = try evaluator.evaluate(expr)
+        #expect(result == .integer(15))
+    }
+
+    @Test func testBitwiseAndTypeMismatchLeft() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.bitwiseAnd, .literal(.real(5.0)), .literal(.integer(3)))
+        #expect(throws: RuntimeError.self) {
+            _ = try evaluator.evaluate(expr)
+        }
+    }
+
+    @Test func testBitwiseAndTypeMismatchRight() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.bitwiseAnd, .literal(.integer(5)), .literal(.real(3.0)))
+        #expect(throws: RuntimeError.self) {
+            _ = try evaluator.evaluate(expr)
+        }
+    }
+
     // MARK: - Unary Operations
 
     @Test func testUnaryMinus() throws {


### PR DESCRIPTION
## Summary

Closes #366

Adds support for the bitwise AND operator `∧` in FE pseudo-language.

Changes include:
- Added `bitwiseAnd` token type and tokenization support for `∧` character
- Added `BinaryOperator.bitwiseAnd` with precedence 3 (between logical operators and comparison operators)
- Implemented runtime evaluation using Swift's `&` operator on integers
- Added semantic analysis with strict integer-only type checking (reals are rejected at compile time)
- Added unit tests for tokenization, parsing precedence, and runtime evaluation

**Precedence levels were shifted** to accommodate the new operator:
- `or`: 1, `and`: 2, `bitwiseAnd`: 3, comparison: 4, add/subtract: 5, multiply/divide/modulo: 6, unary: 7

## Review & Testing Checklist for Human

- [ ] Verify the precedence placement matches the issue requirement ("優先度は比較演算子と論理演算子の間")
- [ ] Test with actual FE code: `5 ∧ 3` should evaluate to `1` (0b101 & 0b011 = 0b001)
- [ ] Test error handling: non-integer operands should produce a type error
- [ ] Verify precedence in mixed expressions: `1 + 2 ∧ 3` should parse as `(1 + 2) ∧ 3`

**Recommended test plan:**
```
整数型: result ← 5 ∧ 3
writeLine(result)  // Should output: 1
```

### Notes
- All 1233 tests pass (including 5 new parser precedence tests and 5 new runtime tests)
- The precedence shift affects all operators but maintains their relative ordering
- Semantic analyzer uses strict pattern matching for integer type check (rejects reals at compile time, not just runtime)

Requested by: @fumiya-kume
Link to Devin run: https://app.devin.ai/sessions/340a13acc7514c529a03852679da56db