### PR TITLE
feat: support brace-based array literal syntax {1, 2, 3}

### DIFF
--- a/Sources/FeLangCore/Expression/ExpressionParser.swift
+++ b/Sources/FeLangCore/Expression/ExpressionParser.swift
@@ -160,6 +160,29 @@ public struct ExpressionParser {
             return Expression.arrayLiteral(elements)
         }
 
+        // Array literal expressions {e1, e2, ...} (FE pseudo-language syntax)
+        if token.type == .leftBrace {
+            var elements: [Expression] = []
+
+            // Handle empty array literal {}
+            if parser.peek()?.type == .rightBrace {
+                _ = parser.advance() // consume '}'
+                return Expression.arrayLiteral(elements)
+            }
+
+            // Parse first element
+            elements.append(try parseExpression(&parser))
+
+            // Parse remaining elements
+            while parser.peek()?.type == .comma {
+                _ = parser.advance() // consume ','
+                elements.append(try parseExpression(&parser))
+            }
+
+            try expectToken(&parser, .rightBrace)
+            return Expression.arrayLiteral(elements)
+        }
+
         throw ParsingError.expectedPrimaryExpression(token)
     }
 

--- a/Sources/FeLangCore/Parser/StatementParser.swift
+++ b/Sources/FeLangCore/Parser/StatementParser.swift
@@ -853,10 +853,11 @@ public struct StatementParser {
         // Get the starting position
         let startIndex = parser.index
 
-        // Find the end of the expression using balanced parentheses/brackets
+        // Find the end of the expression using balanced parentheses/brackets/braces
         var endIndex = startIndex
         var parenDepth = 0
         var bracketDepth = 0
+        var braceDepth = 0
 
         // Scan forward to find expression boundary
         var scanIndex = startIndex
@@ -870,7 +871,7 @@ public struct StatementParser {
                 break
             }
 
-            // Track parentheses and bracket depth
+            // Track parentheses, bracket, and brace depth
             if tokenType == .leftParen {
                 parenDepth += 1
             } else if tokenType == .rightParen {
@@ -887,16 +888,24 @@ public struct StatementParser {
                     endIndex = scanIndex
                     break
                 }
+            } else if tokenType == .leftBrace {
+                braceDepth += 1
+            } else if tokenType == .rightBrace {
+                braceDepth -= 1
+                if braceDepth < 0 {
+                    endIndex = scanIndex
+                    break
+                }
             }
 
-            // Stop at statement terminators only when we're not inside parentheses/brackets
-            if parenDepth == 0 && bracketDepth == 0 && isStatementTerminator(tokenType) {
+            // Stop at statement terminators only when we're not inside parentheses/brackets/braces
+            if parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 && isStatementTerminator(tokenType) {
                 endIndex = scanIndex
                 break
             }
 
             // Also stop if we detect the start of a new statement (when newlines are filtered out)
-            if parenDepth == 0 && bracketDepth == 0 && scanIndex > startIndex && isStartOfNewStatement(parser, at: scanIndex) {
+            if parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 && scanIndex > startIndex && isStartOfNewStatement(parser, at: scanIndex) {
                 endIndex = scanIndex
                 break
             }

--- a/Tests/FeLangCoreTests/Expression/ArrayLiteralTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ArrayLiteralTests.swift
@@ -306,4 +306,46 @@ struct ArrayLiteralTests {
             return
         }
     }
+
+    // MARK: - Mixed Bracket-Brace Nesting Tests
+
+    @Test func bracketContainingBraceArrays() throws {
+        let expr = try parseExpression("[{1, 2}, {3, 4}]")
+
+        guard case .arrayLiteral(let elements) = expr else {
+            Issue.record("Expected arrayLiteral but got \(expr)")
+            return
+        }
+
+        #expect(elements.count == 2)
+
+        guard case .arrayLiteral(let firstArray) = elements[0],
+              case .arrayLiteral(let secondArray) = elements[1] else {
+            Issue.record("Expected nested array literals")
+            return
+        }
+
+        #expect(firstArray.count == 2)
+        #expect(secondArray.count == 2)
+    }
+
+    @Test func braceContainingBracketArrays() throws {
+        let expr = try parseExpression("{[1, 2], [3, 4]}")
+
+        guard case .arrayLiteral(let elements) = expr else {
+            Issue.record("Expected arrayLiteral but got \(expr)")
+            return
+        }
+
+        #expect(elements.count == 2)
+
+        guard case .arrayLiteral(let firstArray) = elements[0],
+              case .arrayLiteral(let secondArray) = elements[1] else {
+            Issue.record("Expected nested array literals")
+            return
+        }
+
+        #expect(firstArray.count == 2)
+        #expect(secondArray.count == 2)
+    }
 }

--- a/Tests/FeLangCoreTests/Expression/ArrayLiteralTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ArrayLiteralTests.swift
@@ -207,4 +207,103 @@ struct ArrayLiteralTests {
         let result = printer.print(expr)
         #expect(result == "[[1, 2], [3, 4]]")
     }
+
+    // MARK: - Brace-based Array Literal Tests (FE pseudo-language syntax)
+
+    @Test func emptyBraceArrayLiteral() throws {
+        let expr = try parseExpression("{}")
+
+        guard case .arrayLiteral(let elements) = expr else {
+            Issue.record("Expected arrayLiteral but got \(expr)")
+            return
+        }
+
+        #expect(elements.isEmpty)
+    }
+
+    @Test func singleIntegerElementBrace() throws {
+        let expr = try parseExpression("{42}")
+
+        guard case .arrayLiteral(let elements) = expr else {
+            Issue.record("Expected arrayLiteral but got \(expr)")
+            return
+        }
+
+        #expect(elements.count == 1)
+        guard case .literal(.integer(42)) = elements[0] else {
+            Issue.record("Expected integer literal 42 but got \(elements[0])")
+            return
+        }
+    }
+
+    @Test func multipleIntegerElementsBrace() throws {
+        let expr = try parseExpression("{12, 34, 56}")
+
+        guard case .arrayLiteral(let elements) = expr else {
+            Issue.record("Expected arrayLiteral but got \(expr)")
+            return
+        }
+
+        #expect(elements.count == 3)
+        guard case .literal(.integer(12)) = elements[0],
+              case .literal(.integer(34)) = elements[1],
+              case .literal(.integer(56)) = elements[2] else {
+            Issue.record("Expected integer literals 12, 34, 56")
+            return
+        }
+    }
+
+    @Test func nestedBraceArrayLiteral() throws {
+        let expr = try parseExpression("{{1, 2}, {3, 4}}")
+
+        guard case .arrayLiteral(let elements) = expr else {
+            Issue.record("Expected arrayLiteral but got \(expr)")
+            return
+        }
+
+        #expect(elements.count == 2)
+
+        guard case .arrayLiteral(let firstArray) = elements[0],
+              case .arrayLiteral(let secondArray) = elements[1] else {
+            Issue.record("Expected nested array literals")
+            return
+        }
+
+        #expect(firstArray.count == 2)
+        #expect(secondArray.count == 2)
+    }
+
+    @Test func braceArrayWithExpressions() throws {
+        let expr = try parseExpression("{1 + 2, 3 * 4}")
+
+        guard case .arrayLiteral(let elements) = expr else {
+            Issue.record("Expected arrayLiteral but got \(expr)")
+            return
+        }
+
+        #expect(elements.count == 2)
+
+        guard case .binary(.add, _, _) = elements[0],
+              case .binary(.multiply, _, _) = elements[1] else {
+            Issue.record("Expected binary expressions")
+            return
+        }
+    }
+
+    @Test func braceArrayWithIdentifiers() throws {
+        let expr = try parseExpression("{x, y, z}")
+
+        guard case .arrayLiteral(let elements) = expr else {
+            Issue.record("Expected arrayLiteral but got \(expr)")
+            return
+        }
+
+        #expect(elements.count == 3)
+        guard case .identifier("x") = elements[0],
+              case .identifier("y") = elements[1],
+              case .identifier("z") = elements[2] else {
+            Issue.record("Expected identifiers x, y, z")
+            return
+        }
+    }
 }


