### PR TITLE
feat(core): add undefined value support (未定義)

### DIFF
--- a/Sources/FeLangCore/Expression/Expression.swift
+++ b/Sources/FeLangCore/Expression/Expression.swift
@@ -28,6 +28,7 @@ public enum Literal: Equatable, Sendable {
     case string(String)
     case character(Character)
     case boolean(Bool)
+    case undefined
 }
 
 extension Literal: Codable {
@@ -44,6 +45,8 @@ extension Literal: Codable {
             try container.encode(["character": String(value)])
         case .boolean(let value):
             try container.encode(["boolean": value])
+        case .undefined:
+            try container.encode(["undefined": true])
         }
     }
 
@@ -61,6 +64,8 @@ extension Literal: Codable {
             self = .character(char)
         } else if let value = dict["boolean"]?.value as? Bool {
             self = .boolean(value)
+        } else if dict["undefined"] != nil {
+            self = .undefined
         } else {
             throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Invalid literal value"))
         }
@@ -281,6 +286,8 @@ extension Literal {
             self = .boolean(true)
         case .falseKeyword:
             self = .boolean(false)
+        case .undefinedKeyword:
+            self = .undefined
         default:
             return nil
         }

--- a/Sources/FeLangCore/Expression/Expression.swift
+++ b/Sources/FeLangCore/Expression/Expression.swift
@@ -64,8 +64,15 @@ extension Literal: Codable {
             self = .character(char)
         } else if let value = dict["boolean"]?.value as? Bool {
             self = .boolean(value)
-        } else if dict["undefined"] != nil {
-            self = .undefined
+        } else if let undefinedEntry = dict["undefined"] {
+            if let boolValue = undefinedEntry.value as? Bool, boolValue == true {
+                self = .undefined
+            } else {
+                throw DecodingError.dataCorrupted(.init(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Invalid literal value: expected `{\"undefined\": true}` for undefined literal"
+                ))
+            }
         } else {
             throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Invalid literal value"))
         }

--- a/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
+++ b/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
@@ -212,6 +212,9 @@ public struct PrettyPrinter {
 
         case .boolean(let value):
             return value ? "true" : "false"
+
+        case .undefined:
+            return "未定義"
         }
     }
 

--- a/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
+++ b/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
@@ -807,6 +807,8 @@ public final class SemanticAnalyzer: @unchecked Sendable {
             return .character
         case .boolean:
             return .boolean
+        case .undefined:
+            return .unknown
         }
     }
 

