### PR TITLE
feat(parser): support 2D array [row, col] access syntax

### DIFF
--- a/Sources/FeLangCore/Expression/ExpressionParser.swift
+++ b/Sources/FeLangCore/Expression/ExpressionParser.swift
@@ -77,11 +77,20 @@ public struct ExpressionParser {
         // Parse postfix operations
         while true {
             if parser.peek()?.type == .leftBracket {
-                // Array access: expr[index]
+                // Array access: expr[index] or expr[row, col] for 2D arrays
                 _ = parser.advance() // consume '['
-                let indexExpr = try parseExpression(&parser)
+                let firstIndexExpr = try parseExpression(&parser)
+                expr = Expression.arrayAccess(expr, firstIndexExpr)
+
+                // Handle comma-separated indices for multi-dimensional array access
+                // e.g., matrix[1, 2] is desugared to matrix[1][2]
+                while parser.peek()?.type == .comma {
+                    _ = parser.advance() // consume ','
+                    let nextIndexExpr = try parseExpression(&parser)
+                    expr = Expression.arrayAccess(expr, nextIndexExpr)
+                }
+
                 try expectToken(&parser, .rightBracket)
-                expr = Expression.arrayAccess(expr, indexExpr)
             } else if parser.peek()?.type == .dot {
                 // Field access: expr.field
                 _ = parser.advance() // consume '.'

--- a/Sources/FeLangCore/Parser/StatementParser.swift
+++ b/Sources/FeLangCore/Parser/StatementParser.swift
@@ -258,15 +258,29 @@ public struct StatementParser {
 
         // Check if it's array element assignment
         if parser.peek()?.type == .leftBracket {
-            // Array element assignment: array[index] ← expression
+            // Array element assignment: array[index] ← expression or array[row, col] ← expression
             _ = parser.advance() // consume '['
-            let indexExpr = try parseExpression(&parser)
+            let firstIndexExpr = try parseExpression(&parser)
+            var arrayExpr: Expression = .arrayAccess(.identifier(identifier), firstIndexExpr)
+
+            // Handle comma-separated indices for multi-dimensional array access
+            // e.g., matrix[1, 2] ← value is desugared to matrix[1][2] ← value
+            while parser.peek()?.type == .comma {
+                _ = parser.advance() // consume ','
+                let nextIndexExpr = try parseExpression(&parser)
+                arrayExpr = .arrayAccess(arrayExpr, nextIndexExpr)
+            }
+
             try expectToken(&parser, .rightBracket) // consume ']'
             try expectToken(&parser, .assign) // consume '←'
             let valueExpr = try parseExpression(&parser)
 
-            let arrayAccess = Assignment.ArrayAccess(array: .identifier(identifier), index: indexExpr)
-            return .arrayElement(arrayAccess, valueExpr)
+            // Extract the final array access for the assignment
+            guard case .arrayAccess(let array, let index) = arrayExpr else {
+                throw StatementParsingError.expectedToken(.leftBracket)
+            }
+            let arrayAccessStruct = Assignment.ArrayAccess(array: array, index: index)
+            return .arrayElement(arrayAccessStruct, valueExpr)
         } else if parser.peek()?.type == .assign {
             // Variable assignment: variable ← expression
             _ = parser.advance() // consume '←'

--- a/Sources/FeLangCore/Parser/StatementParser.swift
+++ b/Sources/FeLangCore/Parser/StatementParser.swift
@@ -275,12 +275,18 @@ public struct StatementParser {
             try expectToken(&parser, .assign) // consume '←'
             let valueExpr = try parseExpression(&parser)
 
-            // Extract the final array access for the assignment
-            guard case .arrayAccess(let array, let index) = arrayExpr else {
-                throw StatementParsingError.expectedToken(.leftBracket)
+            // Extract the final array access for the assignment.
+            // At this point, arrayExpr is guaranteed to be .arrayAccess because it is
+            // initialized as .arrayAccess above and only ever wrapped into further
+            // .arrayAccess cases in the loop. If this assumption is violated in the
+            // future, treat it as an internal parser logic error rather than a
+            // user-facing syntax error.
+            if case let .arrayAccess(array, index) = arrayExpr {
+                let arrayAccessStruct = Assignment.ArrayAccess(array: array, index: index)
+                return .arrayElement(arrayAccessStruct, valueExpr)
+            } else {
+                preconditionFailure("Internal parser error: expected final arrayExpr to be .arrayAccess")
             }
-            let arrayAccessStruct = Assignment.ArrayAccess(array: array, index: index)
-            return .arrayElement(arrayAccessStruct, valueExpr)
         } else if parser.peek()?.type == .assign {
             // Variable assignment: variable ← expression
             _ = parser.advance() // consume '←'

--- a/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
@@ -404,6 +404,45 @@ struct ExpressionParserTests {
         #expect(expr == expected)
     }
 
+    @Test func test2DArrayAccessWithCommaSyntax() throws {
+        let expr = try parseExpression("matrix[0, 1]")
+        let expected = Expression.arrayAccess(
+            .arrayAccess(.identifier("matrix"), .literal(.integer(0))),
+            .literal(.integer(1))
+        )
+        #expect(expr == expected)
+    }
+
+    @Test func test2DArrayAccessWithExpressions() throws {
+        let expr = try parseExpression("matrix[i + 1, j * 2]")
+        let expected = Expression.arrayAccess(
+            .arrayAccess(
+                .identifier("matrix"),
+                .binary(.add, .identifier("i"), .literal(.integer(1)))
+            ),
+            .binary(.multiply, .identifier("j"), .literal(.integer(2)))
+        )
+        #expect(expr == expected)
+    }
+
+    @Test func test3DArrayAccessWithCommaSyntax() throws {
+        let expr = try parseExpression("cube[0, 1, 2]")
+        let expected = Expression.arrayAccess(
+            .arrayAccess(
+                .arrayAccess(.identifier("cube"), .literal(.integer(0))),
+                .literal(.integer(1))
+            ),
+            .literal(.integer(2))
+        )
+        #expect(expr == expected)
+    }
+
+    @Test func testCommaSyntaxEquivalentToChainedSyntax() throws {
+        let commaSyntax = try parseExpression("matrix[1, 2]")
+        let chainedSyntax = try parseExpression("matrix[1][2]")
+        #expect(commaSyntax == chainedSyntax)
+    }
+
     @Test func testMixedPostfixOperations() throws {
         // func(x)[0] should be parsed as (func(x))[0]
         let expr = try parseExpression("getValue()[0]")

--- a/Tests/FeLangCoreTests/Parser/StatementParserTests.swift
+++ b/Tests/FeLangCoreTests/Parser/StatementParserTests.swift
@@ -73,6 +73,57 @@ struct StatementParserTests {
         #expect(value == .identifier("value"))
     }
 
+    @Test("2D Array Element Assignment with Comma Syntax")
+    func test2DArrayElementAssignmentWithCommaSyntax() throws {
+        let statements = try parseStatements("matrix[1, 2] ← 99")
+
+        #expect(statements.count == 1)
+        guard case .assignment(.arrayElement(let arrayAccess, let value)) = statements[0] else {
+            #expect(Bool(false), "Expected array element assignment")
+            return
+        }
+
+        #expect(arrayAccess.array == .arrayAccess(.identifier("matrix"), .literal(.integer(1))))
+        #expect(arrayAccess.index == .literal(.integer(2)))
+        #expect(value == .literal(.integer(99)))
+    }
+
+    @Test("2D Array Element Assignment with Expressions")
+    func test2DArrayElementAssignmentWithExpressions() throws {
+        let statements = try parseStatements("matrix[i + 1, j * 2] ← x + y")
+
+        #expect(statements.count == 1)
+        guard case .assignment(.arrayElement(let arrayAccess, let value)) = statements[0] else {
+            #expect(Bool(false), "Expected array element assignment")
+            return
+        }
+
+        #expect(arrayAccess.array == .arrayAccess(
+            .identifier("matrix"),
+            .binary(.add, .identifier("i"), .literal(.integer(1)))
+        ))
+        #expect(arrayAccess.index == .binary(.multiply, .identifier("j"), .literal(.integer(2))))
+        #expect(value == .binary(.add, .identifier("x"), .identifier("y")))
+    }
+
+    @Test("3D Array Element Assignment with Comma Syntax")
+    func test3DArrayElementAssignmentWithCommaSyntax() throws {
+        let statements = try parseStatements("cube[0, 1, 2] ← 42")
+
+        #expect(statements.count == 1)
+        guard case .assignment(.arrayElement(let arrayAccess, let value)) = statements[0] else {
+            #expect(Bool(false), "Expected array element assignment")
+            return
+        }
+
+        #expect(arrayAccess.array == .arrayAccess(
+            .arrayAccess(.identifier("cube"), .literal(.integer(0))),
+            .literal(.integer(1))
+        ))
+        #expect(arrayAccess.index == .literal(.integer(2)))
+        #expect(value == .literal(.integer(42)))
+    }
+
     // MARK: - IF Statement Tests
 
     @Test("Basic IF Statement")


### PR DESCRIPTION
## Summary

Adds support for the FE pseudo-language's comma-separated 2D array access syntax `matrix[row, col]` as specified in issue #358. The implementation desugars `expr[a, b]` to `arrayAccess(arrayAccess(expr, a), b)` without introducing new AST nodes.

Changes:
- **ExpressionParser**: Modified `parsePostfixExpression` to handle comma-separated indices after `[`, creating nested `arrayAccess` expressions
- **StatementParser**: Modified `parseAssignment` to support comma syntax for array element assignments like `matrix[1, 2] ← value`
- Added tests for 2D and 3D array access in both expression parsing and statement parsing

Closes #358

## Review & Testing Checklist for Human

- [ ] Verify the desugaring matches the FE pseudo-language specification (the issue states `matrix[1, 2]` should be equivalent to `matrix[1][2]`)
- [ ] Test actual runtime execution with 2D arrays to ensure the parsed AST executes correctly (unit tests only verify AST structure)
- [ ] Consider edge cases: What happens with `array[]`, `array[,]`, or `array[1,]`? (These may produce parse errors, but worth verifying behavior is reasonable)

**Suggested test plan:**
```fe
変数 matrix: 整数型 の配列 ← [[1, 2, 3], [4, 5, 6]]
writeLine(matrix[0, 1])    // Should output: 2
matrix[1, 2] ← 99
writeLine(matrix[1, 2])    // Should output: 99
```

### Notes
- Link to Devin run: https://app.devin.ai/sessions/b2cb51af10a4467f83c46cb49b3b2b8b
- Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/373">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
