### PR TITLE
feat: ビット論理和演算子∨をサポートする

### DIFF
--- a/Sources/FeLangCore/Expression/Expression.swift
+++ b/Sources/FeLangCore/Expression/Expression.swift
@@ -161,6 +161,7 @@ public enum BinaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
 
     // Bitwise operators
     case bitwiseAnd = "∧"
+    case bitwiseOr = "∨"
 
     // Logical operators
     case and = "and"
@@ -175,7 +176,7 @@ public enum BinaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
             return 1
         case .and:
             return 2
-        case .bitwiseAnd:
+        case .bitwiseAnd, .bitwiseOr:
             return 3
         case .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual:
             return 4
@@ -237,6 +238,8 @@ extension BinaryOperator {
             self = .lessEqual
         case .bitwiseAnd:
             self = .bitwiseAnd
+        case .bitwiseOr:
+            self = .bitwiseOr
         case .andKeyword:
             self = .and
         case .orKeyword:

--- a/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
+++ b/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
@@ -907,6 +907,16 @@ public final class SemanticAnalyzer: @unchecked Sendable {
                 return .error
             }
 
+        case .bitwiseOr:
+            // Bitwise OR only works with integers (strict check, no real allowed)
+            if case .integer = leftType, case .integer = rightType {
+                return .integer
+            } else {
+                let position = SourcePosition(line: 0, column: 0, offset: 0)
+                errorReporter.collect(.incompatibleTypes(leftType, rightType, operation: operatorType.rawValue, position: position))
+                return .error
+            }
+
         case .and, .or:
             // Logical operators work with boolean types
             if leftType.isCompatible(with: .boolean) && rightType.isCompatible(with: .boolean) {

--- a/Sources/FeLangCore/Tokenizer/TokenType.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenType.swift
@@ -87,6 +87,7 @@ public enum TokenType: String, CaseIterable, Equatable, Codable, Sendable {
 
     /// Bitwise operators
     case bitwiseAnd = "∧"
+    case bitwiseOr = "∨"
 
     // MARK: - Delimiters
 
@@ -141,7 +142,7 @@ extension TokenType {
         switch self {
         case .plus, .minus, .multiply, .divide, .modulo, .assign,
              .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual,
-             .bitwiseAnd:
+             .bitwiseAnd, .bitwiseOr:
             return true
         default:
             return false

--- a/Sources/FeLangCore/Tokenizer/Tokenizer.swift
+++ b/Sources/FeLangCore/Tokenizer/Tokenizer.swift
@@ -139,6 +139,8 @@ public final class Tokenizer {
             return Token(type: .less, lexeme: "<", position: position)
         case "∧":
             return Token(type: .bitwiseAnd, lexeme: "∧", position: position)
+        case "∨":
+            return Token(type: .bitwiseOr, lexeme: "∨", position: position)
         case "(":
             return Token(type: .leftParen, lexeme: "(", position: position)
         case ")":

--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -101,6 +101,7 @@ public enum TokenizerUtilities {
         (">", .greater),
         ("<", .less),
         ("∧", .bitwiseAnd),
+        ("∨", .bitwiseOr),
         // NOTE: If multi-character operators starting with "!" (e.g., "!=") are added,
         // they must appear before this single-character "!" entry to preserve longest-match behavior.
         ("!", .notKeyword)

--- a/Sources/FeLangRuntime/ExpressionEvaluator.swift
+++ b/Sources/FeLangRuntime/ExpressionEvaluator.swift
@@ -152,6 +152,8 @@ public struct ExpressionEvaluator: Sendable {
         // Bitwise
         case .bitwiseAnd:
             return try evaluateBitwiseAnd(left, right)
+        case .bitwiseOr:
+            return try evaluateBitwiseOr(left, right)
 
         // Logical
         case .and:
@@ -191,6 +193,16 @@ public struct ExpressionEvaluator: Sendable {
             throw RuntimeError.typeMismatch(expected: "Integer", actual: right.typeName, operation: "∧")
         }
         return .integer(leftInt & rightInt)
+    }
+
+    private func evaluateBitwiseOr(_ left: RuntimeValue, _ right: RuntimeValue) throws -> RuntimeValue {
+        guard case .integer(let leftInt) = left else {
+            throw RuntimeError.typeMismatch(expected: "Integer", actual: left.typeName, operation: "∨")
+        }
+        guard case .integer(let rightInt) = right else {
+            throw RuntimeError.typeMismatch(expected: "Integer", actual: right.typeName, operation: "∨")
+        }
+        return .integer(leftInt | rightInt)
     }
 
     private func evaluateAdd(_ left: RuntimeValue, _ right: RuntimeValue) throws -> RuntimeValue {

--- a/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
+++ b/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
@@ -49,13 +49,13 @@ struct TokenizerTests {
     }
 
     @Test func testOperators() throws {
-        let input = "+ - * / % ← = ≠ > ≧ < ≦ ∧"
+        let input = "+ - * / % ← = ≠ > ≧ < ≦ ∧ ∨"
         let tokenizer = Tokenizer(input: input)
         let tokens = try tokenizer.tokenize()
 
         let expectedTypes: [TokenType] = [
             .plus, .minus, .multiply, .divide, .modulo, .assign,
-            .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual, .bitwiseAnd, .eof
+            .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual, .bitwiseAnd, .bitwiseOr, .eof
         ]
 
         #expect(tokens.count == expectedTypes.count)

--- a/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
@@ -500,6 +500,45 @@ struct ExpressionEvaluatorTests {
         }
     }
 
+    @Test func testBitwiseOr() throws {
+        let evaluator = makeEvaluator()
+        // 5 = 0b101, 3 = 0b011, 5 | 3 = 0b111 = 7
+        let expr = Expression.binary(.bitwiseOr, .literal(.integer(5)), .literal(.integer(3)))
+        let result = try evaluator.evaluate(expr)
+        #expect(result == .integer(7))
+    }
+
+    @Test func testBitwiseOrWithZero() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.bitwiseOr, .literal(.integer(255)), .literal(.integer(0)))
+        let result = try evaluator.evaluate(expr)
+        #expect(result == .integer(255))
+    }
+
+    @Test func testBitwiseOrWithAllOnes() throws {
+        let evaluator = makeEvaluator()
+        // 15 = 0b1111, 15 | 15 = 0b1111 = 15
+        let expr = Expression.binary(.bitwiseOr, .literal(.integer(15)), .literal(.integer(15)))
+        let result = try evaluator.evaluate(expr)
+        #expect(result == .integer(15))
+    }
+
+    @Test func testBitwiseOrTypeMismatchLeft() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.bitwiseOr, .literal(.real(5.0)), .literal(.integer(3)))
+        #expect(throws: RuntimeError.self) {
+            _ = try evaluator.evaluate(expr)
+        }
+    }
+
+    @Test func testBitwiseOrTypeMismatchRight() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.bitwiseOr, .literal(.integer(5)), .literal(.real(3.0)))
+        #expect(throws: RuntimeError.self) {
+            _ = try evaluator.evaluate(expr)
+        }
+    }
+
     // MARK: - Unary Operations
 
     @Test func testUnaryMinus() throws {


### PR DESCRIPTION
## Summary

Adds support for the bitwise OR operator `∨` to FeLangKit, enabling expressions like `5 ∨ 3` to evaluate to `7` (0b101 | 0b011 = 0b111).

This implementation follows the same pattern as the bitwise AND operator (`∧`) from #366:
- Tokenizer recognizes `∨` as `bitwiseOr` token
- Parser treats it as a binary operator with precedence 3 (same level as `bitwiseAnd`)
- Runtime evaluates integer operands using Swift's `|` operator
- Semantic analyzer enforces strict integer type checking (reals not allowed)
- Type mismatches throw appropriate errors

Closes #367

## Review & Testing Checklist for Human

- [ ] Verify precedence level 3 matches the FE pseudo-language specification for bitwise operators
- [ ] Test `5 ∨ 3` in a real FE program to confirm it outputs `7`
- [ ] Test that non-integer operands (e.g., `5.0 ∨ 3`) produce a type error

### Notes

Requested by @fumiya-kume

Link to Devin run: https://app.devin.ai/sessions/981e5113b60345d98838653ed3d991ab
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/381">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ビット論理和演算子（∨）のサポートを追加しました。整数オペランドに対して利用可能です。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->