### PR TITLE
feat: クラスの継承をサポートする

### DIFF
--- a/Sources/FeLangRuntime/RuntimeValue.swift
+++ b/Sources/FeLangRuntime/RuntimeValue.swift
@@ -255,6 +255,9 @@ public struct ClassDefinition: Equatable, Sendable {
     /// The name of the class
     public let name: String
 
+    /// The name of the superclass (nil if no inheritance)
+    public let superclassName: String?
+
     /// Member variable names and their types
     public let members: [String: DataType]
 
@@ -272,6 +275,7 @@ public struct ClassDefinition: Equatable, Sendable {
 
     public init(
         name: String,
+        superclassName: String? = nil,
         members: [String: DataType] = [:],
         constructorParameters: [String] = [],
         constructorParameterTypes: [DataType] = [],
@@ -279,6 +283,7 @@ public struct ClassDefinition: Equatable, Sendable {
         methods: [String: MethodDefinition] = [:]
     ) {
         self.name = name
+        self.superclassName = superclassName
         self.members = members
         self.constructorParameters = constructorParameters
         self.constructorParameterTypes = constructorParameterTypes

--- a/Sources/FeLangRuntime/StatementExecutor.swift
+++ b/Sources/FeLangRuntime/StatementExecutor.swift
@@ -661,7 +661,8 @@ public final class StatementExecutor: @unchecked Sendable {
         if let superclassName = classDef.superclassName,
            let superclassDef = environment.lookupClassDefinition(superclassName) {
             // Recursively collect all inherited members from the superclass chain
-            let inheritedMembers = collectInheritedMembers(from: superclassDef)
+            var visited: Set<String> = [classDef.name]
+            let inheritedMembers = try collectInheritedMembers(from: superclassDef, visited: &visited)
             for (memberName, memberType) in inheritedMembers {
                 fields[memberName] = defaultValue(for: memberType)
             }
@@ -673,7 +674,8 @@ public final class StatementExecutor: @unchecked Sendable {
         }
 
         // Create the instance with merged class definition for method resolution
-        let mergedClassDef = createMergedClassDefinition(classDef)
+        var mergedVisited: Set<String> = []
+        let mergedClassDef = try createMergedClassDefinition(classDef, visited: &mergedVisited)
         var instance = InstanceValue(
             className: classDef.name,
             classDefinition: mergedClassDef,
@@ -715,13 +717,23 @@ public final class StatementExecutor: @unchecked Sendable {
     }
 
     /// Collects all inherited members from a class and its superclass chain.
-    private func collectInheritedMembers(from classDef: ClassDefinition) -> [String: DataType] {
+    /// Uses a visited set to detect circular inheritance.
+    private func collectInheritedMembers(
+        from classDef: ClassDefinition,
+        visited: inout Set<String>
+    ) throws -> [String: DataType] {
+        // Check for circular inheritance
+        guard !visited.contains(classDef.name) else {
+            throw RuntimeError.generic(message: "Circular inheritance detected involving class '\(classDef.name)'")
+        }
+        visited.insert(classDef.name)
+
         var members: [String: DataType] = [:]
 
         // First collect from superclass (if any)
         if let superclassName = classDef.superclassName,
            let superclassDef = environment.lookupClassDefinition(superclassName) {
-            let superMembers = collectInheritedMembers(from: superclassDef)
+            let superMembers = try collectInheritedMembers(from: superclassDef, visited: &visited)
             for (name, type) in superMembers {
                 members[name] = type
             }
@@ -737,14 +749,24 @@ public final class StatementExecutor: @unchecked Sendable {
 
     /// Creates a merged class definition that includes inherited methods for method resolution.
     /// Subclass methods take priority over superclass methods (method override).
-    private func createMergedClassDefinition(_ classDef: ClassDefinition) -> ClassDefinition {
+    /// Uses a visited set to detect circular inheritance.
+    private func createMergedClassDefinition(
+        _ classDef: ClassDefinition,
+        visited: inout Set<String>
+    ) throws -> ClassDefinition {
+        // Check for circular inheritance
+        guard !visited.contains(classDef.name) else {
+            throw RuntimeError.generic(message: "Circular inheritance detected involving class '\(classDef.name)'")
+        }
+        visited.insert(classDef.name)
+
         var mergedMethods: [String: MethodDefinition] = [:]
         var mergedMembers: [String: DataType] = [:]
 
         // Collect methods and members from superclass chain first
         if let superclassName = classDef.superclassName,
            let superclassDef = environment.lookupClassDefinition(superclassName) {
-            let mergedSuperclass = createMergedClassDefinition(superclassDef)
+            let mergedSuperclass = try createMergedClassDefinition(superclassDef, visited: &visited)
             mergedMethods = mergedSuperclass.methods
             mergedMembers = mergedSuperclass.members
         }

--- a/Sources/FeLangRuntime/StatementExecutor.swift
+++ b/Sources/FeLangRuntime/StatementExecutor.swift
@@ -168,6 +168,7 @@ public final class StatementExecutor: @unchecked Sendable {
 
         let classDef = ClassDefinition(
             name: decl.name,
+            superclassName: decl.superclass,
             members: members,
             constructorParameters: constructorParams,
             constructorParameterTypes: constructorParamTypes,
@@ -653,16 +654,29 @@ public final class StatementExecutor: @unchecked Sendable {
             }
         }
 
-        // Initialize member fields with default values
+        // Initialize member fields with default values, starting with inherited members
         var fields: [String: RuntimeValue] = [:]
+
+        // Merge superclass members first (inheritance)
+        if let superclassName = classDef.superclassName,
+           let superclassDef = environment.lookupClassDefinition(superclassName) {
+            // Recursively collect all inherited members from the superclass chain
+            let inheritedMembers = collectInheritedMembers(from: superclassDef)
+            for (memberName, memberType) in inheritedMembers {
+                fields[memberName] = defaultValue(for: memberType)
+            }
+        }
+
+        // Add this class's own members (may override inherited members)
         for (memberName, memberType) in classDef.members {
             fields[memberName] = defaultValue(for: memberType)
         }
 
-        // Create the instance
+        // Create the instance with merged class definition for method resolution
+        let mergedClassDef = createMergedClassDefinition(classDef)
         var instance = InstanceValue(
             className: classDef.name,
-            classDefinition: classDef,
+            classDefinition: mergedClassDef,
             fields: fields
         )
 
@@ -698,6 +712,62 @@ public final class StatementExecutor: @unchecked Sendable {
         }
 
         return .instance(instance)
+    }
+
+    /// Collects all inherited members from a class and its superclass chain.
+    private func collectInheritedMembers(from classDef: ClassDefinition) -> [String: DataType] {
+        var members: [String: DataType] = [:]
+
+        // First collect from superclass (if any)
+        if let superclassName = classDef.superclassName,
+           let superclassDef = environment.lookupClassDefinition(superclassName) {
+            let superMembers = collectInheritedMembers(from: superclassDef)
+            for (name, type) in superMembers {
+                members[name] = type
+            }
+        }
+
+        // Then add this class's members (may override)
+        for (name, type) in classDef.members {
+            members[name] = type
+        }
+
+        return members
+    }
+
+    /// Creates a merged class definition that includes inherited methods for method resolution.
+    /// Subclass methods take priority over superclass methods (method override).
+    private func createMergedClassDefinition(_ classDef: ClassDefinition) -> ClassDefinition {
+        var mergedMethods: [String: MethodDefinition] = [:]
+        var mergedMembers: [String: DataType] = [:]
+
+        // Collect methods and members from superclass chain first
+        if let superclassName = classDef.superclassName,
+           let superclassDef = environment.lookupClassDefinition(superclassName) {
+            let mergedSuperclass = createMergedClassDefinition(superclassDef)
+            mergedMethods = mergedSuperclass.methods
+            mergedMembers = mergedSuperclass.members
+        }
+
+        // Add this class's members (may override inherited)
+        for (name, type) in classDef.members {
+            mergedMembers[name] = type
+        }
+
+        // Add this class's methods (may override inherited)
+        for (name, method) in classDef.methods {
+            mergedMethods[name] = method
+        }
+
+        return ClassDefinition(
+            name: classDef.name,
+            superclassName: classDef.superclassName,
+            members: mergedMembers,
+            constructorParameters: classDef.constructorParameters,
+            constructorParameterTypes: classDef.constructorParameterTypes,
+            constructorBody: classDef.constructorBody,
+            methods: mergedMethods
+        )
     }
 
     private func callFunctionValue(

--- a/Sources/FeLangRuntime/StatementExecutor.swift
+++ b/Sources/FeLangRuntime/StatementExecutor.swift
@@ -658,8 +658,10 @@ public final class StatementExecutor: @unchecked Sendable {
         var fields: [String: RuntimeValue] = [:]
 
         // Merge superclass members first (inheritance)
-        if let superclassName = classDef.superclassName,
-           let superclassDef = environment.lookupClassDefinition(superclassName) {
+        if let superclassName = classDef.superclassName {
+            guard let superclassDef = environment.lookupClassDefinition(superclassName) else {
+                throw RuntimeError.generic(message: "Superclass '\(superclassName)' not found for class '\(classDef.name)'")
+            }
             // Recursively collect all inherited members from the superclass chain
             var visited: Set<String> = [classDef.name]
             let inheritedMembers = try collectInheritedMembers(from: superclassDef, visited: &visited)

--- a/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
@@ -1271,4 +1271,29 @@ struct ClassInheritanceTests {
             #expect(error.description.contains("Circular inheritance"))
         }
     }
+
+    @Test func testUndefinedSuperclassError() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        // Define class that extends a non-existent superclass
+        let dogClass = ClassDeclaration(
+            name: "Dog",
+            superclass: "NonExistentAnimal",
+            members: [MemberDeclaration(name: "breed", type: .string)],
+            constructor: nil,
+            methods: []
+        )
+
+        _ = try executor.executeStatement(.classDeclaration(dogClass))
+
+        // Attempting to create an instance should throw a superclass not found error
+        do {
+            _ = try executor.callFunction("Dog", arguments: [])
+            Issue.record("Expected superclass not found error")
+        } catch let error as RuntimeError {
+            #expect(error.description.contains("Superclass"))
+            #expect(error.description.contains("not found"))
+        }
+    }
 }

--- a/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
@@ -992,3 +992,249 @@ struct RuntimeErrorTests {
         #expect(error.description.contains("Stack overflow"))
     }
 }
+
+// MARK: - Class Inheritance Tests
+
+struct ClassInheritanceTests {
+
+    @Test func testSubclassInheritsSuperclassMemberVariables() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        // Define superclass Animal with member 'name'
+        let animalClass = ClassDeclaration(
+            name: "Animal",
+            superclass: nil,
+            members: [MemberDeclaration(name: "name", type: .string)],
+            constructor: ConstructorDeclaration(
+                parameters: [Parameter(name: "n", type: .string)],
+                body: [
+                    .assignment(.fieldAccess(
+                        Assignment.FieldAccess(object: .identifier("self"), field: "name"),
+                        .identifier("n")
+                    ))
+                ]
+            ),
+            methods: []
+        )
+
+        // Define subclass Dog that extends Animal with additional member 'breed'
+        let dogClass = ClassDeclaration(
+            name: "Dog",
+            superclass: "Animal",
+            members: [MemberDeclaration(name: "breed", type: .string)],
+            constructor: ConstructorDeclaration(
+                parameters: [Parameter(name: "n", type: .string), Parameter(name: "b", type: .string)],
+                body: [
+                    .assignment(.fieldAccess(
+                        Assignment.FieldAccess(object: .identifier("self"), field: "name"),
+                        .identifier("n")
+                    )),
+                    .assignment(.fieldAccess(
+                        Assignment.FieldAccess(object: .identifier("self"), field: "breed"),
+                        .identifier("b")
+                    ))
+                ]
+            ),
+            methods: []
+        )
+
+        // Execute class declarations
+        _ = try executor.executeStatement(.classDeclaration(animalClass))
+        _ = try executor.executeStatement(.classDeclaration(dogClass))
+
+        // Create Dog instance
+        let dogInstance = try executor.callFunction("Dog", arguments: [.string("Buddy"), .string("Labrador")])
+
+        // Verify the instance has both inherited 'name' and own 'breed' members
+        guard case .instance(let inst) = dogInstance else {
+            Issue.record("Expected instance value")
+            return
+        }
+
+        #expect(inst.fields["name"] == .string("Buddy"))
+        #expect(inst.fields["breed"] == .string("Labrador"))
+    }
+
+    @Test func testSubclassCanCallSuperclassMethod() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        // Define superclass with a method
+        let animalClass = ClassDeclaration(
+            name: "Animal",
+            superclass: nil,
+            members: [MemberDeclaration(name: "age", type: .integer)],
+            constructor: ConstructorDeclaration(
+                parameters: [Parameter(name: "a", type: .integer)],
+                body: [
+                    .assignment(.fieldAccess(
+                        Assignment.FieldAccess(object: .identifier("self"), field: "age"),
+                        .identifier("a")
+                    ))
+                ]
+            ),
+            methods: [
+                MethodDeclaration(
+                    name: "getAge",
+                    parameters: [],
+                    returnType: .integer,
+                    body: [
+                        .returnStatement(ReturnStatement(
+                            expression: .fieldAccess(.identifier("self"), "age")
+                        ))
+                    ]
+                )
+            ]
+        )
+
+        // Define subclass without overriding the method
+        let dogClass = ClassDeclaration(
+            name: "Dog",
+            superclass: "Animal",
+            members: [MemberDeclaration(name: "breed", type: .string)],
+            constructor: ConstructorDeclaration(
+                parameters: [Parameter(name: "a", type: .integer), Parameter(name: "b", type: .string)],
+                body: [
+                    .assignment(.fieldAccess(
+                        Assignment.FieldAccess(object: .identifier("self"), field: "age"),
+                        .identifier("a")
+                    )),
+                    .assignment(.fieldAccess(
+                        Assignment.FieldAccess(object: .identifier("self"), field: "breed"),
+                        .identifier("b")
+                    ))
+                ]
+            ),
+            methods: []
+        )
+
+        _ = try executor.executeStatement(.classDeclaration(animalClass))
+        _ = try executor.executeStatement(.classDeclaration(dogClass))
+
+        // Create Dog instance and verify it can use inherited method
+        let dogInstance = try executor.callFunction("Dog", arguments: [.integer(3), .string("Labrador")])
+
+        guard case .instance(let inst) = dogInstance else {
+            Issue.record("Expected instance value")
+            return
+        }
+
+        // Verify the inherited method exists in the class definition
+        #expect(inst.classDefinition.methods["getAge"] != nil)
+    }
+
+    @Test func testSubclassMethodOverridesSuperclassMethod() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        // Define superclass with a method that returns 1
+        let animalClass = ClassDeclaration(
+            name: "Animal",
+            superclass: nil,
+            members: [],
+            constructor: nil,
+            methods: [
+                MethodDeclaration(
+                    name: "speak",
+                    parameters: [],
+                    returnType: .integer,
+                    body: [
+                        .returnStatement(ReturnStatement(expression: .literal(.integer(1))))
+                    ]
+                )
+            ]
+        )
+
+        // Define subclass that overrides the method to return 2
+        let dogClass = ClassDeclaration(
+            name: "Dog",
+            superclass: "Animal",
+            members: [],
+            constructor: nil,
+            methods: [
+                MethodDeclaration(
+                    name: "speak",
+                    parameters: [],
+                    returnType: .integer,
+                    body: [
+                        .returnStatement(ReturnStatement(expression: .literal(.integer(2))))
+                    ]
+                )
+            ]
+        )
+
+        _ = try executor.executeStatement(.classDeclaration(animalClass))
+        _ = try executor.executeStatement(.classDeclaration(dogClass))
+
+        let dogInstance = try executor.callFunction("Dog", arguments: [])
+
+        guard case .instance(let inst) = dogInstance else {
+            Issue.record("Expected instance value")
+            return
+        }
+
+        // Verify the subclass method overrides the superclass method
+        let speakMethod = inst.classDefinition.methods["speak"]
+        #expect(speakMethod != nil)
+
+        // The method body should return 2 (subclass version), not 1 (superclass version)
+        if let method = speakMethod {
+            #expect(method.body.count == 1)
+            if case .returnStatement(let ret) = method.body[0],
+               case .literal(.integer(let value)) = ret.expression {
+                #expect(value == 2)
+            } else {
+                Issue.record("Expected return statement with integer literal")
+            }
+        }
+    }
+
+    @Test func testMultiLevelInheritance() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        // Define base class
+        let animalClass = ClassDeclaration(
+            name: "Animal",
+            superclass: nil,
+            members: [MemberDeclaration(name: "alive", type: .boolean)],
+            constructor: nil,
+            methods: []
+        )
+
+        // Define intermediate class
+        let mammalClass = ClassDeclaration(
+            name: "Mammal",
+            superclass: "Animal",
+            members: [MemberDeclaration(name: "warmBlooded", type: .boolean)],
+            constructor: nil,
+            methods: []
+        )
+
+        // Define leaf class
+        let dogClass = ClassDeclaration(
+            name: "Dog",
+            superclass: "Mammal",
+            members: [MemberDeclaration(name: "breed", type: .string)],
+            constructor: nil,
+            methods: []
+        )
+
+        _ = try executor.executeStatement(.classDeclaration(animalClass))
+        _ = try executor.executeStatement(.classDeclaration(mammalClass))
+        _ = try executor.executeStatement(.classDeclaration(dogClass))
+
+        let dogInstance = try executor.callFunction("Dog", arguments: [])
+
+        guard case .instance(let inst) = dogInstance else {
+            Issue.record("Expected instance value")
+            return
+        }
+
+        // Verify all inherited members are present
+        #expect(inst.fields["alive"] != nil)
+        #expect(inst.fields["warmBlooded"] != nil)
+        #expect(inst.fields["breed"] != nil)
+    }
+}

--- a/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
@@ -1237,4 +1237,38 @@ struct ClassInheritanceTests {
         #expect(inst.fields["warmBlooded"] != nil)
         #expect(inst.fields["breed"] != nil)
     }
+
+    @Test func testCircularInheritanceDetection() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        // Define class A that extends B
+        let classA = ClassDeclaration(
+            name: "A",
+            superclass: "B",
+            members: [MemberDeclaration(name: "valueA", type: .integer)],
+            constructor: nil,
+            methods: []
+        )
+
+        // Define class B that extends A (circular inheritance)
+        let classB = ClassDeclaration(
+            name: "B",
+            superclass: "A",
+            members: [MemberDeclaration(name: "valueB", type: .integer)],
+            constructor: nil,
+            methods: []
+        )
+
+        _ = try executor.executeStatement(.classDeclaration(classA))
+        _ = try executor.executeStatement(.classDeclaration(classB))
+
+        // Attempting to create an instance should throw a circular inheritance error
+        do {
+            _ = try executor.callFunction("A", arguments: [])
+            Issue.record("Expected circular inheritance error")
+        } catch let error as RuntimeError {
+            #expect(error.description.contains("Circular inheritance"))
+        }
+    }
 }


### PR DESCRIPTION
# feat: クラスの継承をサポートする

Closes #365

## Summary

This PR adds class inheritance support to FeLangKit, allowing subclasses to inherit member variables and methods from superclasses.

**Key changes:**
- Added `superclassName` field to `ClassDefinition` to track inheritance relationships
- Implemented member variable inheritance by merging superclass members into subclass instances
- Implemented method resolution where subclass methods take priority over superclass methods (method override)
- Both features support multi-level inheritance chains (e.g., Animal → Mammal → Dog)

## Review & Testing Checklist for Human

- [ ] **Verify superclass constructor behavior**: The implementation does NOT automatically call the superclass constructor - subclass constructors must manually initialize inherited fields. Confirm this matches the expected FE pseudo-language semantics from issue #365
- [ ] **Test actual method execution**: The tests verify methods exist in the merged definition but don't execute inherited methods at runtime. Consider adding an E2E test that actually calls an inherited method
- [ ] **Check edge cases**: No validation for circular inheritance (A extends B, B extends A) or missing superclass references - these could cause infinite recursion or silent failures

### Suggested Test Plan
1. Write a simple FE program with class inheritance and run it through the interpreter
2. Test calling an inherited method on a subclass instance
3. Test method override by defining same method in both parent and child

### Notes
- Link to Devin run: https://app.devin.ai/sessions/6e9ad799fc524055873f4eeed403ad62
- Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/380">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
