### PR TITLE
Add class definition support with member variables and constructors

### DIFF
--- a/Sources/FeLangCore/Parser/ParsingBoundaryDetection.swift
+++ b/Sources/FeLangCore/Parser/ParsingBoundaryDetection.swift
@@ -26,7 +26,8 @@ public enum ParsingBoundaryDetection {
              .endwhileKeyword,  // WHILE statement block ends
              .endforKeyword,    // FOR statement block ends
              .endfunctionKeyword,   // FUNCTION declaration block ends
-             .endprocedureKeyword:  // PROCEDURE declaration block ends
+             .endprocedureKeyword,  // PROCEDURE declaration block ends
+             .endclassKeyword:      // CLASS declaration block ends
             return true
 
         // FOR loop specific keywords that separate expression components
@@ -125,9 +126,10 @@ public enum ParsingBoundaryDetection {
              .constantKeyword:  // Constant declarations: 定数 name: type ← value
             return true
 
-        // Function/procedure declarations
+        // Function/procedure/class declarations
         case .functionKeyword,  // FUNCTION declarations with return values
-             .procedureKeyword: // PROCEDURE declarations without return values
+             .procedureKeyword, // PROCEDURE declarations without return values
+             .classKeyword:     // CLASS declarations
             return true
 
         // Flow control statements
@@ -292,7 +294,7 @@ public enum ParsingBoundaryDetection {
     /// Used for detecting nested control flow structures
     public static func isBlockStartToken(_ tokenType: TokenType) -> Bool {
         switch tokenType {
-        case .ifKeyword, .whileKeyword, .forKeyword, .functionKeyword, .procedureKeyword:
+        case .ifKeyword, .whileKeyword, .forKeyword, .functionKeyword, .procedureKeyword, .classKeyword:
             return true
         default:
             return false
@@ -303,7 +305,7 @@ public enum ParsingBoundaryDetection {
     /// Used for matching block start/end pairs
     public static func isBlockEndToken(_ tokenType: TokenType) -> Bool {
         switch tokenType {
-        case .endifKeyword, .endwhileKeyword, .endforKeyword, .endfunctionKeyword, .endprocedureKeyword:
+        case .endifKeyword, .endwhileKeyword, .endforKeyword, .endfunctionKeyword, .endprocedureKeyword, .endclassKeyword:
             return true
         default:
             return false
@@ -352,7 +354,8 @@ public enum ParsingBoundaryDetection {
              (.whileKeyword, .endwhileKeyword),
              (.forKeyword, .endforKeyword),
              (.functionKeyword, .endfunctionKeyword),
-             (.procedureKeyword, .endprocedureKeyword):
+             (.procedureKeyword, .endprocedureKeyword),
+             (.classKeyword, .endclassKeyword):
             return true
         default:
             return false

--- a/Sources/FeLangCore/Parser/Statement.swift
+++ b/Sources/FeLangCore/Parser/Statement.swift
@@ -18,6 +18,9 @@ public indirect enum Statement: Equatable, Codable, Sendable {
     case procedureDeclaration(ProcedureDeclaration)
     case returnStatement(ReturnStatement)
 
+    // Class
+    case classDeclaration(ClassDeclaration)
+
     // Other
     case expressionStatement(Expression)
     case breakStatement
@@ -99,6 +102,7 @@ public enum ForStatement: Equatable, Codable, Sendable {
 public enum Assignment: Equatable, Codable, Sendable {
     case variable(String, Expression)
     case arrayElement(ArrayAccess, Expression)
+    case fieldAccess(FieldAccess, Expression)
 
     public struct ArrayAccess: Equatable, Codable, Sendable {
         public let array: Expression
@@ -107,6 +111,16 @@ public enum Assignment: Equatable, Codable, Sendable {
         public init(array: Expression, index: Expression) {
             self.array = array
             self.index = index
+        }
+    }
+
+    public struct FieldAccess: Equatable, Codable, Sendable {
+        public let object: Expression
+        public let field: String
+
+        public init(object: Expression, field: String) {
+            self.object = object
+            self.field = field
         }
     }
 }
@@ -287,5 +301,73 @@ public struct RecordDeclaration: Equatable, Codable, Sendable {
         self.name = name
         self.fields = fields
         self.position = position
+    }
+}
+
+/// Represents a class declaration with member variables, constructor, and methods.
+public struct ClassDeclaration: Equatable, Codable, Sendable {
+    public let name: String
+    public let superclass: String?
+    public let members: [MemberDeclaration]
+    public let constructor: ConstructorDeclaration?
+    public let methods: [MethodDeclaration]
+    public let position: SourcePosition?
+
+    public init(
+        name: String,
+        superclass: String? = nil,
+        members: [MemberDeclaration] = [],
+        constructor: ConstructorDeclaration? = nil,
+        methods: [MethodDeclaration] = [],
+        position: SourcePosition? = nil
+    ) {
+        self.name = name
+        self.superclass = superclass
+        self.members = members
+        self.constructor = constructor
+        self.methods = methods
+        self.position = position
+    }
+}
+
+/// Represents a member variable declaration in a class.
+public struct MemberDeclaration: Equatable, Codable, Sendable {
+    public let name: String
+    public let type: DataType
+
+    public init(name: String, type: DataType) {
+        self.name = name
+        self.type = type
+    }
+}
+
+/// Represents a constructor declaration in a class.
+public struct ConstructorDeclaration: Equatable, Codable, Sendable {
+    public let parameters: [Parameter]
+    public let body: [Statement]
+
+    public init(parameters: [Parameter], body: [Statement]) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+/// Represents a method declaration in a class.
+public struct MethodDeclaration: Equatable, Codable, Sendable {
+    public let name: String
+    public let parameters: [Parameter]
+    public let returnType: DataType?
+    public let body: [Statement]
+
+    public init(
+        name: String,
+        parameters: [Parameter],
+        returnType: DataType? = nil,
+        body: [Statement]
+    ) {
+        self.name = name
+        self.parameters = parameters
+        self.returnType = returnType
+        self.body = body
     }
 }

--- a/Sources/FeLangCore/Parser/StatementParser.swift
+++ b/Sources/FeLangCore/Parser/StatementParser.swift
@@ -51,12 +51,12 @@ public struct StatementParser {
 
             // Track nesting depth for security
             switch token.type {
-            case .ifKeyword, .whileKeyword, .forKeyword, .functionKeyword, .procedureKeyword:
+            case .ifKeyword, .whileKeyword, .forKeyword, .functionKeyword, .procedureKeyword, .classKeyword:
                 nestingDepth += 1
                 guard nestingDepth <= maxNestingDepth else {
                     throw StatementParsingError.nestingTooDeep
                 }
-            case .endifKeyword, .endwhileKeyword, .endforKeyword, .endfunctionKeyword, .endprocedureKeyword:
+            case .endifKeyword, .endwhileKeyword, .endforKeyword, .endfunctionKeyword, .endprocedureKeyword, .endclassKeyword:
                 nestingDepth = max(0, nestingDepth - 1)
             default:
                 break
@@ -90,6 +90,8 @@ public struct StatementParser {
             return .functionDeclaration(try parseFunctionDeclaration(&parser, nestingDepth: nestingDepth))
         case .procedureKeyword:
             return .procedureDeclaration(try parseProcedureDeclaration(&parser, nestingDepth: nestingDepth))
+        case .classKeyword:
+            return .classDeclaration(try parseClassDeclaration(&parser, nestingDepth: nestingDepth))
         case .returnKeyword:
             return .returnStatement(try parseReturnStatement(&parser))
         case .breakKeyword:
@@ -244,12 +246,37 @@ public struct StatementParser {
             }
         }
 
+        // Check for field access assignment: identifier.field ←
+        if let nextToken = parser.peek(offset: 1), nextToken.type == .dot {
+            // Skip through field accesses (could be chained like a.b.c)
+            var offset = 2  // Start after the '.'
+
+            while let token = parser.peek(offset: offset) {
+                if token.type == .identifier {
+                    offset += 1
+                    // Check if followed by another dot (chained access)
+                    if let nextDot = parser.peek(offset: offset), nextDot.type == .dot {
+                        offset += 1
+                        continue
+                    }
+                    break
+                } else {
+                    break
+                }
+            }
+
+            // Check if followed by assignment operator
+            if let assignToken = parser.peek(offset: offset), assignToken.type == .assign {
+                return .assignment(try parseAssignment(&parser))
+            }
+        }
+
         // Not an assignment, parse as expression
         let expression = try parseExpression(&parser)
         return .expressionStatement(expression)
     }
 
-    /// Parses an assignment statement (variable ← expression or array[index] ← expression).
+    /// Parses an assignment statement (variable ← expression, array[index] ← expression, or object.field ← expression).
     private func parseAssignment(_ parser: inout TokenStream) throws -> Assignment {
         guard let identifierToken = parser.advance(), identifierToken.type == .identifier else {
             throw StatementParsingError.expectedIdentifier
@@ -267,6 +294,28 @@ public struct StatementParser {
 
             let arrayAccess = Assignment.ArrayAccess(array: .identifier(identifier), index: indexExpr)
             return .arrayElement(arrayAccess, valueExpr)
+        } else if parser.peek()?.type == .dot {
+            // Field access assignment: object.field ← expression (possibly chained like a.b.c)
+            var currentExpr: Expression = .identifier(identifier)
+
+            while parser.peek()?.type == .dot {
+                _ = parser.advance() // consume '.'
+                guard let fieldToken = parser.advance(), fieldToken.type == .identifier else {
+                    throw StatementParsingError.expectedIdentifier
+                }
+                currentExpr = .fieldAccess(currentExpr, fieldToken.lexeme)
+            }
+
+            try expectToken(&parser, .assign) // consume '←'
+            let valueExpr = try parseExpression(&parser)
+
+            // Extract the final field access for the assignment
+            guard case .fieldAccess(let objectExpr, let fieldName) = currentExpr else {
+                throw StatementParsingError.expectedToken(.assign)
+            }
+
+            let fieldAccess = Assignment.FieldAccess(object: objectExpr, field: fieldName)
+            return .fieldAccess(fieldAccess, valueExpr)
         } else if parser.peek()?.type == .assign {
             // Variable assignment: variable ← expression
             _ = parser.advance() // consume '←'
@@ -444,6 +493,166 @@ public struct StatementParser {
         }
 
         return ReturnStatement(expression: expression)
+    }
+
+    /// Parses a class declaration.
+    /// Syntax: class ClassName
+    ///           member1: Type1
+    ///           member2: Type2
+    ///           ClassName(param1: Type1, param2: Type2)
+    ///             body
+    ///         endclass
+    private func parseClassDeclaration(_ parser: inout TokenStream, nestingDepth: Int = 0) throws -> ClassDeclaration {
+        let position = parser.peek()?.position
+
+        try expectToken(&parser, .classKeyword) // consume 'class'
+
+        guard let nameToken = parser.advance(), nameToken.type == .identifier else {
+            throw StatementParsingError.expectedIdentifier
+        }
+        let className = nameToken.lexeme
+
+        var members: [MemberDeclaration] = []
+        var constructor: ConstructorDeclaration?
+        var methods: [MethodDeclaration] = []
+
+        // Parse class body until endclass
+        while let token = parser.peek(), token.type != .endclassKeyword && token.type != .eof {
+            // Skip newlines and whitespace
+            if token.type == .newline || token.type == .whitespace {
+                _ = parser.advance()
+                continue
+            }
+
+            // Check if this is a constructor (identifier matching class name followed by '(')
+            if token.type == .identifier && token.lexeme == className {
+                if let nextToken = parser.peek(offset: 1), nextToken.type == .leftParen {
+                    constructor = try parseConstructorDeclaration(&parser, className: className)
+                    continue
+                }
+            }
+
+            // Check if this is a method (function keyword)
+            if token.type == .functionKeyword {
+                methods.append(try parseMethodDeclaration(&parser, nestingDepth: nestingDepth))
+                continue
+            }
+
+            // Otherwise, try to parse as member declaration (name: Type)
+            if token.type == .identifier {
+                if let nextToken = parser.peek(offset: 1), nextToken.type == .colon {
+                    members.append(try parseMemberDeclaration(&parser))
+                    continue
+                }
+            }
+
+            // Unknown token in class body
+            throw StatementParsingError.unexpectedToken(token, expected: .endclassKeyword)
+        }
+
+        try expectToken(&parser, .endclassKeyword) // consume 'endclass'
+
+        return ClassDeclaration(
+            name: className,
+            superclass: nil,
+            members: members,
+            constructor: constructor,
+            methods: methods,
+            position: position
+        )
+    }
+
+    /// Parses a member declaration (name: Type).
+    private func parseMemberDeclaration(_ parser: inout TokenStream) throws -> MemberDeclaration {
+        guard let nameToken = parser.advance(), nameToken.type == .identifier else {
+            throw StatementParsingError.expectedIdentifier
+        }
+        let name = nameToken.lexeme
+
+        try expectToken(&parser, .colon) // consume ':'
+        let type = try parseDataType(&parser)
+
+        return MemberDeclaration(name: name, type: type)
+    }
+
+    /// Parses a constructor declaration (ClassName(params) body).
+    private func parseConstructorDeclaration(_ parser: inout TokenStream, className: String) throws -> ConstructorDeclaration {
+        // Consume constructor name (same as class name)
+        guard let nameToken = parser.advance(), nameToken.type == .identifier && nameToken.lexeme == className else {
+            throw StatementParsingError.expectedIdentifier
+        }
+
+        try expectToken(&parser, .leftParen) // consume '('
+        let parameters = try parseParameterList(&parser)
+        try expectToken(&parser, .rightParen) // consume ')'
+
+        // Parse constructor body until we hit another member, method, or endclass
+        let body = try parseClassMemberBody(&parser)
+
+        return ConstructorDeclaration(parameters: parameters, body: body)
+    }
+
+    /// Parses a method declaration (function name(params): ReturnType body endfunction).
+    private func parseMethodDeclaration(_ parser: inout TokenStream, nestingDepth: Int = 0) throws -> MethodDeclaration {
+        try expectToken(&parser, .functionKeyword) // consume 'function'
+
+        guard let nameToken = parser.advance(), nameToken.type == .identifier else {
+            throw StatementParsingError.expectedIdentifier
+        }
+        let name = nameToken.lexeme
+
+        try expectToken(&parser, .leftParen) // consume '('
+        let parameters = try parseParameterList(&parser)
+        try expectToken(&parser, .rightParen) // consume ')'
+
+        // Optional return type
+        var returnType: DataType?
+        if parser.peek()?.type == .colon {
+            _ = parser.advance() // consume ':'
+            returnType = try parseDataType(&parser)
+        }
+
+        // Parse method body
+        let body = try parseBlock(&parser, until: [.endfunctionKeyword], nestingDepth: nestingDepth)
+        try expectToken(&parser, .endfunctionKeyword) // consume 'endfunction'
+
+        return MethodDeclaration(name: name, parameters: parameters, returnType: returnType, body: body)
+    }
+
+    /// Parses a constructor body (statements until next member/method/endclass).
+    private func parseClassMemberBody(_ parser: inout TokenStream) throws -> [Statement] {
+        var statements: [Statement] = []
+
+        while let token = parser.peek() {
+            // Skip newlines and whitespace
+            if token.type == .newline || token.type == .whitespace {
+                _ = parser.advance()
+                continue
+            }
+
+            // Stop at endclass or function keyword (method) or identifier followed by colon (member) or identifier followed by '(' (constructor)
+            if token.type == .endclassKeyword || token.type == .functionKeyword {
+                break
+            }
+
+            // Check for member declaration (identifier followed by colon)
+            if token.type == .identifier {
+                if let nextToken = parser.peek(offset: 1) {
+                    if nextToken.type == .colon || nextToken.type == .leftParen {
+                        break
+                    }
+                }
+            }
+
+            if token.type == .eof {
+                break
+            }
+
+            let statement = try parseStatement(&parser)
+            statements.append(statement)
+        }
+
+        return statements
     }
 
     // MARK: - Helper Parsing Methods

--- a/Sources/FeLangCore/Parser/StatementParser.swift
+++ b/Sources/FeLangCore/Parser/StatementParser.swift
@@ -920,7 +920,8 @@ public struct StatementParser {
              .endwhileKeyword,  // WHILE statement block ends
              .endforKeyword,    // FOR statement block ends
              .endfunctionKeyword,   // FUNCTION declaration block ends
-             .endprocedureKeyword:  // PROCEDURE declaration block ends
+             .endprocedureKeyword,  // PROCEDURE declaration block ends
+             .endclassKeyword:      // CLASS declaration block ends
             return true
 
         // FOR loop specific keywords that separate expression components
@@ -1013,9 +1014,10 @@ public struct StatementParser {
              .constantKeyword:  // Constant declarations: 定数 name: type ← value
             return true
 
-        // Function/procedure declarations
+        // Function/procedure/class declarations
         case .functionKeyword,  // FUNCTION declarations with return values
-             .procedureKeyword: // PROCEDURE declarations without return values
+             .procedureKeyword, // PROCEDURE declarations without return values
+             .classKeyword:     // CLASS declarations
             return true
 
         // Flow control statements

--- a/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
+++ b/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
@@ -314,6 +314,9 @@ public struct PrettyPrinter {
 
         case .recordDeclaration(let recordDecl):
             return printRecordDeclaration(recordDecl, indent: indent)
+
+        case .classDeclaration(let classDecl):
+            return printClassDeclaration(classDecl, indent: indent)
         }
     }
 
@@ -383,6 +386,9 @@ public struct PrettyPrinter {
 
         case .arrayElement(let arrayAccess, let expr):
             return "\(printExpression(arrayAccess.array))[\(printExpression(arrayAccess.index))] ← \(printExpression(expr))"
+
+        case .fieldAccess(let fieldAccess, let expr):
+            return "\(printExpression(fieldAccess.object)).\(fieldAccess.field) ← \(printExpression(expr))"
         }
     }
 
@@ -468,6 +474,29 @@ public struct PrettyPrinter {
 
         let newlineBeforeEnd = hasContent ? "" : "\n"
         result += "\(newlineBeforeEnd)\(indentStr)endrecord"
+        return result
+    }
+
+    private func printClassDeclaration(_ classDecl: ClassDeclaration, indent: Int) -> String {
+        let indentStr = makeIndent(indent)
+        var result = "\(indentStr)class \(classDecl.name)"
+
+        var hasContent = appendContentLines(classDecl.members, to: &result, indent: indent + 1) {
+            "\($0.name): \(printDataType($0.type))"
+        }
+
+        if let constructor = classDecl.constructor {
+            if !hasContent {
+                result += "\n"
+                hasContent = true
+            }
+            let params = constructor.parameters.map { "\($0.name): \(printDataType($0.type))" }.joined(separator: ", ")
+            result += makeIndent(indent + 1) + "\(classDecl.name)(\(params))\n"
+            result += printStatements(constructor.body, indent: indent + 2) + "\n"
+        }
+
+        let newlineBeforeEnd = hasContent ? "" : "\n"
+        result += "\(newlineBeforeEnd)\(indentStr)endclass"
         return result
     }
 

--- a/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
+++ b/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
@@ -140,6 +140,9 @@ public final class SemanticAnalyzer: @unchecked Sendable {
         case .recordDeclaration:
             // Record declarations are handled at type level, not symbol level
             break
+        case .classDeclaration:
+            // Class declarations are handled at type level, not symbol level
+            break
         case .assignment, .expressionStatement, .returnStatement, .breakStatement, .continueStatement:
             // These don't declare new symbols
             break
@@ -418,6 +421,9 @@ public final class SemanticAnalyzer: @unchecked Sendable {
         case .recordDeclaration:
             // Record type declarations don't need type checking here
             break
+        case .classDeclaration:
+            // Class type declarations don't need type checking here
+            break
         case .breakStatement, .continueStatement:
             // No type checking needed
             break
@@ -497,6 +503,12 @@ public final class SemanticAnalyzer: @unchecked Sendable {
                 let position = SourcePosition(line: 0, column: 0, offset: 0)
                 errorReporter.collect(.typeMismatch(expected: elementType, actual: valueType, position: position))
             }
+
+        case .fieldAccess(let fieldAccess, let expr):
+            // Type check field access assignment
+            _ = inferExpressionType(fieldAccess.object)
+            _ = inferExpressionType(expr)
+            // Field type checking is deferred to runtime for now
         }
     }
 
@@ -1050,6 +1062,9 @@ public final class SemanticAnalyzer: @unchecked Sendable {
             symbolTable.popScope()
         case .recordDeclaration:
             // Record declarations are validated separately
+            break
+        case .classDeclaration:
+            // Class declarations are validated separately
             break
         case .variableDeclaration, .constantDeclaration, .assignment, .expressionStatement:
             // These are validated in type checking pass

--- a/Sources/FeLangCore/Tokenizer/TokenType.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenType.swift
@@ -46,6 +46,10 @@ public enum TokenType: String, CaseIterable, Equatable, Codable, Sendable {
     case variableKeyword = "変数"
     case constantKeyword = "定数"
 
+    /// Class keywords
+    case classKeyword = "class"
+    case endclassKeyword = "endclass"
+
     // MARK: - Literals
 
     case integerLiteral
@@ -107,7 +111,8 @@ extension TokenType {
              .whileKeyword, .doKeyword, .endwhileKeyword, .forKeyword, .toKeyword, .stepKeyword, .inKeyword, .endforKeyword,
              .functionKeyword, .endfunctionKeyword, .procedureKeyword, .endprocedureKeyword,
              .andKeyword, .orKeyword, .notKeyword, .returnKeyword, .breakKeyword, .continueKeyword,
-             .trueKeyword, .falseKeyword, .variableKeyword, .constantKeyword:
+             .trueKeyword, .falseKeyword, .variableKeyword, .constantKeyword,
+             .classKeyword, .endclassKeyword:
             return true
         default:
             return false

--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -23,13 +23,15 @@ public enum TokenizerUtilities {
         // 8 characters
         ("endwhile", .endwhileKeyword),
         ("function", .functionKeyword),
-
-        // 8 characters
+        ("endclass", .endclassKeyword),
         ("continue", .continueKeyword),
 
         // 6 characters
         ("return", .returnKeyword),
         ("endfor", .endforKeyword),
+
+        // 5 characters
+        ("class", .classKeyword),
 
         // 5 characters
         ("endif", .endifKeyword),

--- a/Sources/FeLangCore/Visitor/ASTWalker.swift
+++ b/Sources/FeLangCore/Visitor/ASTWalker.swift
@@ -202,6 +202,9 @@ public enum ASTWalker {
                     return collectIdentifiers(from: arrayAccess.array)
                         .union(collectIdentifiers(from: arrayAccess.index))
                         .union(collectIdentifiers(from: expr))
+                case .fieldAccess(let fieldAccess, let expr):
+                    return collectIdentifiers(from: fieldAccess.object)
+                        .union(collectIdentifiers(from: expr))
                 }
             },
             visitVariableDeclaration: { varDecl in
@@ -255,6 +258,11 @@ public enum ASTWalker {
             visitRecordDeclaration: { recordDecl in
                 var identifiers = Set([recordDecl.name])
                 identifiers.formUnion(Set(recordDecl.fields.map { $0.name }))
+                return identifiers
+            },
+            visitClassDeclaration: { classDecl in
+                var identifiers = Set([classDecl.name])
+                identifiers.formUnion(Set(classDecl.members.map { $0.name }))
                 return identifiers
             }
         )
@@ -319,6 +327,8 @@ public enum ASTWalker {
                     return 1 + countNodes(in: expr)
                 case .arrayElement(let arrayAccess, let expr):
                     return 1 + countNodes(in: arrayAccess.array) + countNodes(in: arrayAccess.index) + countNodes(in: expr)
+                case .fieldAccess(let fieldAccess, let expr):
+                    return 1 + countNodes(in: fieldAccess.object) + countNodes(in: expr)
                 }
             },
             visitVariableDeclaration: { varDecl in
@@ -362,6 +372,9 @@ public enum ASTWalker {
             },
             visitRecordDeclaration: { recordDecl in
                 return 1 + recordDecl.fields.count
+            },
+            visitClassDeclaration: { classDecl in
+                return 1 + classDecl.members.count
             }
         )
 
@@ -436,6 +449,13 @@ public enum ASTWalker {
                     let transformedExpr = transformExpression(expr, transform)
                     return .assignment(.arrayElement(
                         Assignment.ArrayAccess(array: transformedArray, index: transformedIndex),
+                        transformedExpr
+                    ))
+                case .fieldAccess(let fieldAccess, let expr):
+                    let transformedObject = transformExpression(fieldAccess.object, transform)
+                    let transformedExpr = transformExpression(expr, transform)
+                    return .assignment(.fieldAccess(
+                        Assignment.FieldAccess(object: transformedObject, field: fieldAccess.field),
                         transformedExpr
                     ))
                 }
@@ -513,6 +533,9 @@ public enum ASTWalker {
                     fields: recordDecl.fields,
                     position: recordDecl.position
                 ))
+            },
+            visitClassDeclaration: { classDecl in
+                return .classDeclaration(classDecl)
             }
         )
 

--- a/Sources/FeLangCore/Visitor/StatementVisitor.swift
+++ b/Sources/FeLangCore/Visitor/StatementVisitor.swift
@@ -68,6 +68,9 @@ public struct StatementVisitor<Result>: Sendable where Result: Sendable {
     /// Visits record declarations.
     public let visitRecordDeclaration: @Sendable (RecordDeclaration) -> Result
 
+    /// Visits class declarations.
+    public let visitClassDeclaration: @Sendable (ClassDeclaration) -> Result
+
     // MARK: - Initialization
 
     /// Creates a new statement visitor with the specified visit closures.
@@ -85,7 +88,8 @@ public struct StatementVisitor<Result>: Sendable where Result: Sendable {
         visitBreakStatement: @escaping @Sendable () -> Result,
         visitContinueStatement: @escaping @Sendable () -> Result,
         visitBlock: @escaping @Sendable ([Statement]) -> Result,
-        visitRecordDeclaration: @escaping @Sendable (RecordDeclaration) -> Result
+        visitRecordDeclaration: @escaping @Sendable (RecordDeclaration) -> Result,
+        visitClassDeclaration: @escaping @Sendable (ClassDeclaration) -> Result
     ) {
         self.visitIfStatement = visitIfStatement
         self.visitWhileStatement = visitWhileStatement
@@ -101,6 +105,7 @@ public struct StatementVisitor<Result>: Sendable where Result: Sendable {
         self.visitContinueStatement = visitContinueStatement
         self.visitBlock = visitBlock
         self.visitRecordDeclaration = visitRecordDeclaration
+        self.visitClassDeclaration = visitClassDeclaration
     }
 
     // MARK: - Visit Method
@@ -138,6 +143,8 @@ public struct StatementVisitor<Result>: Sendable where Result: Sendable {
             return visitBlock(statements)
         case .recordDeclaration(let recordDecl):
             return visitRecordDeclaration(recordDecl)
+        case .classDeclaration(let classDecl):
+            return visitClassDeclaration(classDecl)
         }
     }
 }

--- a/Sources/FeLangRuntime/Environment.swift
+++ b/Sources/FeLangRuntime/Environment.swift
@@ -41,6 +41,9 @@ public final class Environment: @unchecked Sendable {
     ///   if multiple threads can define/lookup records concurrently.
     private var recordDefinitions: [String: [RecordField]] = [:]
 
+    /// Class definitions (similar to record definitions, globally scoped).
+    private var classDefinitions: [String: ClassDefinition] = [:]
+
     // MARK: - Initialization
 
     public init(maxScopeDepth: Int = 1000, maxCallDepth: Int = 500) {
@@ -360,5 +363,22 @@ public final class Environment: @unchecked Sendable {
     /// - Returns: The record fields if found, nil otherwise
     public func lookupRecordDefinition(_ name: String) -> [RecordField]? {
         return recordDefinitions[name]
+    }
+
+    // MARK: - Class Definitions
+
+    /// Defines a new class.
+    /// - Parameters:
+    ///   - name: The name of the class
+    ///   - definition: The class definition
+    public func defineClass(_ name: String, definition: ClassDefinition) {
+        classDefinitions[name] = definition
+    }
+
+    /// Looks up a class definition by name.
+    /// - Parameter name: The name of the class to look up
+    /// - Returns: The class definition if found, nil otherwise
+    public func lookupClassDefinition(_ name: String) -> ClassDefinition? {
+        return classDefinitions[name]
     }
 }

--- a/Sources/FeLangRuntime/ExpressionEvaluator.swift
+++ b/Sources/FeLangRuntime/ExpressionEvaluator.swift
@@ -351,14 +351,21 @@ public struct ExpressionEvaluator: Sendable {
         _ object: RuntimeValue,
         field: String
     ) throws -> RuntimeValue {
-        guard case .record(let fields) = object else {
+        switch object {
+        case .record(let fields):
+            guard let value = fields[field] else {
+                throw RuntimeError.invalidFieldAccess(field: field, type: "record")
+            }
+            return value
+
+        case .instance(let inst):
+            guard let value = inst.fields[field] else {
+                throw RuntimeError.invalidFieldAccess(field: field, type: inst.className)
+            }
+            return value
+
+        default:
             throw RuntimeError.invalidFieldAccess(field: field, type: object.typeName)
         }
-
-        guard let value = fields[field] else {
-            throw RuntimeError.invalidFieldAccess(field: field, type: "record")
-        }
-
-        return value
     }
 }

--- a/Sources/FeLangRuntime/RuntimeValue.swift
+++ b/Sources/FeLangRuntime/RuntimeValue.swift
@@ -30,6 +30,12 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
     /// A procedure value
     case procedure(ProcedureValue)
 
+    /// A class definition
+    case classDefinition(ClassDefinition)
+
+    /// A class instance
+    case instance(InstanceValue)
+
     /// Represents nil/null/void
     case null
 
@@ -47,6 +53,8 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
         case .record: return "Record"
         case .function: return "Function"
         case .procedure: return "Procedure"
+        case .classDefinition(let classDef): return "Class<\(classDef.name)>"
+        case .instance(let inst): return inst.className
         case .null: return "Null"
         }
     }
@@ -120,6 +128,11 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
             return "<function \(functionValue.name)>"
         case .procedure(let proc):
             return "<procedure \(proc.name)>"
+        case .classDefinition(let classDef):
+            return "<class \(classDef.name)>"
+        case .instance(let inst):
+            let fieldStrings = inst.fields.map { "\($0.key): \($0.value.toString())" }
+            return "\(inst.className){\(fieldStrings.joined(separator: ", "))}"
         case .null:
             return "null"
         }
@@ -228,5 +241,96 @@ public struct ProcedureValue: Equatable, Sendable {
         self.capturedConstants = capturedConstants
         self.capturedTypes = capturedTypes
         self.capturedUninitialized = capturedUninitialized
+    }
+}
+
+/// Represents a class definition that can be instantiated.
+public struct ClassDefinition: Equatable, Sendable {
+    /// The name of the class
+    public let name: String
+
+    /// Member variable names and their types
+    public let members: [String: DataType]
+
+    /// Constructor parameters
+    public let constructorParameters: [String]
+
+    /// Constructor parameter types
+    public let constructorParameterTypes: [DataType]
+
+    /// Constructor body statements
+    public let constructorBody: [Statement]
+
+    /// Method definitions
+    public let methods: [String: MethodDefinition]
+
+    public init(
+        name: String,
+        members: [String: DataType] = [:],
+        constructorParameters: [String] = [],
+        constructorParameterTypes: [DataType] = [],
+        constructorBody: [Statement] = [],
+        methods: [String: MethodDefinition] = [:]
+    ) {
+        self.name = name
+        self.members = members
+        self.constructorParameters = constructorParameters
+        self.constructorParameterTypes = constructorParameterTypes
+        self.constructorBody = constructorBody
+        self.methods = methods
+    }
+}
+
+/// Represents a method definition within a class.
+public struct MethodDefinition: Equatable, Sendable {
+    /// The name of the method
+    public let name: String
+
+    /// Parameter names
+    public let parameters: [String]
+
+    /// Parameter types
+    public let parameterTypes: [DataType]
+
+    /// Return type (nil for void methods)
+    public let returnType: DataType?
+
+    /// Method body statements
+    public let body: [Statement]
+
+    public init(
+        name: String,
+        parameters: [String],
+        parameterTypes: [DataType] = [],
+        returnType: DataType? = nil,
+        body: [Statement]
+    ) {
+        self.name = name
+        self.parameters = parameters
+        self.parameterTypes = parameterTypes
+        self.returnType = returnType
+        self.body = body
+    }
+}
+
+/// Represents an instance of a class.
+public struct InstanceValue: Equatable, Sendable {
+    /// The name of the class this instance belongs to
+    public let className: String
+
+    /// The class definition reference
+    public let classDefinition: ClassDefinition
+
+    /// Instance field values (mutable through copy-on-write)
+    public var fields: [String: RuntimeValue]
+
+    public init(
+        className: String,
+        classDefinition: ClassDefinition,
+        fields: [String: RuntimeValue] = [:]
+    ) {
+        self.className = className
+        self.classDefinition = classDefinition
+        self.fields = fields
     }
 }

--- a/Sources/FeLangRuntime/StatementExecutor.swift
+++ b/Sources/FeLangRuntime/StatementExecutor.swift
@@ -125,6 +125,10 @@ public final class StatementExecutor: @unchecked Sendable {
         case .recordDeclaration(let decl):
             executeRecordDeclaration(decl)
             return .normal
+
+        case .classDeclaration(let decl):
+            executeClassDeclaration(decl)
+            return .normal
         }
     }
 
@@ -132,6 +136,46 @@ public final class StatementExecutor: @unchecked Sendable {
 
     private func executeRecordDeclaration(_ decl: RecordDeclaration) {
         environment.defineRecord(decl.name, fields: decl.fields)
+    }
+
+    private func executeClassDeclaration(_ decl: ClassDeclaration) {
+        var members: [String: DataType] = [:]
+        for member in decl.members {
+            members[member.name] = member.type
+        }
+
+        var constructorParams: [String] = []
+        var constructorParamTypes: [DataType] = []
+        var constructorBody: [Statement] = []
+
+        if let constructor = decl.constructor {
+            constructorParams = constructor.parameters.map { $0.name }
+            constructorParamTypes = constructor.parameters.map { $0.type }
+            constructorBody = constructor.body
+        }
+
+        var methods: [String: MethodDefinition] = [:]
+        for method in decl.methods {
+            let methodDef = MethodDefinition(
+                name: method.name,
+                parameters: method.parameters.map { $0.name },
+                parameterTypes: method.parameters.map { $0.type },
+                returnType: method.returnType,
+                body: method.body
+            )
+            methods[method.name] = methodDef
+        }
+
+        let classDef = ClassDefinition(
+            name: decl.name,
+            members: members,
+            constructorParameters: constructorParams,
+            constructorParameterTypes: constructorParamTypes,
+            constructorBody: constructorBody,
+            methods: methods
+        )
+
+        environment.defineClass(decl.name, definition: classDef)
     }
 
     private func executeVariableDeclaration(_ decl: VariableDeclaration) throws {
@@ -206,6 +250,53 @@ public final class StatementExecutor: @unchecked Sendable {
         case .arrayElement(let arrayAccess, let expr):
             let value = try evaluator.evaluate(expr)
             try assignArrayElement(arrayAccess, value: value)
+
+        case .fieldAccess(let fieldAccess, let expr):
+            let value = try evaluator.evaluate(expr)
+            try assignFieldAccess(fieldAccess, value: value)
+        }
+    }
+
+    private func assignFieldAccess(_ access: Assignment.FieldAccess, value: RuntimeValue) throws {
+        let objectValue = try evaluator.evaluate(access.object)
+
+        switch objectValue {
+        case .instance(var inst):
+            // Validate field exists
+            guard inst.fields[access.field] != nil else {
+                throw RuntimeError.invalidFieldAccess(field: access.field, type: inst.className)
+            }
+
+            // Validate type if member has a declared type
+            if let expectedType = inst.classDefinition.members[access.field] {
+                try validateType(value, expected: expectedType, context: "assignment to '\(access.field)'")
+            }
+
+            inst.fields[access.field] = value
+
+            // Update the instance in the environment
+            switch access.object {
+            case .identifier(let name):
+                try environment.assign(name, value: .instance(inst))
+            default:
+                throw RuntimeError.generic(message: "Cannot assign to field of complex expression")
+            }
+
+        case .record(var fields):
+            guard fields[access.field] != nil else {
+                throw RuntimeError.invalidFieldAccess(field: access.field, type: "record")
+            }
+            fields[access.field] = value
+
+            switch access.object {
+            case .identifier(let name):
+                try environment.assign(name, value: .record(fields))
+            default:
+                throw RuntimeError.generic(message: "Cannot assign to field of complex expression")
+            }
+
+        default:
+            throw RuntimeError.invalidFieldAccess(field: access.field, type: objectValue.typeName)
         }
     }
 
@@ -527,12 +618,86 @@ public final class StatementExecutor: @unchecked Sendable {
             }
         }
 
+        // Check if this is a class instantiation
+        if let classDef = environment.lookupClassDefinition(name) {
+            return try createInstance(classDef, arguments: arguments)
+        }
+
         // Then try external function resolver (for standard library functions)
         if let resolver = externalFunctionResolver {
             return try resolver(name, arguments)
         }
 
         throw RuntimeError.undefinedFunction(name: name)
+    }
+
+    private func createInstance(
+        _ classDef: ClassDefinition,
+        arguments: [RuntimeValue]
+    ) throws -> RuntimeValue {
+        // Validate constructor argument count
+        guard arguments.count == classDef.constructorParameters.count else {
+            throw RuntimeError.wrongArgumentCount(
+                function: classDef.name,
+                expected: classDef.constructorParameters.count,
+                actual: arguments.count
+            )
+        }
+
+        // Validate constructor parameter types
+        if !classDef.constructorParameterTypes.isEmpty {
+            for (index, (param, arg)) in zip(classDef.constructorParameters, arguments).enumerated() {
+                guard index < classDef.constructorParameterTypes.count else { continue }
+                let expectedType = classDef.constructorParameterTypes[index]
+                try validateType(arg, expected: expectedType, context: "parameter '\(param)' of '\(classDef.name)' constructor")
+            }
+        }
+
+        // Initialize member fields with default values
+        var fields: [String: RuntimeValue] = [:]
+        for (memberName, memberType) in classDef.members {
+            fields[memberName] = defaultValue(for: memberType)
+        }
+
+        // Create the instance
+        var instance = InstanceValue(
+            className: classDef.name,
+            classDefinition: classDef,
+            fields: fields
+        )
+
+        // Execute constructor body if present
+        if !classDef.constructorBody.isEmpty {
+            try environment.enterCall()
+            defer { environment.exitCall() }
+
+            functionDepth += 1
+            defer { functionDepth -= 1 }
+
+            try environment.pushScope()
+            defer { environment.popScope() }
+
+            // Bind constructor parameters
+            for (index, (param, arg)) in zip(classDef.constructorParameters, arguments).enumerated() {
+                let paramType = index < classDef.constructorParameterTypes.count
+                    ? classDef.constructorParameterTypes[index]
+                    : nil
+                environment.define(param, value: arg, type: paramType)
+            }
+
+            // Define 'self' as the instance being constructed
+            environment.define("self", value: .instance(instance))
+
+            // Execute constructor body
+            _ = try execute(classDef.constructorBody)
+
+            // Retrieve the potentially modified 'self' instance
+            if case .instance(let modifiedInstance) = try environment.get("self") {
+                instance = modifiedInstance
+            }
+        }
+
+        return .instance(instance)
     }
 
     private func callFunctionValue(
@@ -685,7 +850,7 @@ public final class StatementExecutor: @unchecked Sendable {
         case .record:
             // Record type name cannot be inferred from runtime value
             return nil
-        case .function, .procedure, .null:
+        case .function, .procedure, .null, .classDefinition, .instance:
             return nil
         }
     }

--- a/Sources/FeLangServer/CompletionProvider.swift
+++ b/Sources/FeLangServer/CompletionProvider.swift
@@ -35,6 +35,10 @@ public struct CompletionProvider: Sendable {
         CompletionItem(label: "procedure", kind: .keyword, detail: "Procedure declaration", insertText: "procedure "),
         CompletionItem(label: "endprocedure", kind: .keyword, detail: "End procedure"),
 
+        // Classes
+        CompletionItem(label: "class", kind: .keyword, detail: "Class declaration", insertText: "class "),
+        CompletionItem(label: "endclass", kind: .keyword, detail: "End class"),
+
         // Logical operators
         CompletionItem(label: "and", kind: .keyword, detail: "Logical AND"),
         CompletionItem(label: "or", kind: .keyword, detail: "Logical OR"),
@@ -273,6 +277,7 @@ public struct CompletionProvider: Sendable {
             "while", "do", "endwhile",
             "for", "to", "step", "endfor", "in",
             "function", "endfunction", "procedure", "endprocedure",
+            "class", "endclass",
             "return", "break", "continue",
             "and", "or", "not", "true", "false",
             "integer", "real", "string", "character", "boolean", "array",

--- a/Sources/FeLangServer/DefinitionProvider.swift
+++ b/Sources/FeLangServer/DefinitionProvider.swift
@@ -157,6 +157,7 @@ public struct DefinitionProvider: Sendable {
             "while", "do", "endwhile",
             "for", "to", "step", "endfor", "in",
             "function", "endfunction", "procedure", "endprocedure",
+            "class", "endclass",
             "return", "break", "continue",
             "and", "or", "not", "true", "false"
         ])

--- a/Sources/FeLangServer/HoverProvider.swift
+++ b/Sources/FeLangServer/HoverProvider.swift
@@ -35,6 +35,10 @@ public struct HoverProvider: Sendable {
         "procedure": "**procedure** - Procedure declaration\n\nDeclares a procedure (no return value).\n\n```fe\nprocedure name(params)\n    // code\nendprocedure\n```",
         "endprocedure": "**endprocedure** - End procedure\n\nMarks the end of a procedure declaration.",
 
+        // Classes
+        "class": "**class** - Class declaration\n\nDeclares a class with member variables and constructor.\n\n```fe\nclass ClassName\n    member1: Type1\n    member2: Type2\n    ClassName(param: Type)\n        self.member1 ← param\nendclass\n```",
+        "endclass": "**endclass** - End class\n\nMarks the end of a class declaration.",
+
         // Logical
         "and": "**and** - Logical AND\n\nReturns true if both operands are true.",
         "or": "**or** - Logical OR\n\nReturns true if either operand is true.",

--- a/Tests/FeLangCoreTests/Visitor/StatementVisitorTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/StatementVisitorTests.swift
@@ -21,7 +21,8 @@ struct StatementVisitorTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record_decl" }
+            visitRecordDeclaration: { _ in "record_decl" },
+            visitClassDeclaration: { _ in "class_decl" }
         )
 
         let ifStmt = IfStatement(
@@ -50,7 +51,8 @@ struct StatementVisitorTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record_decl" }
+            visitRecordDeclaration: { _ in "record_decl" },
+            visitClassDeclaration: { _ in "class_decl" }
         )
 
         let whileStmt = WhileStatement(
@@ -86,7 +88,8 @@ struct StatementVisitorTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record_decl" }
+            visitRecordDeclaration: { _ in "record_decl" },
+            visitClassDeclaration: { _ in "class_decl" }
         )
 
         let rangeFor = ForStatement.RangeFor(
@@ -120,6 +123,8 @@ struct StatementVisitorTests {
                     return "assign_var(\(name))"
                 case .arrayElement(let arrayAccess, _):
                     return "assign_array(\(arrayAccess.array))"
+                case .fieldAccess(let fieldAccess, _):
+                    return "assign_field(\(fieldAccess.field))"
                 }
             },
             visitVariableDeclaration: { _ in "var_decl" },
@@ -131,7 +136,8 @@ struct StatementVisitorTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record_decl" }
+            visitRecordDeclaration: { _ in "record_decl" },
+            visitClassDeclaration: { _ in "class_decl" }
         )
 
         let varAssignment = Statement.assignment(.variable("x", .literal(.integer(42))))
@@ -160,7 +166,8 @@ struct StatementVisitorTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record_decl" }
+            visitRecordDeclaration: { _ in "record_decl" },
+            visitClassDeclaration: { _ in "class_decl" }
         )
 
         let varDecl = Statement.variableDeclaration(VariableDeclaration(
@@ -214,7 +221,8 @@ struct StatementVisitorTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { statements in "block(\(statements.count))" },
-            visitRecordDeclaration: { _ in "record" }
+            visitRecordDeclaration: { _ in "record" },
+            visitClassDeclaration: { _ in "class_decl" }
         )
 
         let returnStmt = Statement.returnStatement(ReturnStatement(expression: .literal(.integer(42))))
@@ -262,6 +270,8 @@ struct StatementVisitorTests {
                     return "\(name) = \(expr)"
                 case .arrayElement(let arrayAccess, let expr):
                     return "\(arrayAccess.array)[\(arrayAccess.index)] = \(expr)"
+                case .fieldAccess(let fieldAccess, let expr):
+                    return "\(fieldAccess.object).\(fieldAccess.field) = \(expr)"
                 }
             case .variableDeclaration(let varDecl):
                 if let initialValue = varDecl.initialValue {
@@ -294,6 +304,8 @@ struct StatementVisitorTests {
                 return "{ \(results.joined(separator: "; ")) }"
             case .recordDeclaration(let recordDecl):
                 return "record \(recordDecl.name)"
+            case .classDeclaration(let classDecl):
+                return "class \(classDecl.name)"
             }
         }
 
@@ -334,7 +346,8 @@ struct StatementVisitorTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record_decl" }
+            visitRecordDeclaration: { _ in "record_decl" },
+            visitClassDeclaration: { _ in "class_decl" }
         )
 
         let stmt = Statement.breakStatement
@@ -364,7 +377,8 @@ struct StatementVisitorTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record_decl" }
+            visitRecordDeclaration: { _ in "record_decl" },
+            visitClassDeclaration: { _ in "class_decl" }
         )
 
         // Test simple statements
@@ -399,7 +413,7 @@ struct StatementVisitorTests {
                 return 1 + body.map(countStatements).reduce(0, +)
             case .assignment, .variableDeclaration, .constantDeclaration,
                  .returnStatement, .expressionStatement, .breakStatement, .continueStatement,
-                 .recordDeclaration:
+                 .recordDeclaration, .classDeclaration:
                 return 1
             case .functionDeclaration(let funcDecl):
                 return 1 + funcDecl.body.map(countStatements).reduce(0, +)

--- a/Tests/FeLangCoreTests/Visitor/VisitableTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/VisitableTests.swift
@@ -42,7 +42,8 @@ struct VisitableTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record" }
+            visitRecordDeclaration: { _ in "record" },
+            visitClassDeclaration: { _ in "class" }
         )
 
         let stmt = Statement.breakStatement
@@ -100,6 +101,7 @@ struct VisitableTests {
                 switch assignment {
                 case .variable: return "assign_var"
                 case .arrayElement: return "assign_array"
+                case .fieldAccess: return "assign_field"
                 }
             },
             visitVariableDeclaration: { _ in "var_decl" },
@@ -111,7 +113,8 @@ struct VisitableTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record" }
+            visitRecordDeclaration: { _ in "record" },
+            visitClassDeclaration: { _ in "class" }
         )
 
         // Test all statement types with convenience method
@@ -185,7 +188,8 @@ struct VisitableTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record" }
+            visitRecordDeclaration: { _ in "record" },
+            visitClassDeclaration: { _ in "class" }
         )
 
         let expr = Expression.literal(.integer(42))
@@ -225,7 +229,8 @@ struct VisitableTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record" }
+            visitRecordDeclaration: { _ in "record" },
+            visitClassDeclaration: { _ in "class" }
         )
 
         // Test that we can use visitors in async contexts
@@ -266,7 +271,8 @@ struct VisitableTests {
             visitBreakStatement: { "break" },
             visitContinueStatement: { "continue" },
             visitBlock: { _ in "block" },
-            visitRecordDeclaration: { _ in "record" }
+            visitRecordDeclaration: { _ in "record" },
+            visitClassDeclaration: { _ in "class" }
         )
 
         let expr = Expression.literal(.integer(42))


### PR DESCRIPTION
Closes #363

## Summary

This PR implements class definition support for FeLangKit, enabling users to define custom types with member variables and constructors. The implementation includes:

- New `class`/`endclass` keywords in the tokenizer
- AST types for class declarations, member variables, constructors, and methods
- Parser support for class syntax with member declarations and constructors
- Runtime support for class definitions and instance creation
- Field access expressions and field assignment statements (`instance.field ← value`)
- Updates to all visitor patterns, semantic analyzer, pretty printer, and LSP providers

Example syntax:
```fe
class Point
    x: integer
    y: integer
    Point(x: integer, y: integer)
        self.x ← x
        self.y ← y
endclass

p ← Point(10, 20)
p.x ← 30
```

Note: Methods are parsed but execution is deferred to issue #364.

## Review & Testing Checklist for Human

- [ ] **Test class parsing edge cases**: empty class, class with only members, class with only constructor, nested classes (should error)
- [ ] **Test field access assignment**: verify chained field access works (`a.b.c ← value`) and errors are clear for invalid access
- [ ] **Test constructor execution**: verify `self` reference works correctly and fields are properly initialized
- [ ] **Verify method handling**: methods are parsed but not executed - confirm this doesn't cause confusing runtime errors
- [ ] **Test instance creation**: with/without constructors, with wrong argument counts/types

**Recommended test plan:**
1. Write a simple class with members and constructor, create an instance, access and modify fields
2. Try creating an instance with wrong number of arguments (should error)
3. Try accessing a non-existent field (should error)
4. Try defining a method and calling it (should fail gracefully or error clearly)

### Notes

- All 1223 existing tests pass
- Lint passes with 0 violations
- No E2E tests were added for the new class feature - manual testing recommended

Link to Devin run: https://app.devin.ai/sessions/c3a2b1ce3c054c1c88ef1346c0cd6ae8
Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/374">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * クラス宣言のサポート追加：メンバー変数、コンストラクタ、メソッドの定義が可能になりました。
  * オブジェクトのフィールドアクセス機能を実装。ドット記法を使用したフィールド参照と割り当てに対応しました。
  * クラスキーワード（`class`/`endclass`）と関連する言語機能を統合。

* **テスト**
  * クラス宣言とフィールドアクセスの動作検証テストを追加。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->