### PR DESCRIPTION
Closes #356

## Summary

Adds support for FE pseudo-language array literal syntax using curly braces (`{1, 2, 3}`), which is now parsed as an `arrayLiteral` node equivalent to the existing bracket syntax (`[1, 2, 3]`). Both empty arrays (`{}`) and arrays with elements are supported.

The implementation adds a new branch in `parsePrimaryExpression` that handles `.leftBrace` tokens, mirroring the existing `.leftBracket` logic. Since both syntaxes produce the same AST node, no runtime changes are required.

## Review & Testing Checklist for Human

- [ ] Verify that brace syntax won't conflict with future record literal syntax if that's planned
- [ ] Test mixed nesting scenarios like `[{1, 2}, {3, 4}]` or `{[1, 2], [3, 4]}` to ensure they work correctly
- [ ] Confirm that PrettyPrinter outputting `[]` for arrays originally written as `{}` is acceptable behavior

**Suggested test plan**: Parse the examples from the issue (`{12, 34, 56}` and `{}`) and verify they produce the expected `arrayLiteral` AST nodes.

### Notes

- Link to Devin run: https://app.devin.ai/sessions/0f12b6bb88a44609a921f3483402cea1
- Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/376">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- 配列リテラルで波括弧 {} 構文をサポート。既存の角括弧 [] 構文に加えて利用可能
- 空の波括弧 {} で空配列を作成
- コンマ区切りの要素をサポート。ネストされた配列、式、識別子に対応

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->