--- a/Sources/FeLangCore/Tokenizer/TokenType.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenType.swift
@@ -46,6 +46,9 @@ public enum TokenType: String, CaseIterable, Equatable, Codable, Sendable {
     case variableKeyword = "変数"
     case constantKeyword = "定数"
 
+    /// Undefined keyword
+    case undefinedKeyword = "未定義"
+
     // MARK: - Literals
 
     case integerLiteral
@@ -107,7 +110,7 @@ extension TokenType {
              .whileKeyword, .doKeyword, .endwhileKeyword, .forKeyword, .toKeyword, .stepKeyword, .inKeyword, .endforKeyword,
              .functionKeyword, .endfunctionKeyword, .procedureKeyword, .endprocedureKeyword,
              .andKeyword, .orKeyword, .notKeyword, .returnKeyword, .breakKeyword, .continueKeyword,
-             .trueKeyword, .falseKeyword, .variableKeyword, .constantKeyword:
+             .trueKeyword, .falseKeyword, .variableKeyword, .constantKeyword, .undefinedKeyword:
             return true
         default:
             return false

--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -55,6 +55,9 @@ public enum TokenizerUtilities {
         ("not", .notKeyword),
         ("for", .forKeyword),
 
+        // 3 characters (Japanese)
+        ("未定義", .undefinedKeyword),
+
         // 2 characters
         ("配列", .arrayType),
         ("変数", .variableKeyword),

--- a/Sources/FeLangRuntime/ExpressionEvaluator.swift
+++ b/Sources/FeLangRuntime/ExpressionEvaluator.swift
@@ -92,6 +92,8 @@ public struct ExpressionEvaluator: Sendable {
             return .character(value)
         case .boolean(let value):
             return .boolean(value)
+        case .undefined:
+            return .undefined
         }
     }
 

--- a/Sources/FeLangRuntime/ExpressionEvaluator.swift
+++ b/Sources/FeLangRuntime/ExpressionEvaluator.swift
@@ -68,13 +68,31 @@ public struct ExpressionEvaluator: Sendable {
 
     private func validateArrayElementTypes(_ values: [RuntimeValue]) throws {
         guard let firstValue = values.first else { return }
-        let expectedType = firstValue.typeName
-        for (index, value) in values.enumerated() where index > 0 && value.typeName != expectedType {
-            throw RuntimeError.typeMismatch(
-                expected: expectedType,
-                actual: value.typeName,
-                operation: "array literal element at index \(index)"
-            )
+        // Skip undefined values when determining expected type
+        let expectedType: String
+        if case .undefined = firstValue {
+            // If first element is undefined, find first non-undefined element
+            if let nonUndefined = values.first(where: { if case .undefined = $0 { return false } else { return true } }) {
+                expectedType = nonUndefined.typeName
+            } else {
+                // All elements are undefined, no type checking needed
+                return
+            }
+        } else {
+            expectedType = firstValue.typeName
+        }
+        for (index, value) in values.enumerated() where index > 0 {
+            if case .undefined = value {
+                // Undefined is compatible with any type
+                continue
+            }
+            if value.typeName != expectedType {
+                throw RuntimeError.typeMismatch(
+                    expected: expectedType,
+                    actual: value.typeName,
+                    operation: "array literal element at index \(index)"
+                )
+            }
         }
     }
 

--- a/Sources/FeLangRuntime/RuntimeValue.swift
+++ b/Sources/FeLangRuntime/RuntimeValue.swift
@@ -33,6 +33,9 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
     /// Represents nil/null/void
     case null
 
+    /// Represents an undefined value (未定義)
+    case undefined
+
     // MARK: - Properties
 
     /// Returns the type name of this value
@@ -48,6 +51,7 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
         case .function: return "Function"
         case .procedure: return "Procedure"
         case .null: return "Null"
+        case .undefined: return "Undefined"
         }
     }
 
@@ -58,7 +62,7 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
             return value
         case .integer(let value):
             return value != 0
-        case .null:
+        case .null, .undefined:
             return false
         default:
             return true
@@ -122,6 +126,8 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
             return "<procedure \(proc.name)>"
         case .null:
             return "null"
+        case .undefined:
+            return "未定義"
         }
     }
 

