### PR TITLE
feat: add shift operators << and >> support

### DIFF
--- a/Sources/FeLangCore/Expression/Expression.swift
+++ b/Sources/FeLangCore/Expression/Expression.swift
@@ -161,6 +161,8 @@ public enum BinaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
 
     // Bitwise operators
     case bitwiseAnd = "∧"
+    case leftShift = "<<"
+    case rightShift = ">>"
 
     // Logical operators
     case and = "and"
@@ -179,7 +181,7 @@ public enum BinaryOperator: String, CaseIterable, Equatable, Codable, Sendable {
             return 3
         case .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual:
             return 4
-        case .add, .subtract:
+        case .add, .subtract, .leftShift, .rightShift:
             return 5
         case .multiply, .divide, .modulo:
             return 6
@@ -237,6 +239,10 @@ extension BinaryOperator {
             self = .lessEqual
         case .bitwiseAnd:
             self = .bitwiseAnd
+        case .leftShift:
+            self = .leftShift
+        case .rightShift:
+            self = .rightShift
         case .andKeyword:
             self = .and
         case .orKeyword:

--- a/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
+++ b/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
@@ -897,8 +897,8 @@ public final class SemanticAnalyzer: @unchecked Sendable {
                 return .error
             }
 
-        case .bitwiseAnd:
-            // Bitwise AND only works with integers (strict check, no real allowed)
+        case .bitwiseAnd, .leftShift, .rightShift:
+            // Bitwise operators only work with integers (strict check, no real allowed)
             if case .integer = leftType, case .integer = rightType {
                 return .integer
             } else {

--- a/Sources/FeLangCore/Tokenizer/FastParsingTokenizer.swift
+++ b/Sources/FeLangCore/Tokenizer/FastParsingTokenizer.swift
@@ -445,6 +445,16 @@ public struct FastParsingTokenizer {
 
         let byte = utf8[bytePosition]
 
+        // Check for multi-character shift operators first
+        if byte == 60 && bytePosition + 1 < utf8.count && utf8[bytePosition + 1] == 60 { // "<<"
+            bytePosition += 2
+            return TokenData(type: .leftShift, lexeme: "<<")
+        }
+        if byte == 62 && bytePosition + 1 < utf8.count && utf8[bytePosition + 1] == 62 { // ">>"
+            bytePosition += 2
+            return TokenData(type: .rightShift, lexeme: ">>")
+        }
+
         // Use lookup table for O(1) operator matching
         guard let (tokenType, lexeme) = Self.asciiOperatorTable[byte] else {
             return nil

--- a/Sources/FeLangCore/Tokenizer/TokenType.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenType.swift
@@ -87,6 +87,8 @@ public enum TokenType: String, CaseIterable, Equatable, Codable, Sendable {
 
     /// Bitwise operators
     case bitwiseAnd = "∧"
+    case leftShift = "<<"
+    case rightShift = ">>"
 
     // MARK: - Delimiters
 
@@ -141,7 +143,7 @@ extension TokenType {
         switch self {
         case .plus, .minus, .multiply, .divide, .modulo, .assign,
              .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual,
-             .bitwiseAnd:
+             .bitwiseAnd, .leftShift, .rightShift:
             return true
         default:
             return false

--- a/Sources/FeLangCore/Tokenizer/Tokenizer.swift
+++ b/Sources/FeLangCore/Tokenizer/Tokenizer.swift
@@ -134,9 +134,17 @@ public final class Tokenizer {
         case "≦":
             return Token(type: .lessEqual, lexeme: "≦", position: position)
         case ">":
-            return Token(type: .greater, lexeme: ">", position: position)
+            if match(">") {
+                return Token(type: .rightShift, lexeme: ">>", position: position)
+            } else {
+                return Token(type: .greater, lexeme: ">", position: position)
+            }
         case "<":
-            return Token(type: .less, lexeme: "<", position: position)
+            if match("<") {
+                return Token(type: .leftShift, lexeme: "<<", position: position)
+            } else {
+                return Token(type: .less, lexeme: "<", position: position)
+            }
         case "∧":
             return Token(type: .bitwiseAnd, lexeme: "∧", position: position)
         case "(":

--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -89,6 +89,8 @@ public enum TokenizerUtilities {
         ("≠", .notEqual),
         (">=", .greaterEqual),
         ("<=", .lessEqual),
+        ("<<", .leftShift),
+        (">>", .rightShift),
         ("≧", .greaterEqual),
         ("≦", .lessEqual),
         ("+", .plus),

--- a/Sources/FeLangRuntime/ExpressionEvaluator.swift
+++ b/Sources/FeLangRuntime/ExpressionEvaluator.swift
@@ -204,6 +204,9 @@ public struct ExpressionEvaluator: Sendable {
         guard case .integer(let rightInt) = right else {
             throw RuntimeError.typeMismatch(expected: "Integer", actual: right.typeName, operation: "<<")
         }
+        guard rightInt >= 0 && rightInt < Int.bitWidth else {
+            throw RuntimeError.invalidOperand(operation: "<<", operandType: "shift amount \(rightInt) out of valid range (0..<\(Int.bitWidth))")
+        }
         return .integer(leftInt << rightInt)
     }
 
@@ -213,6 +216,9 @@ public struct ExpressionEvaluator: Sendable {
         }
         guard case .integer(let rightInt) = right else {
             throw RuntimeError.typeMismatch(expected: "Integer", actual: right.typeName, operation: ">>")
+        }
+        guard rightInt >= 0 && rightInt < Int.bitWidth else {
+            throw RuntimeError.invalidOperand(operation: ">>", operandType: "shift amount \(rightInt) out of valid range (0..<\(Int.bitWidth))")
         }
         return .integer(leftInt >> rightInt)
     }

--- a/Sources/FeLangRuntime/ExpressionEvaluator.swift
+++ b/Sources/FeLangRuntime/ExpressionEvaluator.swift
@@ -152,6 +152,10 @@ public struct ExpressionEvaluator: Sendable {
         // Bitwise
         case .bitwiseAnd:
             return try evaluateBitwiseAnd(left, right)
+        case .leftShift:
+            return try evaluateLeftShift(left, right)
+        case .rightShift:
+            return try evaluateRightShift(left, right)
 
         // Logical
         case .and:
@@ -191,6 +195,26 @@ public struct ExpressionEvaluator: Sendable {
             throw RuntimeError.typeMismatch(expected: "Integer", actual: right.typeName, operation: "∧")
         }
         return .integer(leftInt & rightInt)
+    }
+
+    private func evaluateLeftShift(_ left: RuntimeValue, _ right: RuntimeValue) throws -> RuntimeValue {
+        guard case .integer(let leftInt) = left else {
+            throw RuntimeError.typeMismatch(expected: "Integer", actual: left.typeName, operation: "<<")
+        }
+        guard case .integer(let rightInt) = right else {
+            throw RuntimeError.typeMismatch(expected: "Integer", actual: right.typeName, operation: "<<")
+        }
+        return .integer(leftInt << rightInt)
+    }
+
+    private func evaluateRightShift(_ left: RuntimeValue, _ right: RuntimeValue) throws -> RuntimeValue {
+        guard case .integer(let leftInt) = left else {
+            throw RuntimeError.typeMismatch(expected: "Integer", actual: left.typeName, operation: ">>")
+        }
+        guard case .integer(let rightInt) = right else {
+            throw RuntimeError.typeMismatch(expected: "Integer", actual: right.typeName, operation: ">>")
+        }
+        return .integer(leftInt >> rightInt)
     }
 
     private func evaluateAdd(_ left: RuntimeValue, _ right: RuntimeValue) throws -> RuntimeValue {

--- a/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
+++ b/Tests/FeLangCoreTests/Tokenizer/TokenizerTests.swift
@@ -49,18 +49,50 @@ struct TokenizerTests {
     }
 
     @Test func testOperators() throws {
-        let input = "+ - * / % ← = ≠ > ≧ < ≦ ∧"
+        let input = "+ - * / % ← = ≠ > ≧ < ≦ ∧ << >>"
         let tokenizer = Tokenizer(input: input)
         let tokens = try tokenizer.tokenize()
 
         let expectedTypes: [TokenType] = [
             .plus, .minus, .multiply, .divide, .modulo, .assign,
-            .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual, .bitwiseAnd, .eof
+            .equal, .notEqual, .greater, .greaterEqual, .less, .lessEqual,
+            .bitwiseAnd, .leftShift, .rightShift, .eof
         ]
 
         #expect(tokens.count == expectedTypes.count)
         for (index, expectedType) in expectedTypes.enumerated() {
             #expect(tokens[index].type == expectedType)
+        }
+    }
+
+    @Test func testShiftOperators() throws {
+        let input = "1 << 3"
+        let tokenizer = Tokenizer(input: input)
+        let tokens = try tokenizer.tokenize()
+
+        #expect(tokens.count == 4)
+        #expect(tokens[0].type == .integerLiteral)
+        #expect(tokens[0].lexeme == "1")
+        #expect(tokens[1].type == .leftShift)
+        #expect(tokens[1].lexeme == "<<")
+        #expect(tokens[2].type == .integerLiteral)
+        #expect(tokens[2].lexeme == "3")
+        #expect(tokens[3].type == .eof)
+    }
+
+    @Test func testShiftOperatorsDoNotConflictWithComparison() throws {
+        let input = "a < b << c > d >> e"
+        let tokenizer = Tokenizer(input: input)
+        let tokens = try tokenizer.tokenize()
+
+        let expectedTypes: [TokenType] = [
+            .identifier, .less, .identifier, .leftShift, .identifier,
+            .greater, .identifier, .rightShift, .identifier, .eof
+        ]
+
+        #expect(tokens.count == expectedTypes.count)
+        for (index, expectedType) in expectedTypes.enumerated() {
+            #expect(tokens[index].type == expectedType, "Token \(index): expected \(expectedType), got \(tokens[index].type)")
         }
     }
 

--- a/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
@@ -500,6 +500,52 @@ struct ExpressionEvaluatorTests {
         }
     }
 
+    @Test func testLeftShift() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.leftShift, .literal(.integer(1)), .literal(.integer(3)))
+        let result = try evaluator.evaluate(expr)
+        #expect(result == .integer(8))
+    }
+
+    @Test func testRightShift() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.rightShift, .literal(.integer(16)), .literal(.integer(2)))
+        let result = try evaluator.evaluate(expr)
+        #expect(result == .integer(4))
+    }
+
+    @Test func testLeftShiftTypeMismatchLeft() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.leftShift, .literal(.real(1.0)), .literal(.integer(3)))
+        #expect(throws: RuntimeError.self) {
+            _ = try evaluator.evaluate(expr)
+        }
+    }
+
+    @Test func testLeftShiftTypeMismatchRight() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.leftShift, .literal(.integer(1)), .literal(.real(3.0)))
+        #expect(throws: RuntimeError.self) {
+            _ = try evaluator.evaluate(expr)
+        }
+    }
+
+    @Test func testRightShiftTypeMismatchLeft() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.rightShift, .literal(.real(16.0)), .literal(.integer(2)))
+        #expect(throws: RuntimeError.self) {
+            _ = try evaluator.evaluate(expr)
+        }
+    }
+
+    @Test func testRightShiftTypeMismatchRight() throws {
+        let evaluator = makeEvaluator()
+        let expr = Expression.binary(.rightShift, .literal(.integer(16)), .literal(.real(2.0)))
+        #expect(throws: RuntimeError.self) {
+            _ = try evaluator.evaluate(expr)
+        }
+    }
+
     // MARK: - Unary Operations
 
     @Test func testUnaryMinus() throws {


### PR DESCRIPTION
## Summary

Adds support for left shift (`<<`) and right shift (`>>`) bitwise operators for integer operations in the FE pseudo-language, as requested in issue #368.

**Changes:**
- Added `leftShift` and `rightShift` token types and binary operators
- Updated tokenizer to recognize `<<` and `>>` (placed before `<` and `>` for longest-match)
- Implemented shift operator evaluation for integers with type checking
- Updated semantic analyzer to validate shift operators require integer operands

Closes #368

## Updates since last revision

- **Fixed FastParsingTokenizer**: Added explicit checks for `<<` and `>>` in `parseASCIIOperatorFast` before falling back to single-character lookup table
- **Added shift amount validation**: Shift amounts are now validated to be within range `0..<Int.bitWidth`. Invalid amounts throw `RuntimeError.invalidOperand` instead of causing a runtime crash

## Review & Testing Checklist for Human

- [ ] **Verify operator precedence is intentional**: Shift operators have precedence 5 (same as add/subtract), per issue #368 spec ("優先度は算術演算子と同程度"). This differs from C/Java where shifts have lower precedence. Confirm `1 << 2 + 3` parsing as `(1 << 2) + 3 = 7` is acceptable (C/Java would give `1 << 5 = 32`).
- [ ] **Test shift amount edge cases**: Verify that `1 << -1` and `1 << 64` throw proper errors rather than crashing.
- [ ] **Verify ParsingTokenizer works**: `ParsingTokenizer` uses `TokenizerUtilities.operators` which was updated. Confirm it correctly tokenizes shift operators.

**Suggested test plan:**
1. Run `swift test` to verify all 1265 tests pass
2. Manually test expressions like `1 << 3` (expect 8) and `16 >> 2` (expect 4)
3. Test mixed expressions like `a < b << c` to verify no conflict with comparison operators
4. Test invalid shift amounts to verify error handling

### Notes

- Link to Devin run: https://app.devin.ai/sessions/c00f0458d2c549e38ad299442afccf7c
- Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/383">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->