### PR TITLE
feat(tokenizer): add ÷ division operator support

### DIFF
--- a/Sources/FeLangCore/Tokenizer/Tokenizer.swift
+++ b/Sources/FeLangCore/Tokenizer/Tokenizer.swift
@@ -115,6 +115,8 @@ public final class Tokenizer {
             return Token(type: .multiply, lexeme: "*", position: position)
         case "%":
             return Token(type: .modulo, lexeme: "%", position: position)
+        case "÷":
+            return Token(type: .divide, lexeme: "÷", position: position)
         case "←":
             return Token(type: .assign, lexeme: "←", position: position)
         case "=":

--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -89,6 +89,7 @@ public enum TokenizerUtilities {
         ("-", .minus),
         ("*", .multiply),
         ("/", .divide),
+        ("÷", .divide),
         ("%", .modulo),
         ("=", .equal),
         (">", .greater),

--- a/Sources/FeLangCore/Utilities/UnicodeNormalizer.swift
+++ b/Sources/FeLangCore/Utilities/UnicodeNormalizer.swift
@@ -359,11 +359,11 @@ public struct UnicodeNormalizer {
             ("∆", "delta"),
             ("Ω", "omega"),
 
-                // Mathematical operators that might be confused
-                ("×", "*"),       // Multiplication sign to asterisk
-                // Note: ÷ is preserved as a valid division operator in FeLangKit
-                ("≈", "~="),      // Approximately equal
-                ("∞", "infinity")  // Infinity symbol
+            // Mathematical operators that might be confused
+            ("×", "*"),       // Multiplication sign to asterisk
+            // Note: ÷ is preserved as a valid division operator in FeLangKit
+            ("≈", "~="),      // Approximately equal
+            ("∞", "infinity")  // Infinity symbol
         ]
 
         for (original, replacement) in mathReplacements {

--- a/Sources/FeLangCore/Utilities/UnicodeNormalizer.swift
+++ b/Sources/FeLangCore/Utilities/UnicodeNormalizer.swift
@@ -359,11 +359,11 @@ public struct UnicodeNormalizer {
             ("∆", "delta"),
             ("Ω", "omega"),
 
-            // Mathematical operators that might be confused
-            ("×", "*"),       // Multiplication sign to asterisk
-            ("÷", "/"),       // Division sign to slash
-            ("≈", "~="),      // Approximately equal
-            ("∞", "infinity")  // Infinity symbol
+                // Mathematical operators that might be confused
+                ("×", "*"),       // Multiplication sign to asterisk
+                // Note: ÷ is preserved as a valid division operator in FeLangKit
+                ("≈", "~="),      // Approximately equal
+                ("∞", "infinity")  // Infinity symbol
         ]
 
         for (original, replacement) in mathReplacements {

--- a/Sources/FeLangCore/Utilities/UnicodeNormalizer.swift
+++ b/Sources/FeLangCore/Utilities/UnicodeNormalizer.swift
@@ -582,7 +582,8 @@ public struct UnicodeNormalizer {
 
     /// Counts how many mathematical symbols need normalization
     private func countMathSymbolChanges(_ input: String) -> Int {
-        let mathSymbols = ["α", "β", "π", "∑", "∏", "∆", "Ω", "×", "÷", "≈", "∞"]
+        // Note: ÷ is excluded because it's preserved as a valid division operator in FeLangKit
+        let mathSymbols = ["α", "β", "π", "∑", "∏", "∆", "Ω", "×", "≈", "∞"]
         return mathSymbols.reduce(0) { count, symbol in
             count + input.components(separatedBy: symbol).count - 1
         }

--- a/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
@@ -74,6 +74,12 @@ struct ExpressionParserTests {
         #expect(expr == expected)
     }
 
+    @Test func testDivisionWithUnicodeOperator() throws {
+        let expr = try parseExpression("10 ÷ 2")
+        let expected = Expression.binary(.divide, .literal(.integer(10)), .literal(.integer(2)))
+        #expect(expr == expected)
+    }
+
     @Test func testModulo() throws {
         let expr = try parseExpression("7 % 3")
         let expected = Expression.binary(.modulo, .literal(.integer(7)), .literal(.integer(3)))

--- a/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
+++ b/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
@@ -53,6 +53,21 @@ struct TokenizerTests {
         }
     }
 
+    @Test func testDivisionOperatorUnicode() throws {
+        let input = "10 ÷ 2"
+        let tokenizer = Tokenizer(input: input)
+        let tokens = try tokenizer.tokenize()
+
+        #expect(tokens.count == 4) // integer, divide, integer, eof
+        #expect(tokens[0].type == .integerLiteral)
+        #expect(tokens[0].lexeme == "10")
+        #expect(tokens[1].type == .divide)
+        #expect(tokens[1].lexeme == "÷")
+        #expect(tokens[2].type == .integerLiteral)
+        #expect(tokens[2].lexeme == "2")
+        #expect(tokens[3].type == .eof)
+    }
+
     @Test func testDelimiters() throws {
         let input = "( ) [ ] { } , . ; :"
         let tokenizer = Tokenizer(input: input)

--- a/Tests/FeLangCoreTests/Utilities/UnicodeNormalizationTests.swift
+++ b/Tests/FeLangCoreTests/Utilities/UnicodeNormalizationTests.swift
@@ -403,7 +403,7 @@ struct UnicodeNormalizationTests {
         #expect(result.contains("pi"), "π should be normalized to pi")
         #expect(result.contains("*"), "× should be normalized to *")
         #expect(result.contains("alpha"), "α should be normalized to alpha")
-        #expect(result.contains("/"), "÷ should be normalized to /")
+        #expect(result.contains("÷"), "÷ should be preserved as a valid division operator")
         #expect(result.contains("beta"), "β should be normalized to beta")
         #expect(result.contains("~="), "≈ should be normalized to ~=")
         #expect(result.contains("infinity"), "∞ should be normalized to infinity")

--- a/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
@@ -357,6 +357,15 @@ struct ExpressionEvaluatorTests {
         #expect(result == .integer(3))
     }
 
+    @Test func testDivideWithUnicodeOperator() throws {
+        let evaluator = makeEvaluator()
+        let tokens = try ParsingTokenizer.tokenize("10 ÷ 3")
+        let parser = ExpressionParser()
+        let expr = try parser.parseExpression(from: tokens)
+        let result = try evaluator.evaluate(expr)
+        #expect(result == .integer(3))
+    }
+
     @Test func testDivideByZeroError() throws {
         let evaluator = makeEvaluator()
         let expr = Expression.binary(.divide, .literal(.integer(10)), .literal(.integer(0)))


### PR DESCRIPTION
# feat(tokenizer): add ÷ division operator support

## Summary
Adds support for the Unicode division sign (`÷`) as an alternative to the slash (`/`) division operator in FeLangKit, as specified in the FE pseudo-language specification.

**Changes:**
- Added `÷` to the operators array in `TokenizerUtilities.swift` mapping to `.divide` token type
- Added explicit case for `÷` in `Tokenizer.swift` switch statement
- Modified `UnicodeNormalizer.swift` to preserve `÷` instead of converting it to `/`
- Added tests for tokenizer, parser, and runtime evaluation

## Review & Testing Checklist for Human
- [ ] Verify that preserving `÷` in `UnicodeNormalizer` doesn't break any downstream functionality that may have relied on it being converted to `/`
- [ ] Confirm that both `/` and `÷` work interchangeably for division in actual FE programs

**Suggested test plan:**
```fe
10 ÷ 2    // Should evaluate to 5
10 ÷ 3    // Should evaluate to 3 (integer division)
```

### Notes
- Closes #354
- All 1226 tests pass
- The `÷` operator maps to the same `.divide` token type as `/`, so AST and runtime require no changes

Link to Devin run: https://app.devin.ai/sessions/61e85714abe14022b5a5abe0e520d404
Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/371">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ユニコード除算演算子「÷」をネイティブにサポートし、従来のASCII「/」と同等に扱えるようになりました。

* **動作変更**
  * 入力正規化で「÷」を「/」に変換しないようになり、元の記号がそのまま処理されます。

* **テスト**
  * トークナイズ〜解析〜評価まで「÷」を検証するテストを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->