### PR TITLE
feat: add do-while loop support

### DIFF
--- a/Sources/FeLangCore/Parser/ParsingBoundaryDetection.swift
+++ b/Sources/FeLangCore/Parser/ParsingBoundaryDetection.swift
@@ -292,9 +292,11 @@ public enum ParsingBoundaryDetection {
 
     /// Determines if a token marks the start of a block structure
     /// Used for detecting nested control flow structures
+    /// Note: doKeyword is not included because do-while loops have a different termination pattern
+    /// (they end with 'while (condition)' instead of an 'enddo' keyword)
     public static func isBlockStartToken(_ tokenType: TokenType) -> Bool {
         switch tokenType {
-        case .ifKeyword, .whileKeyword, .doKeyword, .forKeyword, .functionKeyword, .procedureKeyword:
+        case .ifKeyword, .whileKeyword, .forKeyword, .functionKeyword, .procedureKeyword:
             return true
         default:
             return false

--- a/Sources/FeLangCore/Parser/ParsingBoundaryDetection.swift
+++ b/Sources/FeLangCore/Parser/ParsingBoundaryDetection.swift
@@ -118,6 +118,7 @@ public enum ParsingBoundaryDetection {
         // Control flow statements
         case .ifKeyword,        // IF-THEN-ELSE conditional statements
              .whileKeyword,     // WHILE-DO loop statements
+             .doKeyword,        // DO-WHILE loop statements
              .forKeyword:       // FOR loop statements (range or forEach)
             return true
 
@@ -293,7 +294,7 @@ public enum ParsingBoundaryDetection {
     /// Used for detecting nested control flow structures
     public static func isBlockStartToken(_ tokenType: TokenType) -> Bool {
         switch tokenType {
-        case .ifKeyword, .whileKeyword, .forKeyword, .functionKeyword, .procedureKeyword:
+        case .ifKeyword, .whileKeyword, .doKeyword, .forKeyword, .functionKeyword, .procedureKeyword:
             return true
         default:
             return false

--- a/Sources/FeLangCore/Parser/Statement.swift
+++ b/Sources/FeLangCore/Parser/Statement.swift
@@ -3,6 +3,7 @@ public indirect enum Statement: Equatable, Codable, Sendable {
     // Control flow
     case ifStatement(IfStatement)
     case whileStatement(WhileStatement)
+    case doWhileStatement(DoWhileStatement)
     case forStatement(ForStatement)
 
     // Assignments
@@ -58,6 +59,18 @@ public struct WhileStatement: Equatable, Codable, Sendable {
     public init(condition: Expression, body: [Statement]) {
         self.condition = condition
         self.body = body
+    }
+}
+
+/// Represents a DO-WHILE statement (post-condition loop).
+/// The body is executed at least once, then the condition is checked.
+public struct DoWhileStatement: Equatable, Codable, Sendable {
+    public let body: [Statement]
+    public let condition: Expression
+
+    public init(body: [Statement], condition: Expression) {
+        self.body = body
+        self.condition = condition
     }
 }
 

--- a/Sources/FeLangCore/Parser/StatementParser.swift
+++ b/Sources/FeLangCore/Parser/StatementParser.swift
@@ -50,8 +50,10 @@ public struct StatementParser {
             }
 
             // Track nesting depth for security
+            // Note: doKeyword is not included because do-while loops don't have an enddo keyword
+            // (they terminate with 'while (condition)'), so the depth would never be decremented
             switch token.type {
-            case .ifKeyword, .whileKeyword, .doKeyword, .forKeyword, .functionKeyword, .procedureKeyword:
+            case .ifKeyword, .whileKeyword, .forKeyword, .functionKeyword, .procedureKeyword:
                 nestingDepth += 1
                 guard nestingDepth <= maxNestingDepth else {
                     throw StatementParsingError.nestingTooDeep

--- a/Sources/FeLangCore/Parser/StatementParser.swift
+++ b/Sources/FeLangCore/Parser/StatementParser.swift
@@ -51,7 +51,7 @@ public struct StatementParser {
 
             // Track nesting depth for security
             switch token.type {
-            case .ifKeyword, .whileKeyword, .forKeyword, .functionKeyword, .procedureKeyword:
+            case .ifKeyword, .whileKeyword, .doKeyword, .forKeyword, .functionKeyword, .procedureKeyword:
                 nestingDepth += 1
                 guard nestingDepth <= maxNestingDepth else {
                     throw StatementParsingError.nestingTooDeep
@@ -80,6 +80,8 @@ public struct StatementParser {
             return .ifStatement(try parseIfStatement(&parser, nestingDepth: nestingDepth))
         case .whileKeyword:
             return .whileStatement(try parseWhileStatement(&parser, nestingDepth: nestingDepth))
+        case .doKeyword:
+            return .doWhileStatement(try parseDoWhileStatement(&parser, nestingDepth: nestingDepth))
         case .forKeyword:
             return .forStatement(try parseForStatement(&parser, nestingDepth: nestingDepth))
         case .variableKeyword:
@@ -154,6 +156,21 @@ public struct StatementParser {
         try expectToken(&parser, .endwhileKeyword) // consume 'endwhile'
 
         return WhileStatement(condition: condition, body: body)
+    }
+
+    /// Parses a DO-WHILE statement (do ... while (condition)).
+    /// The body is executed at least once, then the condition is checked.
+    private func parseDoWhileStatement(_ parser: inout TokenStream, nestingDepth: Int = 0) throws -> DoWhileStatement {
+        try expectToken(&parser, .doKeyword) // consume 'do'
+
+        let body = try parseBlock(&parser, until: [.whileKeyword], nestingDepth: nestingDepth)
+
+        try expectToken(&parser, .whileKeyword) // consume 'while'
+        try expectToken(&parser, .leftParen) // consume '('
+        let condition = try parseExpression(&parser)
+        try expectToken(&parser, .rightParen) // consume ')'
+
+        return DoWhileStatement(body: body, condition: condition)
     }
 
     /// Parses a FOR statement (range-based or forEach).
@@ -797,6 +814,7 @@ public struct StatementParser {
         // Control flow statements
         case .ifKeyword,        // IF-THEN-ELSE conditional statements
              .whileKeyword,     // WHILE-DO loop statements
+             .doKeyword,        // DO-WHILE loop statements
              .forKeyword:       // FOR loop statements (range or forEach)
             return true
 

--- a/Sources/FeLangCore/Parser/StatementParser.swift
+++ b/Sources/FeLangCore/Parser/StatementParser.swift
@@ -162,10 +162,11 @@ public struct StatementParser {
 
     /// Parses a DO-WHILE statement (do ... while (condition)).
     /// The body is executed at least once, then the condition is checked.
+    /// Uses lookahead to distinguish terminating `while (` from nested `while condition do`.
     private func parseDoWhileStatement(_ parser: inout TokenStream, nestingDepth: Int = 0) throws -> DoWhileStatement {
         try expectToken(&parser, .doKeyword) // consume 'do'
 
-        let body = try parseBlock(&parser, until: [.whileKeyword], nestingDepth: nestingDepth)
+        let body = try parseDoWhileBody(&parser, nestingDepth: nestingDepth)
 
         try expectToken(&parser, .whileKeyword) // consume 'while'
         try expectToken(&parser, .leftParen) // consume '('
@@ -173,6 +174,42 @@ public struct StatementParser {
         try expectToken(&parser, .rightParen) // consume ')'
 
         return DoWhileStatement(body: body, condition: condition)
+    }
+
+    /// Parses the body of a do-while statement until the terminating `while (` is found.
+    /// Distinguishes between terminating `while (` and nested `while condition do` using lookahead.
+    private func parseDoWhileBody(_ parser: inout TokenStream, nestingDepth: Int = 0) throws -> [Statement] {
+        // Check nesting depth for security
+        guard nestingDepth < 100 else {
+            throw StatementParsingError.nestingTooDeep
+        }
+
+        var statements: [Statement] = []
+
+        while let token = parser.peek(), token.type != .eof {
+            // Skip newlines and whitespace
+            if token.type == .newline || token.type == .whitespace {
+                _ = parser.advance()
+                continue
+            }
+
+            // Check if this is the terminating `while (` of the do-while
+            // The terminating while is followed by `(`, while a nested while loop
+            // is followed by a condition expression and then `do`
+            if token.type == .whileKeyword {
+                // Lookahead to check if next token is `(`
+                if let nextToken = parser.peek(offset: 1), nextToken.type == .leftParen {
+                    // This is the terminating `while (` - stop parsing body
+                    break
+                }
+                // Otherwise, this is a nested while loop - continue parsing as statement
+            }
+
+            let statement = try parseStatement(&parser, nestingDepth: nestingDepth + 1)
+            statements.append(statement)
+        }
+
+        return statements
     }
 
     /// Parses a FOR statement (range-based or forEach).

--- a/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
+++ b/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
@@ -279,6 +279,9 @@ public struct PrettyPrinter {
         case .whileStatement(let whileStmt):
             return printWhileStatement(whileStmt, indent: indent)
 
+        case .doWhileStatement(let doWhileStmt):
+            return printDoWhileStatement(doWhileStmt, indent: indent)
+
         case .forStatement(let forStmt):
             return printForStatement(forStmt, indent: indent)
 
@@ -351,6 +354,14 @@ public struct PrettyPrinter {
         var result = "\(indentStr)while \(printExpression(whileStmt.condition)) do\n"
         result += printStatements(whileStmt.body, indent: indent + 1)
         result += "\n\(indentStr)endwhile"
+        return result
+    }
+
+    private func printDoWhileStatement(_ doWhileStmt: DoWhileStatement, indent: Int) -> String {
+        let indentStr = makeIndent(indent)
+        var result = "\(indentStr)do\n"
+        result += printStatements(doWhileStmt.body, indent: indent + 1)
+        result += "\n\(indentStr)while (\(printExpression(doWhileStmt.condition)))"
         return result
     }
 

--- a/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
+++ b/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
@@ -129,6 +129,8 @@ public final class SemanticAnalyzer: @unchecked Sendable {
             collectSymbolsFromIfStatement(stmt)
         case .whileStatement(let stmt):
             collectSymbolsFromWhileStatement(stmt)
+        case .doWhileStatement(let stmt):
+            collectSymbolsFromDoWhileStatement(stmt)
         case .forStatement(let stmt):
             collectSymbolsFromForStatement(stmt)
         case .block(let statements):
@@ -325,6 +327,14 @@ public final class SemanticAnalyzer: @unchecked Sendable {
         symbolTable.popScope()
     }
 
+    private func collectSymbolsFromDoWhileStatement(_ stmt: DoWhileStatement) {
+        _ = symbolTable.pushScope(kind: .loop)
+        for bodyStmt in stmt.body {
+            collectSymbolsFromStatement(bodyStmt)
+        }
+        symbolTable.popScope()
+    }
+
     private func collectSymbolsFromForStatement(_ stmt: ForStatement) {
         switch stmt {
         case .range(let rangeFor):
@@ -399,6 +409,8 @@ public final class SemanticAnalyzer: @unchecked Sendable {
             typeCheckIfStatement(stmt)
         case .whileStatement(let stmt):
             typeCheckWhileStatement(stmt)
+        case .doWhileStatement(let stmt):
+            typeCheckDoWhileStatement(stmt)
         case .forStatement(let stmt):
             typeCheckForStatement(stmt)
         case .returnStatement(let stmt):
@@ -548,6 +560,20 @@ public final class SemanticAnalyzer: @unchecked Sendable {
             typeCheckStatement(bodyStmt)
         }
         symbolTable.popScope()
+    }
+
+    private func typeCheckDoWhileStatement(_ stmt: DoWhileStatement) {
+        _ = symbolTable.pushScope(kind: .loop)
+        for bodyStmt in stmt.body {
+            typeCheckStatement(bodyStmt)
+        }
+        symbolTable.popScope()
+
+        let conditionType = inferExpressionType(stmt.condition)
+        if !conditionType.isCompatible(with: .boolean) {
+            let position = SourcePosition(line: 0, column: 0, offset: 0)
+            errorReporter.collect(.typeMismatch(expected: .boolean, actual: conditionType, position: position))
+        }
     }
 
     private func typeCheckForStatement(_ stmt: ForStatement) {
@@ -1036,6 +1062,8 @@ public final class SemanticAnalyzer: @unchecked Sendable {
             validateIfStatement(stmt)
         case .whileStatement(let stmt):
             validateWhileStatement(stmt)
+        case .doWhileStatement(let stmt):
+            validateDoWhileStatement(stmt)
         case .forStatement(let stmt):
             validateForStatement(stmt)
         case .functionDeclaration(let decl):
@@ -1103,6 +1131,14 @@ public final class SemanticAnalyzer: @unchecked Sendable {
     }
 
     private func validateWhileStatement(_ stmt: WhileStatement) {
+        _ = symbolTable.pushScope(kind: .loop)
+        for bodyStmt in stmt.body {
+            validateStatement(bodyStmt)
+        }
+        symbolTable.popScope()
+    }
+
+    private func validateDoWhileStatement(_ stmt: DoWhileStatement) {
         _ = symbolTable.pushScope(kind: .loop)
         for bodyStmt in stmt.body {
             validateStatement(bodyStmt)

--- a/Sources/FeLangCore/Visitor/ASTWalker.swift
+++ b/Sources/FeLangCore/Visitor/ASTWalker.swift
@@ -172,6 +172,13 @@ public enum ASTWalker {
                 })
                 return identifiers
             },
+            visitDoWhileStatement: { doWhileStmt in
+                var identifiers = collectIdentifiers(from: doWhileStmt.condition)
+                identifiers.formUnion(doWhileStmt.body.reduce(Set<String>()) { result, stmt in
+                    result.union(collectIdentifiers(from: stmt))
+                })
+                return identifiers
+            },
             visitForStatement: { forStmt in
                 var identifiers = Set<String>()
                 switch forStmt {
@@ -293,6 +300,13 @@ public enum ASTWalker {
                 }
                 return 1 + conditionCount + bodyCount
             },
+            visitDoWhileStatement: { doWhileStmt in
+                let conditionCount = countNodes(in: doWhileStmt.condition)
+                let bodyCount = doWhileStmt.body.reduce(0) { result, stmt in
+                    result + countNodes(in: stmt)
+                }
+                return 1 + conditionCount + bodyCount
+            },
             visitForStatement: { forStmt in
                 var count = 1
                 switch forStmt {
@@ -399,6 +413,14 @@ public enum ASTWalker {
                 return .whileStatement(WhileStatement(
                     condition: transformedCondition,
                     body: transformedBody
+                ))
+            },
+            visitDoWhileStatement: { doWhileStmt in
+                let transformedCondition = transformExpression(doWhileStmt.condition, transform)
+                let transformedBody = doWhileStmt.body.map { transformExpressions(in: $0, transform) }
+                return .doWhileStatement(DoWhileStatement(
+                    body: transformedBody,
+                    condition: transformedCondition
                 ))
             },
             visitForStatement: { forStmt in

--- a/Sources/FeLangCore/Visitor/StatementVisitor.swift
+++ b/Sources/FeLangCore/Visitor/StatementVisitor.swift
@@ -31,6 +31,9 @@ public struct StatementVisitor<Result>: Sendable where Result: Sendable {
     /// Visits while statements.
     public let visitWhileStatement: @Sendable (WhileStatement) -> Result
 
+    /// Visits do-while statements.
+    public let visitDoWhileStatement: @Sendable (DoWhileStatement) -> Result
+
     /// Visits for statements.
     public let visitForStatement: @Sendable (ForStatement) -> Result
 
@@ -74,6 +77,7 @@ public struct StatementVisitor<Result>: Sendable where Result: Sendable {
     public init(
         visitIfStatement: @escaping @Sendable (IfStatement) -> Result,
         visitWhileStatement: @escaping @Sendable (WhileStatement) -> Result,
+        visitDoWhileStatement: @escaping @Sendable (DoWhileStatement) -> Result,
         visitForStatement: @escaping @Sendable (ForStatement) -> Result,
         visitAssignment: @escaping @Sendable (Assignment) -> Result,
         visitVariableDeclaration: @escaping @Sendable (VariableDeclaration) -> Result,
@@ -89,6 +93,7 @@ public struct StatementVisitor<Result>: Sendable where Result: Sendable {
     ) {
         self.visitIfStatement = visitIfStatement
         self.visitWhileStatement = visitWhileStatement
+        self.visitDoWhileStatement = visitDoWhileStatement
         self.visitForStatement = visitForStatement
         self.visitAssignment = visitAssignment
         self.visitVariableDeclaration = visitVariableDeclaration
@@ -114,6 +119,8 @@ public struct StatementVisitor<Result>: Sendable where Result: Sendable {
             return visitIfStatement(ifStmt)
         case .whileStatement(let whileStmt):
             return visitWhileStatement(whileStmt)
+        case .doWhileStatement(let doWhileStmt):
+            return visitDoWhileStatement(doWhileStmt)
         case .forStatement(let forStmt):
             return visitForStatement(forStmt)
         case .assignment(let assignment):

--- a/Sources/FeLangRuntime/StatementExecutor.swift
+++ b/Sources/FeLangRuntime/StatementExecutor.swift
@@ -391,8 +391,15 @@ public final class StatementExecutor: @unchecked Sendable {
 
         repeat {
             // Execute body in its own scope (consistent with while/for loops)
+            // Use do-catch to ensure popScope is called even on exception
             try environment.pushScope()
-            let result = try execute(doWhileStmt.body)
+            let result: ControlFlow
+            do {
+                result = try execute(doWhileStmt.body)
+            } catch {
+                environment.popScope()
+                throw error
+            }
             environment.popScope()
 
             switch result {

--- a/Sources/FeLangRuntime/StatementExecutor.swift
+++ b/Sources/FeLangRuntime/StatementExecutor.swift
@@ -87,6 +87,9 @@ public final class StatementExecutor: @unchecked Sendable {
         case .whileStatement(let whileStmt):
             return try executeWhileStatement(whileStmt)
 
+        case .doWhileStatement(let doWhileStmt):
+            return try executeDoWhileStatement(doWhileStmt)
+
         case .forStatement(let forStmt):
             return try executeForStatement(forStmt)
 
@@ -380,6 +383,38 @@ public final class StatementExecutor: @unchecked Sendable {
         }
 
         return .normal
+    }
+
+    private func executeDoWhileStatement(_ doWhileStmt: DoWhileStatement) throws -> ControlFlow {
+        loopDepth += 1
+        defer { loopDepth -= 1 }
+
+        repeat {
+            try environment.pushScope()
+            defer { environment.popScope() }
+            let result = try execute(doWhileStmt.body)
+
+            switch result {
+            case .breakLoop:
+                return .normal
+            case .continueLoop:
+                break
+            case .returnValue:
+                return result
+            case .normal:
+                break
+            }
+
+            let condition = try evaluator.evaluate(doWhileStmt.condition)
+            guard case .boolean(let boolValue) = condition else {
+                throw RuntimeError.typeMismatch(
+                    expected: "Boolean",
+                    actual: condition.typeName,
+                    operation: "do-while condition"
+                )
+            }
+            guard boolValue else { return .normal }
+        } while true
     }
 
     private func executeForStatement(_ forStmt: ForStatement) throws -> ControlFlow {

--- a/Sources/FeLangRuntime/StatementExecutor.swift
+++ b/Sources/FeLangRuntime/StatementExecutor.swift
@@ -390,9 +390,10 @@ public final class StatementExecutor: @unchecked Sendable {
         defer { loopDepth -= 1 }
 
         repeat {
+            // Execute body in its own scope (consistent with while/for loops)
             try environment.pushScope()
-            defer { environment.popScope() }
             let result = try execute(doWhileStmt.body)
+            environment.popScope()
 
             switch result {
             case .breakLoop:
@@ -405,6 +406,7 @@ public final class StatementExecutor: @unchecked Sendable {
                 break
             }
 
+            // Evaluate condition outside the body scope (consistent with while loops)
             let condition = try evaluator.evaluate(doWhileStmt.condition)
             guard case .boolean(let boolValue) = condition else {
                 throw RuntimeError.typeMismatch(

--- a/Sources/FeLangServer/HoverProvider.swift
+++ b/Sources/FeLangServer/HoverProvider.swift
@@ -17,7 +17,7 @@ public struct HoverProvider: Sendable {
 
         // Loops
         "while": "**while** - While loop\n\nRepeats code while a condition is true.\n\n```fe\nwhile condition do\n    // code\nendwhile\n```",
-        "do": "**do** - Do clause\n\nMarks the beginning of a loop body.",
+        "do": "**do** - Do clause\n\nMarks the beginning of a loop body in while/for loops.\n\nAlso starts a do-while loop:\n\n```fe\ndo\n    // code (executes at least once)\nwhile (condition)\n```",
         "endwhile": "**endwhile** - End while\n\nMarks the end of a while loop.",
         "for": "**for** - For loop\n\nIterates over a range or collection.\n\n```fe\nfor i ← 1 to 10 do\n    // code\nendfor\n```",
         "to": "**to** - Range end\n\nSpecifies the end of a range in a for loop.",

--- a/Tests/FeLangCoreTests/Parser/StatementParserTests.swift
+++ b/Tests/FeLangCoreTests/Parser/StatementParserTests.swift
@@ -162,6 +162,85 @@ struct StatementParserTests {
         #expect(whileStmt.body.count == 1)
     }
 
+    // MARK: - DO-WHILE Statement Tests
+
+    @Test("Basic DO-WHILE Statement")
+    func testBasicDoWhileStatement() throws {
+        let statements = try parseStatements("do i ← i + 1 while (i < 10)")
+
+        #expect(statements.count == 1)
+        guard case .doWhileStatement(let doWhileStmt) = statements[0] else {
+            #expect(Bool(false), "Expected DO-WHILE statement")
+            return
+        }
+
+        #expect(doWhileStmt.condition == .binary(.less, .identifier("i"), .literal(.integer(10))))
+        #expect(doWhileStmt.body.count == 1)
+    }
+
+    @Test("DO-WHILE Statement with Multiple Body Statements")
+    func testDoWhileStatementWithMultipleBodyStatements() throws {
+        let input = """
+        do
+            x ← x + 1
+            writeLine(x)
+        while (x < 5)
+        """
+        let statements = try parseStatements(input)
+
+        #expect(statements.count == 1)
+        guard case .doWhileStatement(let doWhileStmt) = statements[0] else {
+            #expect(Bool(false), "Expected DO-WHILE statement")
+            return
+        }
+
+        #expect(doWhileStmt.body.count == 2)
+        #expect(doWhileStmt.condition == .binary(.less, .identifier("x"), .literal(.integer(5))))
+    }
+
+    @Test("DO-WHILE Statement with Complex Condition")
+    func testDoWhileStatementWithComplexCondition() throws {
+        let statements = try parseStatements("do x ← x + 1 while (x < 10 and y > 0)")
+
+        #expect(statements.count == 1)
+        guard case .doWhileStatement(let doWhileStmt) = statements[0] else {
+            #expect(Bool(false), "Expected DO-WHILE statement")
+            return
+        }
+
+        guard case .binary(.and, _, _) = doWhileStmt.condition else {
+            #expect(Bool(false), "Expected AND condition")
+            return
+        }
+    }
+
+    @Test("Nested DO-WHILE Statements")
+    func testNestedDoWhileStatements() throws {
+        let input = """
+        do
+            do
+                x ← x + 1
+            while (x < 5)
+        while (y < 10)
+        """
+        let statements = try parseStatements(input)
+
+        #expect(statements.count == 1)
+        guard case .doWhileStatement(let outerDoWhile) = statements[0] else {
+            #expect(Bool(false), "Expected outer DO-WHILE statement")
+            return
+        }
+
+        #expect(outerDoWhile.body.count == 1)
+        guard case .doWhileStatement(let innerDoWhile) = outerDoWhile.body[0] else {
+            #expect(Bool(false), "Expected inner DO-WHILE statement")
+            return
+        }
+
+        #expect(innerDoWhile.condition == .binary(.less, .identifier("x"), .literal(.integer(5))))
+        #expect(outerDoWhile.condition == .binary(.less, .identifier("y"), .literal(.integer(10))))
+    }
+
     // MARK: - FOR Statement Tests
 
     @Test("Range-based FOR Statement")

--- a/Tests/FeLangCoreTests/Parser/StatementParserTests.swift
+++ b/Tests/FeLangCoreTests/Parser/StatementParserTests.swift
@@ -241,6 +241,40 @@ struct StatementParserTests {
         #expect(outerDoWhile.condition == .binary(.less, .identifier("y"), .literal(.integer(10))))
     }
 
+    @Test("DO-WHILE with Nested While Loop")
+    func testDoWhileWithNestedWhileLoop() throws {
+        // This tests that a nested while loop inside do-while is correctly parsed
+        // The parser must distinguish between `while condition do` (nested while loop)
+        // and `while (condition)` (terminating condition of do-while)
+        let input = """
+        do
+            while x < 5 do
+                x ← x + 1
+            endwhile
+        while (y < 10)
+        """
+        let statements = try parseStatements(input)
+
+        #expect(statements.count == 1)
+        guard case .doWhileStatement(let doWhileStmt) = statements[0] else {
+            #expect(Bool(false), "Expected DO-WHILE statement")
+            return
+        }
+
+        // The body should contain the nested while loop
+        #expect(doWhileStmt.body.count == 1)
+        guard case .whileStatement(let nestedWhile) = doWhileStmt.body[0] else {
+            #expect(Bool(false), "Expected nested WHILE statement in do-while body")
+            return
+        }
+
+        // Verify the nested while loop's condition
+        #expect(nestedWhile.condition == .binary(.less, .identifier("x"), .literal(.integer(5))))
+
+        // Verify the do-while's terminating condition
+        #expect(doWhileStmt.condition == .binary(.less, .identifier("y"), .literal(.integer(10))))
+    }
+
     // MARK: - FOR Statement Tests
 
     @Test("Range-based FOR Statement")

--- a/Tests/FeLangCoreTests/Visitor/StatementVisitorTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/StatementVisitorTests.swift
@@ -10,6 +10,7 @@ struct StatementVisitorTests {
         let visitor = StatementVisitor<String>(
             visitIfStatement: { ifStmt in "if(\(ifStmt.condition))" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { _ in "for" },
             visitAssignment: { _ in "assignment" },
             visitVariableDeclaration: { _ in "var_decl" },
@@ -39,6 +40,7 @@ struct StatementVisitorTests {
         let visitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { whileStmt in "while(\(whileStmt.condition))" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { _ in "for" },
             visitAssignment: { _ in "assignment" },
             visitVariableDeclaration: { _ in "var_decl" },
@@ -68,6 +70,7 @@ struct StatementVisitorTests {
         let visitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { forStmt in
                 switch forStmt {
                 case .range(let rangeFor):
@@ -113,6 +116,7 @@ struct StatementVisitorTests {
         let visitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { _ in "for" },
             visitAssignment: { assignment in
                 switch assignment {
@@ -149,6 +153,7 @@ struct StatementVisitorTests {
         let visitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { _ in "for" },
             visitAssignment: { _ in "assignment" },
             visitVariableDeclaration: { varDecl in "var(\(varDecl.name))" },
@@ -197,6 +202,7 @@ struct StatementVisitorTests {
         let visitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { _ in "for" },
             visitAssignment: { _ in "assignment" },
             visitVariableDeclaration: { _ in "var_decl" },
@@ -247,6 +253,9 @@ struct StatementVisitorTests {
             case .whileStatement(let whileStmt):
                 let body = whileStmt.body.map(stringifyStatement).joined(separator: "; ")
                 return "while (\(whileStmt.condition)) { \(body) }"
+            case .doWhileStatement(let doWhileStmt):
+                let body = doWhileStmt.body.map(stringifyStatement).joined(separator: "; ")
+                return "do { \(body) } while (\(doWhileStmt.condition))"
             case .forStatement(let forStmt):
                 switch forStmt {
                 case .range(let rangeFor):
@@ -323,6 +332,7 @@ struct StatementVisitorTests {
         let visitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { _ in "for" },
             visitAssignment: { _ in "assignment" },
             visitVariableDeclaration: { _ in "var_decl" },
@@ -353,6 +363,7 @@ struct StatementVisitorTests {
         let visitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { _ in "for" },
             visitAssignment: { _ in "assignment" },
             visitVariableDeclaration: { _ in "var_decl" },
@@ -388,6 +399,8 @@ struct StatementVisitorTests {
                 return 1 + ifStmt.thenBody.map(countStatements).reduce(0, +)
             case .whileStatement(let whileStmt):
                 return 1 + whileStmt.body.map(countStatements).reduce(0, +)
+            case .doWhileStatement(let doWhileStmt):
+                return 1 + doWhileStmt.body.map(countStatements).reduce(0, +)
             case .forStatement(let forStmt):
                 let body: [Statement]
                 switch forStmt {

--- a/Tests/FeLangCoreTests/Visitor/VisitableTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/VisitableTests.swift
@@ -31,6 +31,7 @@ struct VisitableTests {
         let visitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { _ in "for" },
             visitAssignment: { _ in "assignment" },
             visitVariableDeclaration: { _ in "var_decl" },
@@ -90,6 +91,7 @@ struct VisitableTests {
         let visitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { forStmt in
                 switch forStmt {
                 case .range: return "for_range"
@@ -174,6 +176,7 @@ struct VisitableTests {
         let stmtVisitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { _ in "for" },
             visitAssignment: { _ in "assignment" },
             visitVariableDeclaration: { _ in "var_decl" },
@@ -214,6 +217,7 @@ struct VisitableTests {
         let stmtVisitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { _ in "for" },
             visitAssignment: { _ in "assignment" },
             visitVariableDeclaration: { _ in "var_decl" },
@@ -255,6 +259,7 @@ struct VisitableTests {
         let stmtVisitor = StatementVisitor<String>(
             visitIfStatement: { _ in "if" },
             visitWhileStatement: { _ in "while" },
+            visitDoWhileStatement: { _ in "do_while" },
             visitForStatement: { _ in "for" },
             visitAssignment: { _ in "assignment" },
             visitVariableDeclaration: { _ in "var_decl" },

--- a/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
@@ -632,6 +632,109 @@ struct StatementExecutorTests {
         #expect(env.lookup("sum") == .integer(9))
     }
 
+    @Test func testDoWhileLoop() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        env.define("count", value: .integer(0))
+
+        let increment = Statement.assignment(.variable(
+            "count",
+            .binary(.add, .identifier("count"), .literal(.integer(1)))
+        ))
+
+        let doWhileStmt = DoWhileStatement(
+            body: [increment],
+            condition: .binary(.less, .identifier("count"), .literal(.integer(5)))
+        )
+
+        _ = try executor.executeStatement(.doWhileStatement(doWhileStmt))
+        #expect(env.lookup("count") == .integer(5))
+    }
+
+    @Test func testDoWhileLoopExecutesAtLeastOnce() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        env.define("count", value: .integer(0))
+
+        let increment = Statement.assignment(.variable(
+            "count",
+            .binary(.add, .identifier("count"), .literal(.integer(1)))
+        ))
+
+        let doWhileStmt = DoWhileStatement(
+            body: [increment],
+            condition: .literal(.boolean(false))
+        )
+
+        _ = try executor.executeStatement(.doWhileStatement(doWhileStmt))
+        #expect(env.lookup("count") == .integer(1))
+    }
+
+    @Test func testDoWhileLoopBreak() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        env.define("count", value: .integer(0))
+
+        let increment = Statement.assignment(.variable(
+            "count",
+            .binary(.add, .identifier("count"), .literal(.integer(1)))
+        ))
+
+        let ifBreak = Statement.ifStatement(IfStatement(
+            condition: .binary(.equal, .identifier("count"), .literal(.integer(3))),
+            thenBody: [.breakStatement],
+            elseIfs: [],
+            elseBody: nil
+        ))
+
+        let doWhileStmt = DoWhileStatement(
+            body: [increment, ifBreak],
+            condition: .literal(.boolean(true))
+        )
+
+        _ = try executor.executeStatement(.doWhileStatement(doWhileStmt))
+        #expect(env.lookup("count") == .integer(3))
+    }
+
+    @Test func testDoWhileLoopContinue() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        env.define("count", value: .integer(0))
+        env.define("sum", value: .integer(0))
+
+        let incrementCount = Statement.assignment(.variable(
+            "count",
+            .binary(.add, .identifier("count"), .literal(.integer(1)))
+        ))
+
+        let ifContinue = Statement.ifStatement(IfStatement(
+            condition: .binary(.equal,
+                               .binary(.modulo, .identifier("count"), .literal(.integer(2))),
+                               .literal(.integer(0))),
+            thenBody: [.continueStatement],
+            elseIfs: [],
+            elseBody: nil
+        ))
+
+        let addToSum = Statement.assignment(.variable(
+            "sum",
+            .binary(.add, .identifier("sum"), .identifier("count"))
+        ))
+
+        let doWhileStmt = DoWhileStatement(
+            body: [incrementCount, ifContinue, addToSum],
+            condition: .binary(.less, .identifier("count"), .literal(.integer(5)))
+        )
+
+        _ = try executor.executeStatement(.doWhileStatement(doWhileStmt))
+        // sum = 1 + 3 + 5 = 9 (skipping 2 and 4)
+        #expect(env.lookup("sum") == .integer(9))
+    }
+
     @Test func testBreakOutsideLoopError() throws {
         let env = Environment()
         let executor = StatementExecutor(environment: env)


### PR DESCRIPTION
# feat: add do-while loop support

## Summary
Implements post-condition loop syntax (`do ... while (condition)`) as specified in issue #357. The do-while loop executes its body at least once before checking the condition, unlike a regular while loop.

Changes span the full compiler pipeline:
- **AST**: Added `DoWhileStatement` struct and `Statement.doWhileStatement` case
- **Parser**: Added parsing for `do <body> while (condition)` syntax
- **Semantic Analysis**: Added three-pass analysis (symbol collection, type checking, validation)
- **Runtime**: Implemented execution with proper break/continue/return handling
- **Visitor Pattern**: Updated `StatementVisitor` and `ASTWalker` with do-while support
- **Pretty Printer**: Added formatting output for do-while statements
- **Language Server**: Enhanced hover documentation for the `do` keyword

## Review & Testing Checklist for Human
- [ ] **Verify syntax matches requirements**: Confirm the parsed syntax `do <body> while (condition)` matches what was specified in issue #357 - the issue should define the exact expected syntax
- [ ] **Test E2E from source code**: The tests construct AST nodes directly. Manually test parsing and executing a do-while program from actual FE source code to verify the full pipeline works
- [ ] **Verify continue behavior**: When `continue` is used inside a do-while, it should skip to the condition check (not restart the body). Test: `do { i ← i + 1; if i = 2 then continue; sum ← sum + i } while (i < 5)`
- [ ] **Check error position reporting**: In `SemanticAnalyzer.swift:571`, the error position is hardcoded to `(0,0,0)` - type mismatch errors for do-while conditions won't show the correct location

### Recommended Test Plan
```fe
変数 count: 整数型 ← 0
do
    count ← count + 1
    writeLine(count)
while (count < 3)
```
Expected output: 1, 2, 3 (body executes at least once, then checks condition)

### Notes
- All 1235 existing tests pass
- SwiftLint passes with no violations
- The `do` keyword already existed in the tokenizer (used for while-do loops), so no tokenizer changes were needed

Closes #357

---
Link to Devin run: https://app.devin.ai/sessions/21c4463acba84735a9cfd43eb27e5ef0
Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/375">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * DO-WHILEループ構文を追加しました。ループ本体を最初に実行してから条件を評価する制御フロー機能が利用可能になります。

* **Documentation**
  * 「do」キーワードのホバードキュメントを更新し、DO-WHILEループの説明を追加しました。

* **Tests**
  * DO-WHILEループの包括的なテストカバレッジを追加しました。基本的な使用方法、複数ステートメント、ネストされたループ、ブレーク/コンティニュー動作を含みます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->