--- a/Sources/FeLangRuntime/StatementExecutor.swift
+++ b/Sources/FeLangRuntime/StatementExecutor.swift
@@ -693,6 +693,9 @@ public final class StatementExecutor: @unchecked Sendable {
     private func validateType(_ value: RuntimeValue, expected: DataType, context: String) throws {
         let matches: Bool
         switch (expected, value) {
+        case (_, .undefined):
+            // Undefined is compatible with any type (matches semantic analyzer behavior)
+            matches = true
         case (.integer, .integer):
             matches = true
         case (.real, .real):

--- a/Sources/FeLangRuntime/StatementExecutor.swift
+++ b/Sources/FeLangRuntime/StatementExecutor.swift
@@ -685,7 +685,7 @@ public final class StatementExecutor: @unchecked Sendable {
         case .record:
             // Record type name cannot be inferred from runtime value
             return nil
-        case .function, .procedure, .null:
+        case .function, .procedure, .null, .undefined:
             return nil
         }
     }

--- a/Sources/FeLangRuntime/StatementExecutor.swift
+++ b/Sources/FeLangRuntime/StatementExecutor.swift
@@ -798,6 +798,10 @@ public final class StatementExecutor: @unchecked Sendable {
     ) -> [Int] {
         var mismatchIndices: [Int] = []
         for (index, element) in elements.enumerated() {
+            if case .undefined = element {
+                // Undefined is compatible with any type
+                continue
+            }
             if let actualType = inferDataType(from: element) {
                 if !typesMatch(actualType, expected: expectedElementType) {
                     mismatchIndices.append(index)
@@ -830,6 +834,10 @@ public final class StatementExecutor: @unchecked Sendable {
         for field in definition {
             guard let value = fields[field.name] else {
                 return (false, "missing field '\(field.name)'")
+            }
+            if case .undefined = value {
+                // Undefined is compatible with any type
+                continue
             }
             if let actualType = inferDataType(from: value) {
                 if !typesMatch(actualType, expected: field.type) {

--- a/Sources/FeLangServer/CompletionProvider.swift
+++ b/Sources/FeLangServer/CompletionProvider.swift
@@ -44,6 +44,9 @@ public struct CompletionProvider: Sendable {
         CompletionItem(label: "true", kind: .keyword, detail: "Boolean true"),
         CompletionItem(label: "false", kind: .keyword, detail: "Boolean false"),
 
+        // Undefined literal
+        CompletionItem(label: "未定義", kind: .keyword, detail: "Undefined value (未定義値)"),
+
         // Japanese keywords
         CompletionItem(label: "もし", kind: .keyword, detail: "条件分岐 (if)", insertText: "もし "),
         CompletionItem(label: "ならば", kind: .keyword, detail: "Then clause"),
@@ -279,7 +282,9 @@ public struct CompletionProvider: Sendable {
             // Japanese keywords
             "もし", "ならば", "でなければ", "を実行", "繰り返し", "を繰り返す",
             // Japanese type names
-            "整数型", "実数型", "文字列型", "文字型", "論理型", "配列型"
+            "整数型", "実数型", "文字列型", "文字型", "論理型", "配列型",
+            // Undefined keyword
+            "未定義"
         ])
         return keywords.contains(word.lowercased()) || keywords.contains(word)
     }

--- a/Sources/FeLangServer/CompletionProvider.swift
+++ b/Sources/FeLangServer/CompletionProvider.swift
@@ -40,13 +40,6 @@ public struct CompletionProvider: Sendable {
         CompletionItem(label: "or", kind: .keyword, detail: "Logical OR"),
         CompletionItem(label: "not", kind: .keyword, detail: "Logical NOT"),
 
-        // Boolean literals
-        CompletionItem(label: "true", kind: .keyword, detail: "Boolean true"),
-        CompletionItem(label: "false", kind: .keyword, detail: "Boolean false"),
-
-        // Undefined literal
-        CompletionItem(label: "未定義", kind: .keyword, detail: "Undefined value (未定義値)"),
-
         // Japanese keywords
         CompletionItem(label: "もし", kind: .keyword, detail: "条件分岐 (if)", insertText: "もし "),
         CompletionItem(label: "ならば", kind: .keyword, detail: "Then clause"),
@@ -111,6 +104,13 @@ public struct CompletionProvider: Sendable {
         CompletionItem(label: "concat_arrays", kind: .function, detail: "Concatenate arrays", insertText: "concat_arrays(")
     ]
 
+    /// Literal values that can be used in expressions/assignments
+    private static let literals: [CompletionItem] = [
+        CompletionItem(label: "true", kind: .keyword, detail: "Boolean true"),
+        CompletionItem(label: "false", kind: .keyword, detail: "Boolean false"),
+        CompletionItem(label: "未定義", kind: .keyword, detail: "Undefined value (未定義値)")
+    ]
+
     public init() {}
 
     /// Provide completions at a position in a document.
@@ -123,6 +123,7 @@ public struct CompletionProvider: Sendable {
         switch context {
         case .keyword:
             items.append(contentsOf: Self.keywords)
+            items.append(contentsOf: Self.literals)
         case .type:
             items.append(contentsOf: Self.types)
         case .function:
@@ -131,8 +132,10 @@ public struct CompletionProvider: Sendable {
         case .variable:
             items.append(contentsOf: getVariables(document: document))
             items.append(contentsOf: Self.standardFunctions)
+            items.append(contentsOf: Self.literals)
         case .general:
             items.append(contentsOf: Self.keywords)
+            items.append(contentsOf: Self.literals)
             items.append(contentsOf: Self.types)
             items.append(contentsOf: Self.standardFunctions)
             items.append(contentsOf: getVariables(document: document))

--- a/Sources/FeLangServer/DefinitionProvider.swift
+++ b/Sources/FeLangServer/DefinitionProvider.swift
@@ -158,7 +158,8 @@ public struct DefinitionProvider: Sendable {
             "for", "to", "step", "endfor", "in",
             "function", "endfunction", "procedure", "endprocedure",
             "return", "break", "continue",
-            "and", "or", "not", "true", "false"
+            "and", "or", "not", "true", "false",
+            "未定義"
         ])
 
         // Types

--- a/Sources/FeLangServer/HoverProvider.swift
+++ b/Sources/FeLangServer/HoverProvider.swift
@@ -43,6 +43,7 @@ public struct HoverProvider: Sendable {
         // Literals
         "true": "**true** - Boolean true\n\nThe boolean value representing truth.",
         "false": "**false** - Boolean false\n\nThe boolean value representing falsehood.",
+        "未定義": "**未定義** (undefined) - 未定義値\n\n変数に値が格納されていない状態を表します。",
 
         // Japanese
         "もし": "**もし** (if) - 条件分岐\n\n条件に基づいてコードを実行します。",

--- a/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
@@ -43,6 +43,11 @@ struct ExpressionParserTests {
         #expect(falseExpr == .literal(.boolean(false)))
     }
 
+    @Test func testUndefinedLiteral() throws {
+        let expr = try parseExpression("未定義")
+        #expect(expr == .literal(.undefined))
+    }
+
     @Test func testIdentifier() throws {
         let expr = try parseExpression("variable")
         #expect(expr == .identifier("variable"))

--- a/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
@@ -464,4 +464,26 @@ struct ExpressionParserTests {
             return
         }
     }
+
+    // MARK: - Codable Tests
+
+    @Test func testUndefinedLiteralCodableRoundTrip() throws {
+        let original = FEExpression.literal(.undefined)
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let data = try encoder.encode(original)
+        let decoded = try decoder.decode(FEExpression.self, from: data)
+
+        #expect(decoded == original)
+    }
+
+    @Test func testUndefinedLiteralCodableInvalidValue() throws {
+        let invalidJSON = #"{"literal":{"undefined":false}}"#
+        let decoder = JSONDecoder()
+
+        #expect(throws: DecodingError.self) {
+            _ = try decoder.decode(FEExpression.self, from: invalidJSON.data(using: .utf8)!)
+        }
+    }
 }

--- a/Tests/FeLangCoreTests/PrettyPrinter/PrettyPrinterTests.swift
+++ b/Tests/FeLangCoreTests/PrettyPrinter/PrettyPrinterTests.swift
@@ -56,6 +56,11 @@ final class PrettyPrinterTests: XCTestCase {
         XCTAssertEqual(printer.print(falseExpr), "false")
     }
 
+    func testUndefinedLiteral() {
+        let expr = Expression.literal(.undefined)
+        XCTAssertEqual(printer.print(expr), "未定義")
+    }
+
     // MARK: - Identifier Tests
 
     func testIdentifier() {

--- a/Tests/FeLangCoreTests/Semantic/SemanticAnalyzerTests.swift
+++ b/Tests/FeLangCoreTests/Semantic/SemanticAnalyzerTests.swift
@@ -922,6 +922,33 @@ final class SemanticAnalyzerTests: XCTestCase {
         XCTAssertTrue(result.errors.isEmpty)
     }
 
+    // MARK: - Undefined Literal Tests
+
+    func testUndefinedLiteralInAssignment() {
+        let statements = [
+            Statement.variableDeclaration(VariableDeclaration(
+                name: "x",
+                type: .integer,
+                initialValue: nil
+            )),
+            Statement.assignment(.variable("x", .literal(.undefined)))
+        ]
+
+        let result = analyzer.analyze(statements)
+        XCTAssertTrue(result.isSuccessful)
+        XCTAssertTrue(result.errors.isEmpty)
+    }
+
+    func testUndefinedLiteralInExpression() {
+        let statements = [
+            Statement.expressionStatement(.literal(.undefined))
+        ]
+
+        let result = analyzer.analyze(statements)
+        XCTAssertTrue(result.isSuccessful)
+        XCTAssertTrue(result.errors.isEmpty)
+    }
+
     // MARK: - Performance Tests
 
     func testAnalysisPerformance() {

--- a/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
+++ b/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
@@ -20,7 +20,7 @@ struct TokenizerTests {
     }
 
     @Test func testKeywords() throws {
-        let input = "整数型 実数型 文字型 文字列型 論理型 レコード 配列 if while for and or not return break true false"
+        let input = "整数型 実数型 文字型 文字列型 論理型 レコード 配列 if while for and or not return break true false 未定義"
         let tokenizer = Tokenizer(input: input)
         let tokens = try tokenizer.tokenize()
 
@@ -28,13 +28,24 @@ struct TokenizerTests {
             .integerType, .realType, .characterType, .stringType, .booleanType,
                          .recordType, .arrayType, .ifKeyword, .whileKeyword, .forKeyword,
             .andKeyword, .orKeyword, .notKeyword, .returnKeyword, .breakKeyword,
-            .trueKeyword, .falseKeyword, .eof
+            .trueKeyword, .falseKeyword, .undefinedKeyword, .eof
         ]
 
         #expect(tokens.count == expectedTypes.count)
         for (index, expectedType) in expectedTypes.enumerated() {
             #expect(tokens[index].type == expectedType)
         }
+    }
+
+    @Test func testUndefinedKeyword() throws {
+        let input = "未定義"
+        let tokenizer = Tokenizer(input: input)
+        let tokens = try tokenizer.tokenize()
+
+        #expect(tokens.count == 2)
+        #expect(tokens[0].type == .undefinedKeyword)
+        #expect(tokens[0].lexeme == "未定義")
+        #expect(tokens[1].type == .eof)
     }
 
     @Test func testOperators() throws {

--- a/Tests/FeLangCoreTests/Visitor/ExpressionVisitorTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/ExpressionVisitorTests.swift
@@ -15,6 +15,7 @@ struct ExpressionVisitorTests {
                 case .string(let value): return "string(\(value))"
                 case .character(let value): return "char(\(value))"
                 case .boolean(let value): return "bool(\(value))"
+                case .undefined: return "undefined"
                 }
             },
             visitIdentifier: { _ in "identifier" },
@@ -156,6 +157,7 @@ struct ExpressionVisitorTests {
                 case .string(let value): return "\"\(value)\""
                 case .character(let value): return "'\(value)'"
                 case .boolean(let value): return "\(value)"
+                case .undefined: return "未定義"
                 }
             case .identifier(let identifier):
                 return identifier

--- a/Tests/FeLangCoreTests/Visitor/VisitableTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/VisitableTests.swift
@@ -65,6 +65,7 @@ struct VisitableTests {
                 case .string(let value): return "string(\(value))"
                 case .character(let value): return "char(\(value))"
                 case .boolean(let value): return "bool(\(value))"
+                case .undefined: return "undefined"
                 }
             },
             visitIdentifier: { "id(\($0))" },

--- a/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
@@ -54,6 +54,16 @@ struct RuntimeValueTests {
         #expect(value.toString() == "null")
     }
 
+    @Test func testUndefinedValue() {
+        let value = RuntimeValue.undefined
+        #expect(value.typeName == "Undefined")
+        #expect(value.toString() == "未定義")
+    }
+
+    @Test func testIsTruthyUndefined() {
+        #expect(RuntimeValue.undefined.isTruthy == false)
+    }
+
     // MARK: - Truthy Tests
 
     @Test func testIsTruthyBoolean() {
@@ -291,6 +301,12 @@ struct ExpressionEvaluatorTests {
         let falseResult = try evaluator.evaluate(.literal(.boolean(false)))
         #expect(trueResult == .boolean(true))
         #expect(falseResult == .boolean(false))
+    }
+
+    @Test func testEvaluateUndefinedLiteral() throws {
+        let evaluator = makeEvaluator()
+        let result = try evaluator.evaluate(.literal(.undefined))
+        #expect(result == .undefined)
     }
 
     @Test func testEvaluateIdentifier() throws {

--- a/Tests/FeLangServerTests/FeLangServerTests.swift
+++ b/Tests/FeLangServerTests/FeLangServerTests.swift
@@ -604,6 +604,22 @@ struct CompletionProviderTests {
         let funcCompletion = completions.items.first { $0.label == "myFunc" }
         #expect(funcCompletion != nil)
     }
+
+    @Test func testUndefinedKeywordCompletion() {
+        let provider = CompletionProvider()
+        var doc = Document(
+            uri: "file:///test.fe",
+            languageId: "fe",
+            version: 1,
+            content: "x ← "
+        )
+
+        let completions = provider.complete(document: &doc, position: Position(line: 0, character: 4))
+
+        let undefinedCompletion = completions.items.first { $0.label == "未定義" }
+        #expect(undefinedCompletion != nil)
+        #expect(undefinedCompletion?.kind == .keyword)
+    }
 }
 
 // MARK: - HoverProvider Tests
@@ -715,6 +731,21 @@ struct HoverProviderTests {
         #expect(hover?.contents.value.contains("sqrt") == true)
         #expect(hover?.contents.value.contains("square root") == true)
     }
+
+    @Test func testUndefinedKeywordHover() {
+        let provider = HoverProvider()
+        var doc = Document(
+            uri: "file:///test.fe",
+            languageId: "fe",
+            version: 1,
+            content: "x ← 未定義"
+        )
+
+        let hover = provider.hover(document: &doc, position: Position(line: 0, character: 5))
+
+        #expect(hover != nil)
+        #expect(hover?.contents.value.contains("未定義") == true)
+    }
 }
 
 // MARK: - DefinitionProvider Tests
@@ -821,6 +852,20 @@ struct DefinitionProviderTests {
 
         #expect(location != nil)
         #expect(location?.range.start.line == 0)
+    }
+
+    @Test func testNoDefinitionForUndefinedKeyword() {
+        let provider = DefinitionProvider()
+        var doc = Document(
+            uri: "file:///test.fe",
+            languageId: "fe",
+            version: 1,
+            content: "x ← 未定義"
+        )
+
+        let location = provider.findDefinition(document: &doc, position: Position(line: 0, character: 5))
+
+        #expect(location == nil)
     }
 }
 


### PR DESCRIPTION
## Summary

Implements support for the undefined keyword (`未定義`) across all layers of FeLangKit, as requested in issue #359.

Changes span the full compiler pipeline:
- **Tokenizer**: Added `undefinedKeyword` token type and keyword mapping
- **AST**: Added `undefined` case to `Literal` enum with Codable support
- **Runtime**: Added `undefined` case to `RuntimeValue` with type name "Undefined", falsy truthy value, and "未定義" string representation
- **Evaluator/Executor**: Handle undefined in literal evaluation and type inference
- **PrettyPrinter/SemanticAnalyzer**: Handle undefined literal formatting and type inference (returns `.unknown`)
- **FeLangServer**: Added undefined to hover docs, completion suggestions, and definition provider keywords

## Review & Testing Checklist for Human

- [ ] Verify that `undefined` returning `.unknown` type in SemanticAnalyzer is the intended behavior for type inference
- [ ] Verify that `undefined` being falsy (like `null`) matches the expected semantics
- [ ] Test undefined in an actual FE program: `変数 x ← 未定義` followed by `print(x)` to confirm end-to-end behavior
- [ ] Verify the Codable encoding (`["undefined": true]`) works correctly for AST serialization/deserialization

**Suggested test plan:**
1. Run `swift test` to verify all 1228 tests pass (already verified locally)
2. Write a simple FE program using `未定義` and run it through the interpreter to verify runtime behavior

### Notes

Closes #359

Link to Devin run: https://app.devin.ai/sessions/60ecd217553b4e8c837b8dfea430043b

Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/372">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
