### PR TITLE
feat: add mod keyword support for modulo operation

### DIFF
--- a/Sources/FeLangCore/Expression/Expression.swift
+++ b/Sources/FeLangCore/Expression/Expression.swift
@@ -221,7 +221,7 @@ extension BinaryOperator {
             self = .multiply
         case .divide:
             self = .divide
-        case .modulo:
+        case .modulo, .modKeyword:
             self = .modulo
         case .equal:
             self = .equal

--- a/Sources/FeLangCore/Parser/ParsingBoundaryDetection.swift
+++ b/Sources/FeLangCore/Parser/ParsingBoundaryDetection.swift
@@ -51,7 +51,7 @@ public enum ParsingBoundaryDetection {
     private static func isExpressionContinuationToken(_ tokenType: TokenType) -> Bool {
         switch tokenType {
         // Binary operators
-        case .plus, .minus, .multiply, .divide, .modulo:
+        case .plus, .minus, .multiply, .divide, .modulo, .modKeyword:
             return true
         // Comparison operators
         case .equal, .notEqual, .less, .greater, .lessEqual, .greaterEqual:

--- a/Sources/FeLangCore/Parser/StatementParser.swift
+++ b/Sources/FeLangCore/Parser/StatementParser.swift
@@ -964,7 +964,7 @@ public struct StatementParser {
     /// Used to distinguish between function calls as new statements vs function calls within expressions
     private func isExpressionContinuationToken(_ tokenType: TokenType) -> Bool {
         switch tokenType {
-        case .plus, .minus, .multiply, .divide, .modulo,
+        case .plus, .minus, .multiply, .divide, .modulo, .modKeyword,
              .equal, .notEqual, .less, .greater, .lessEqual, .greaterEqual,
              .andKeyword, .orKeyword,
              .leftParen, .leftBracket, .comma, .dot,

--- a/Sources/FeLangCore/Tokenizer/TokenType.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenType.swift
@@ -39,6 +39,9 @@ public enum TokenType: String, CaseIterable, Equatable, Codable, Sendable {
     case orKeyword = "or"
     case notKeyword = "not"
 
+    /// Arithmetic keyword operators
+    case modKeyword = "mod"
+
     /// Boolean literals
     case trueKeyword = "true"
     case falseKeyword = "false"
@@ -117,7 +120,7 @@ extension TokenType {
              .recordType, .arrayType, .ifKeyword, .thenKeyword, .elseKeyword, .elifKeyword, .elseifKeyword, .endifKeyword,
              .whileKeyword, .doKeyword, .endwhileKeyword, .forKeyword, .toKeyword, .stepKeyword, .inKeyword, .endforKeyword,
              .functionKeyword, .endfunctionKeyword, .procedureKeyword, .endprocedureKeyword,
-             .andKeyword, .orKeyword, .notKeyword, .returnKeyword, .breakKeyword, .continueKeyword,
+             .andKeyword, .orKeyword, .notKeyword, .modKeyword, .returnKeyword, .breakKeyword, .continueKeyword,
              .trueKeyword, .falseKeyword, .variableKeyword, .constantKeyword,
              .classKeyword, .endclassKeyword, .undefinedKeyword:
             return true

--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -56,6 +56,7 @@ public enum TokenizerUtilities {
         ("論理型", .booleanType),
         ("and", .andKeyword),
         ("not", .notKeyword),
+        ("mod", .modKeyword),
         ("for", .forKeyword),
 
         // 3 characters (Japanese)

--- a/Sources/FeLangServer/CompletionProvider.swift
+++ b/Sources/FeLangServer/CompletionProvider.swift
@@ -45,6 +45,9 @@ public struct CompletionProvider: Sendable {
         CompletionItem(label: "or", kind: .keyword, detail: "Logical OR"),
         CompletionItem(label: "not", kind: .keyword, detail: "Logical NOT"),
 
+        // Arithmetic operators
+        CompletionItem(label: "mod", kind: .keyword, detail: "Modulo operator"),
+
         // Japanese keywords
         CompletionItem(label: "もし", kind: .keyword, detail: "条件分岐 (if)", insertText: "もし "),
         CompletionItem(label: "ならば", kind: .keyword, detail: "Then clause"),
@@ -286,7 +289,7 @@ public struct CompletionProvider: Sendable {
             "function", "endfunction", "procedure", "endprocedure",
             "class", "endclass",
             "return", "break", "continue",
-            "and", "or", "not", "true", "false",
+            "and", "or", "not", "mod", "true", "false",
             "integer", "real", "string", "character", "boolean", "array",
             // Japanese keywords
             "もし", "ならば", "でなければ", "を実行", "繰り返し", "を繰り返す",

--- a/Sources/FeLangServer/HoverProvider.swift
+++ b/Sources/FeLangServer/HoverProvider.swift
@@ -45,6 +45,9 @@ public struct HoverProvider: Sendable {
         "or": "**or** - Logical OR\n\nReturns true if either operand is true.",
         "not": "**not** - Logical NOT\n\nReturns the opposite of a boolean value.",
 
+        // Arithmetic operators
+        "mod": "**mod** - Modulo operator\n\nReturns the remainder of integer division.\n\n```fe\n7 mod 3  // returns 1\n```",
+
         // Literals
         "true": "**true** - Boolean true\n\nThe boolean value representing truth.",
         "false": "**false** - Boolean false\n\nThe boolean value representing falsehood.",

--- a/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
@@ -97,6 +97,17 @@ struct ExpressionParserTests {
         #expect(expr == expected)
     }
 
+    @Test func testModKeywordPrecedence() throws {
+        // 10 + 7 mod 3 should be parsed as 10 + (7 mod 3) since mod has same precedence as * and /
+        let expr = try parseExpression("10 + 7 mod 3")
+        let expected = Expression.binary(
+            .add,
+            .literal(.integer(10)),
+            .binary(.modulo, .literal(.integer(7)), .literal(.integer(3)))
+        )
+        #expect(expr == expected)
+    }
+
     // MARK: - Precedence Tests
 
     @Test func testArithmeticPrecedence() throws {

--- a/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
+++ b/Tests/FeLangCoreTests/Expression/ExpressionParserTests.swift
@@ -91,6 +91,12 @@ struct ExpressionParserTests {
         #expect(expr == expected)
     }
 
+    @Test func testModuloWithModKeyword() throws {
+        let expr = try parseExpression("7 mod 3")
+        let expected = Expression.binary(.modulo, .literal(.integer(7)), .literal(.integer(3)))
+        #expect(expr == expected)
+    }
+
     // MARK: - Precedence Tests
 
     @Test func testArithmeticPrecedence() throws {

--- a/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
+++ b/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
@@ -48,6 +48,21 @@ struct TokenizerTests {
         #expect(tokens[1].type == .eof)
     }
 
+    @Test func testModKeyword() throws {
+        let input = "7 mod 3"
+        let tokenizer = Tokenizer(input: input)
+        let tokens = try tokenizer.tokenize()
+
+        #expect(tokens.count == 4) // integer, mod, integer, eof
+        #expect(tokens[0].type == .integerLiteral)
+        #expect(tokens[0].lexeme == "7")
+        #expect(tokens[1].type == .modKeyword)
+        #expect(tokens[1].lexeme == "mod")
+        #expect(tokens[2].type == .integerLiteral)
+        #expect(tokens[2].lexeme == "3")
+        #expect(tokens[3].type == .eof)
+    }
+
     @Test func testOperators() throws {
         let input = "+ - * / % ← = ≠ > ≧ < ≦ ∧"
         let tokenizer = Tokenizer(input: input)

--- a/Tests/FeLangE2ETests/NumericE2ETests.swift
+++ b/Tests/FeLangE2ETests/NumericE2ETests.swift
@@ -202,6 +202,20 @@ struct NumericE2ETests {
         #expect(output.trimmingCharacters(in: .whitespacesAndNewlines) == "11")
     }
 
+    @Test("Modulo with mod keyword: 7 mod 3 = 1")
+    func testModKeyword() throws {
+        let output = try InProcessTestHelper.run("println(7 mod 3)")
+        #expect(output.trimmingCharacters(in: .whitespacesAndNewlines) == "1")
+    }
+
+    @Test("mod keyword should work same as % operator")
+    func testModKeywordEquivalence() throws {
+        let modOutput = try InProcessTestHelper.run("println(17 mod 5)")
+        let percentOutput = try InProcessTestHelper.run("println(17 % 5)")
+        #expect(modOutput.trimmingCharacters(in: .whitespacesAndNewlines) ==
+                percentOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
     // MARK: - ASCII Not-Equal Operator Tests
 
     @Test("ASCII not-equal operator: 1 != 2 should be true")


### PR DESCRIPTION
# feat: add mod keyword support for modulo operation

Closes #355

## Summary

Adds support for the `mod` keyword as an alternative to the `%` operator for modulo operations, as specified in the FE pseudo-language specification.

Changes made:
- Added `modKeyword` case to `TokenType` enum and `isKeyword` property
- Added `mod` to the keywords array in `TokenizerUtilities` (3-character section)
- Mapped `modKeyword` to `.modulo` in `BinaryOperator.init?(tokenType:)`
- Added hover documentation and code completion support for `mod`
- Added parsing and E2E tests

## Review & Testing Checklist for Human

- [ ] Verify `mod` has the same operator precedence as `%` (both should be precedence level 6 with multiply/divide)
- [ ] Test `7 mod 3` in the REPL or a sample FE program to confirm it returns `1`
- [ ] Verify that `mod` appears in IDE code completion suggestions

**Suggested test plan:** Run `println(7 mod 3)` and `println(17 mod 5)` in the FE interpreter to verify they produce `1` and `2` respectively, matching the behavior of `%`.

### Notes

- Link to Devin run: https://app.devin.ai/sessions/b69eef1bdb0548c6a5b688af48b424f2
- Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/379">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
