### PR TITLE
Implement method call expression support

### DIFF
--- a/Sources/FeLangCore/Expression/Expression.swift
+++ b/Sources/FeLangCore/Expression/Expression.swift
@@ -16,6 +16,7 @@ public indirect enum Expression: Equatable, Codable, Sendable {
     case arrayAccess(Expression, Expression)
     case fieldAccess(Expression, String)
     case functionCall(String, [Expression])
+    case methodCall(Expression, String, [Expression])
 
     // Collection expressions
     case arrayLiteral([Expression])

--- a/Sources/FeLangCore/Expression/ExpressionParser.swift
+++ b/Sources/FeLangCore/Expression/ExpressionParser.swift
@@ -92,12 +92,20 @@ public struct ExpressionParser {
 
                 try expectToken(&parser, .rightBracket)
             } else if parser.peek()?.type == .dot {
-                // Field access: expr.field
+                // Field access or method call: expr.field or expr.method(args)
                 _ = parser.advance() // consume '.'
                 guard let fieldToken = parser.advance(), fieldToken.type == .identifier else {
                     throw ParsingError.expectedIdentifier
                 }
-                expr = Expression.fieldAccess(expr, fieldToken.lexeme)
+                // Check if this is a method call (followed by '(')
+                if parser.peek()?.type == .leftParen {
+                    _ = parser.advance() // consume '('
+                    let args = try parseArgumentList(&parser)
+                    try expectToken(&parser, .rightParen)
+                    expr = Expression.methodCall(expr, fieldToken.lexeme, args)
+                } else {
+                    expr = Expression.fieldAccess(expr, fieldToken.lexeme)
+                }
             } else if parser.peek()?.type == .leftParen,
                       case .identifier(let name) = expr {
                 // Function call: identifier(args...)

--- a/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
+++ b/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
@@ -153,6 +153,9 @@ public struct PrettyPrinter {
         case .functionCall(let name, let args):
             return printFunctionCall(name: name, args: args, indent: indent)
 
+        case .methodCall(let receiver, let method, let args):
+            return printMethodCall(receiver: receiver, method: method, args: args, indent: indent)
+
         case .arrayLiteral(let elements):
             return printArrayLiteral(elements: elements, indent: indent)
         }
@@ -173,6 +176,24 @@ public struct PrettyPrinter {
 
         // Multi-line format with wrapping
         return wrapItems(argStrings, separator: ", ", indent: indent, prefix: "\(name)(", suffix: ")")
+    }
+
+    /// Prints a method call with optional line wrapping.
+    private func printMethodCall(receiver: Expression, method: String, args: [Expression], indent: Int) -> String {
+        let receiverStr = printExpression(receiver, indent: indent)
+        if args.isEmpty {
+            return "\(receiverStr).\(method)()"
+        }
+
+        let argStrings = args.map { printExpression($0, indent: indent + 1) }
+        let singleLine = "\(receiverStr).\(method)(\(argStrings.joined(separator: ", ")))"
+
+        if !shouldWrap(singleLine, currentIndent: indent) {
+            return singleLine
+        }
+
+        // Multi-line format with wrapping
+        return wrapItems(argStrings, separator: ", ", indent: indent, prefix: "\(receiverStr).\(method)(", suffix: ")")
     }
 
     /// Prints an array literal with optional line wrapping.

--- a/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
+++ b/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
@@ -771,6 +771,8 @@ public final class SemanticAnalyzer: @unchecked Sendable {
             return inferFieldAccessType(object, field: field, depth: depth + 1)
         case .functionCall(let name, let arguments):
             return inferFunctionCallType(name, arguments: arguments, depth: depth + 1)
+        case .methodCall(let receiver, _, let arguments):
+            return inferMethodCallType(receiver, arguments: arguments, depth: depth + 1)
         case .arrayLiteral(let elements):
             return inferArrayLiteralType(elements, depth: depth + 1)
         }
@@ -1021,6 +1023,17 @@ public final class SemanticAnalyzer: @unchecked Sendable {
         _ = symbolTable.markAsUsed(name, position: position)
 
         return returnType ?? .void
+    }
+
+    private func inferMethodCallType(_ receiver: Expression, arguments: [Expression], depth: Int) -> FeType {
+        // Infer receiver type and argument types for basic type checking
+        _ = inferExpressionType(receiver, depth: depth)
+        for argument in arguments {
+            _ = inferExpressionType(argument, depth: depth)
+        }
+        // Method call type inference is deferred to runtime since class definitions
+        // are not yet fully implemented. Return unknown type for now.
+        return .unknown
     }
 
     // MARK: - Pass 3: Semantic Validation

--- a/Sources/FeLangCore/Visitor/ASTWalker.swift
+++ b/Sources/FeLangCore/Visitor/ASTWalker.swift
@@ -49,6 +49,13 @@ public enum ASTWalker {
                     result.union(collectIdentifiers(from: arg))
                 }
             },
+            visitMethodCall: { receiver, _, arguments in
+                var identifiers = collectIdentifiers(from: receiver)
+                identifiers.formUnion(arguments.reduce(Set<String>()) { result, arg in
+                    result.union(collectIdentifiers(from: arg))
+                })
+                return identifiers
+            },
             visitArrayLiteral: { elements in
                 elements.reduce(Set<String>()) { result, element in
                     result.union(collectIdentifiers(from: element))
@@ -81,6 +88,11 @@ public enum ASTWalker {
             },
             visitFunctionCall: { _, arguments in
                 1 + arguments.reduce(0) { result, arg in
+                    result + countNodes(in: arg)
+                }
+            },
+            visitMethodCall: { receiver, _, arguments in
+                1 + countNodes(in: receiver) + arguments.reduce(0) { result, arg in
                     result + countNodes(in: arg)
                 }
             },
@@ -129,6 +141,11 @@ public enum ASTWalker {
             visitFunctionCall: { name, arguments in
                 let transformedArguments = arguments.map { transformExpression($0, transform) }
                 return transform(.functionCall(name, transformedArguments))
+            },
+            visitMethodCall: { receiver, method, arguments in
+                let transformedReceiver = transformExpression(receiver, transform)
+                let transformedArguments = arguments.map { transformExpression($0, transform) }
+                return transform(.methodCall(transformedReceiver, method, transformedArguments))
             },
             visitArrayLiteral: { elements in
                 let transformedElements = elements.map { transformExpression($0, transform) }

--- a/Sources/FeLangCore/Visitor/ExpressionVisitor.swift
+++ b/Sources/FeLangCore/Visitor/ExpressionVisitor.swift
@@ -69,6 +69,13 @@ public struct ExpressionVisitor<Result>: Sendable where Result: Sendable {
     ///   - arguments: The argument expressions
     public let visitFunctionCall: @Sendable (String, [Expression]) -> Result
 
+    /// Visits method call expressions.
+    /// - Parameters:
+    ///   - receiver: The receiver expression (object on which method is called)
+    ///   - method: The method name being called
+    ///   - arguments: The argument expressions
+    public let visitMethodCall: @Sendable (Expression, String, [Expression]) -> Result
+
     /// Visits array literal expressions.
     /// - Parameter elements: The array elements
     public let visitArrayLiteral: @Sendable ([Expression]) -> Result
@@ -84,6 +91,7 @@ public struct ExpressionVisitor<Result>: Sendable where Result: Sendable {
         visitArrayAccess: @escaping @Sendable (Expression, Expression) -> Result,
         visitFieldAccess: @escaping @Sendable (Expression, String) -> Result,
         visitFunctionCall: @escaping @Sendable (String, [Expression]) -> Result,
+        visitMethodCall: @escaping @Sendable (Expression, String, [Expression]) -> Result,
         visitArrayLiteral: @escaping @Sendable ([Expression]) -> Result
     ) {
         self.visitLiteral = visitLiteral
@@ -93,6 +101,7 @@ public struct ExpressionVisitor<Result>: Sendable where Result: Sendable {
         self.visitArrayAccess = visitArrayAccess
         self.visitFieldAccess = visitFieldAccess
         self.visitFunctionCall = visitFunctionCall
+        self.visitMethodCall = visitMethodCall
         self.visitArrayLiteral = visitArrayLiteral
     }
 
@@ -117,6 +126,8 @@ public struct ExpressionVisitor<Result>: Sendable where Result: Sendable {
             return visitFieldAccess(object, field)
         case .functionCall(let function, let arguments):
             return visitFunctionCall(function, arguments)
+        case .methodCall(let receiver, let method, let arguments):
+            return visitMethodCall(receiver, method, arguments)
         case .arrayLiteral(let elements):
             return visitArrayLiteral(elements)
         }

--- a/Sources/FeLangRuntime/ExpressionEvaluator.swift
+++ b/Sources/FeLangRuntime/ExpressionEvaluator.swift
@@ -55,6 +55,9 @@ public struct ExpressionEvaluator: Sendable {
             let args = try arguments.map { try evaluate($0) }
             return try callFunction(name, args)
 
+        case .methodCall(_, let method, _):
+            throw RuntimeError.methodCallNotSupported(method: method)
+
         case .arrayLiteral(let elements):
             return try evaluateArrayLiteral(elements)
         }

--- a/Sources/FeLangRuntime/RuntimeError.swift
+++ b/Sources/FeLangRuntime/RuntimeError.swift
@@ -50,6 +50,9 @@ public enum RuntimeError: Error, Equatable, CustomStringConvertible {
     /// Not a callable value
     case notCallable(type: String)
 
+    /// Method call not supported (class definitions not yet implemented)
+    case methodCallNotSupported(method: String)
+
     /// Generic runtime error
     case generic(message: String)
 
@@ -104,6 +107,9 @@ public enum RuntimeError: Error, Equatable, CustomStringConvertible {
 
         case .notCallable(let type):
             return "Runtime error: Value of type '\(type)' is not callable"
+
+        case .methodCallNotSupported(let method):
+            return "Runtime error: Method call '\(method)' is not supported (class definitions not yet implemented)"
 
         case .generic(let message):
             return "Runtime error: \(message)"

--- a/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
@@ -660,4 +660,19 @@ struct ExpressionParserTests {
         let expected = Expression.methodCall(.identifier("list"), "size", [])
         #expect(expr == expected)
     }
+
+    @Test func testMethodCallCodableRoundTrip() throws {
+        let original = FEExpression.methodCall(
+            .identifier("obj"),
+            "getValue",
+            [.literal(.integer(1)), .identifier("x")]
+        )
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let data = try encoder.encode(original)
+        let decoded = try decoder.decode(FEExpression.self, from: data)
+
+        #expect(decoded == original)
+    }
 }

--- a/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
@@ -588,4 +588,76 @@ struct ExpressionParserTests {
             _ = try decoder.decode(FEExpression.self, from: invalidJSON.data(using: .utf8)!)
         }
     }
+
+    // MARK: - Method Call Tests
+
+    @Test func testSimpleMethodCall() throws {
+        let expr = try parseExpression("obj.method()")
+        let expected = Expression.methodCall(.identifier("obj"), "method", [])
+        #expect(expr == expected)
+    }
+
+    @Test func testMethodCallWithArguments() throws {
+        let expr = try parseExpression("obj.method(a, b)")
+        let expected = Expression.methodCall(
+            .identifier("obj"),
+            "method",
+            [.identifier("a"), .identifier("b")]
+        )
+        #expect(expr == expected)
+    }
+
+    @Test func testMethodCallWithExpressionArguments() throws {
+        let expr = try parseExpression("queue.enqueue(val + 1)")
+        let expected = Expression.methodCall(
+            .identifier("queue"),
+            "enqueue",
+            [.binary(.add, .identifier("val"), .literal(.integer(1)))]
+        )
+        #expect(expr == expected)
+    }
+
+    @Test func testChainedMethodCalls() throws {
+        let expr = try parseExpression("obj.method1().method2()")
+        let expected = Expression.methodCall(
+            .methodCall(.identifier("obj"), "method1", []),
+            "method2",
+            []
+        )
+        #expect(expr == expected)
+    }
+
+    @Test func testFieldAccessThenMethodCall() throws {
+        let expr = try parseExpression("obj.field.method(x)")
+        let expected = Expression.methodCall(
+            .fieldAccess(.identifier("obj"), "field"),
+            "method",
+            [.identifier("x")]
+        )
+        #expect(expr == expected)
+    }
+
+    @Test func testMethodCallOnArrayAccess() throws {
+        let expr = try parseExpression("arr[0].method()")
+        let expected = Expression.methodCall(
+            .arrayAccess(.identifier("arr"), .literal(.integer(0))),
+            "method",
+            []
+        )
+        #expect(expr == expected)
+    }
+
+    @Test func testFieldAccessVsMethodCall() throws {
+        let fieldExpr = try parseExpression("obj.field")
+        let methodExpr = try parseExpression("obj.method()")
+
+        #expect(fieldExpr == .fieldAccess(.identifier("obj"), "field"))
+        #expect(methodExpr == .methodCall(.identifier("obj"), "method", []))
+    }
+
+    @Test func testMethodCallSize() throws {
+        let expr = try parseExpression("list.size()")
+        let expected = Expression.methodCall(.identifier("list"), "size", [])
+        #expect(expr == expected)
+    }
 }

--- a/Tests/FeLangCoreTests/PrettyPrinter/PrettyPrinterTests.swift
+++ b/Tests/FeLangCoreTests/PrettyPrinter/PrettyPrinterTests.swift
@@ -173,6 +173,36 @@ final class PrettyPrinterTests: XCTestCase {
         XCTAssertEqual(printer.print(expr), "calculate(x + 1, getValue())")
     }
 
+    // MARK: - Method Call Tests
+
+    func testMethodCallNoArgs() {
+        let expr = Expression.methodCall(.identifier("obj"), "getValue", [])
+        XCTAssertEqual(printer.print(expr), "obj.getValue()")
+    }
+
+    func testMethodCallWithArgs() {
+        let expr = Expression.methodCall(.identifier("list"), "add", [.literal(.integer(1)), .literal(.integer(2))])
+        XCTAssertEqual(printer.print(expr), "list.add(1, 2)")
+    }
+
+    func testChainedMethodCalls() {
+        let expr = Expression.methodCall(
+            .methodCall(.identifier("builder"), "setName", [.literal(.string("test"))]),
+            "build",
+            []
+        )
+        XCTAssertEqual(printer.print(expr), "builder.setName(\"test\").build()")
+    }
+
+    func testMethodCallOnFieldAccess() {
+        let expr = Expression.methodCall(
+            .fieldAccess(.identifier("obj"), "list"),
+            "size",
+            []
+        )
+        XCTAssertEqual(printer.print(expr), "obj.list.size()")
+    }
+
     // MARK: - Assignment Statement Tests
 
     func testVariableAssignment() {

--- a/Tests/FeLangCoreTests/Visitor/ExpressionVisitorTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/ExpressionVisitorTests.swift
@@ -151,6 +151,24 @@ struct ExpressionVisitorTests {
         #expect(result == "function_call(func, 2 args)")
     }
 
+    @Test func visitMethodCall() {
+        let visitor = ExpressionVisitor<String>(
+            visitLiteral: { _ in "literal" },
+            visitIdentifier: { _ in "identifier" },
+            visitBinary: { _, _, _ in "binary" },
+            visitUnary: { _, _ in "unary" },
+            visitArrayAccess: { _, _ in "array_access" },
+            visitFieldAccess: { _, _ in "field_access" },
+            visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { receiver, method, arguments in "method_call(\(receiver), \(method), \(arguments.count) args)" },
+            visitArrayLiteral: { _ in "array_literal" }
+        )
+
+        let expr = Expression.methodCall(.identifier("obj"), "getValue", [.literal(.integer(1)), .identifier("x")])
+        let result = visitor.visit(expr)
+        #expect(result.hasPrefix("method_call(identifier(\"obj\"), getValue, 2 args)"))
+    }
+
     // MARK: - Manual Recursive Visitor Test
 
     @Test func manualRecursiveVisitor() {

--- a/Tests/FeLangCoreTests/Visitor/ExpressionVisitorTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/ExpressionVisitorTests.swift
@@ -24,6 +24,7 @@ struct ExpressionVisitorTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { _, _ in "field_access" },
             visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 
@@ -43,6 +44,7 @@ struct ExpressionVisitorTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { _, _ in "field_access" },
             visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 
@@ -59,6 +61,7 @@ struct ExpressionVisitorTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { _, _ in "field_access" },
             visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 
@@ -81,6 +84,7 @@ struct ExpressionVisitorTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { _, _ in "field_access" },
             visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 
@@ -99,6 +103,7 @@ struct ExpressionVisitorTests {
             visitArrayAccess: { array, index in "array_access(\(array), \(index))" },
             visitFieldAccess: { _, _ in "field_access" },
             visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 
@@ -117,6 +122,7 @@ struct ExpressionVisitorTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { object, field in "field_access(\(object), \(field))" },
             visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 
@@ -136,6 +142,7 @@ struct ExpressionVisitorTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { _, _ in "field_access" },
             visitFunctionCall: { function, arguments in "function_call(\(function), \(arguments.count) args)" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 
@@ -175,6 +182,9 @@ struct ExpressionVisitorTests {
             case .arrayLiteral(let elements):
                 let elementStrings = elements.map(stringifyExpression)
                 return "[\(elementStrings.joined(separator: ", "))]"
+            case .methodCall(let receiver, let method, let arguments):
+                let argStrings = arguments.map(stringifyExpression)
+                return "\(stringifyExpression(receiver)).\(method)(\(argStrings.joined(separator: ", ")))"
             }
         }
 
@@ -215,6 +225,7 @@ struct ExpressionVisitorTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { _, _ in "field_access" },
             visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 
@@ -291,6 +302,19 @@ struct ExpressionVisitorTests {
                     }
                 }
                 return result
+            case .methodCall(let receiver, _, let arguments):
+                var result = ["method_call": 1]
+                let receiverCounts = countExpressionTypes(receiver)
+                for (key, value) in receiverCounts {
+                    result[key, default: 0] += value
+                }
+                for arg in arguments {
+                    let argCounts = countExpressionTypes(arg)
+                    for (key, value) in argCounts {
+                        result[key, default: 0] += value
+                    }
+                }
+                return result
             }
         }
 
@@ -328,6 +352,8 @@ struct ExpressionVisitorTests {
                 return arguments.map(countNodes).reduce(1, +)
             case .arrayLiteral(let elements):
                 return elements.map(countNodes).reduce(1, +)
+            case .methodCall(let receiver, _, let arguments):
+                return countNodes(receiver) + arguments.map(countNodes).reduce(1, +)
             }
         }
 

--- a/Tests/FeLangCoreTests/Visitor/VisitableTests.swift
+++ b/Tests/FeLangCoreTests/Visitor/VisitableTests.swift
@@ -15,6 +15,7 @@ struct VisitableTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { _, _ in "field_access" },
             visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 
@@ -75,6 +76,7 @@ struct VisitableTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { _, field in "field_access(\(field))" },
             visitFunctionCall: { function, _ in "function_call(\(function))" },
+            visitMethodCall: { _, method, _ in "method_call(\(method))" },
             visitArrayLiteral: { elements in "array_literal(\(elements.count))" }
         )
 
@@ -172,6 +174,7 @@ struct VisitableTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { _, _ in "field_access" },
             visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 
@@ -213,6 +216,7 @@ struct VisitableTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { _, _ in "field_access" },
             visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 
@@ -255,6 +259,7 @@ struct VisitableTests {
             visitArrayAccess: { _, _ in "array_access" },
             visitFieldAccess: { _, _ in "field_access" },
             visitFunctionCall: { _, _ in "function_call" },
+            visitMethodCall: { _, _, _ in "method_call" },
             visitArrayLiteral: { _ in "array_literal" }
         )
 

--- a/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
@@ -536,6 +536,14 @@ struct ExpressionEvaluatorTests {
         let result = try evaluator.evaluate(expr)
         #expect(result == .array([.integer(1), .integer(2)]))
     }
+
+    @Test func testMethodCallThrowsNotSupportedError() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.methodCall(.identifier("obj"), "getValue", [])
+        #expect(throws: RuntimeError.self) {
+            _ = try evaluator.evaluate(expr)
+        }
+    }
 }
 
 // MARK: - StatementExecutor Tests
@@ -990,5 +998,11 @@ struct RuntimeErrorTests {
     @Test func testStackOverflowDescription() {
         let error = RuntimeError.stackOverflow
         #expect(error.description.contains("Stack overflow"))
+    }
+
+    @Test func testMethodCallNotSupportedDescription() {
+        let error = RuntimeError.methodCallNotSupported(method: "getValue")
+        #expect(error.description.contains("getValue"))
+        #expect(error.description.contains("not supported"))
     }
 }


### PR DESCRIPTION
Closes #361

## Summary

Adds parsing and AST support for method call expressions (`obj.method(args)`). This enables the syntax for future class method invocations when class definitions are implemented.

**Key changes:**
- New `methodCall(Expression, String, [Expression])` case in `Expression` enum
- Parser distinguishes field access vs method calls by checking for `(` after dot-accessed identifier
- Full visitor pattern support (`ExpressionVisitor`, `ASTWalker`)
- `PrettyPrinter` outputs method calls correctly
- Runtime throws `methodCallNotSupported` error (classes not yet implemented)
- Semantic analyzer returns `.unknown` type for method calls

## Review & Testing Checklist for Human

- [ ] **Parser logic in `ExpressionParser.swift:95-108`**: Verify the distinction between `obj.field` and `obj.method()` is correct - the check for `leftParen` after the identifier determines which AST node is created
- [ ] **Runtime error behavior**: Confirm it's acceptable that `obj.method()` will throw `methodCallNotSupported` at runtime until class definitions are implemented (issue #363)
- [ ] **Semantic analyzer returning `.unknown`**: Check if returning unknown type for method calls could cause unexpected behavior in type checking

**Suggested test plan:**
1. Run `swift test` to verify all 1265 tests pass
2. Try parsing expressions like `obj.method()`, `obj.method(a, b)`, `obj.field.method()` in the REPL
3. Verify that executing a method call produces the expected "not supported" error message

### Notes

Link to Devin run: https://app.devin.ai/sessions/2a897c551df64e75be51212fbc74c3c2

Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/378">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
