### PR TITLE
perf: optimize OutputBuffer string concatenation from O(n²) to O(n)

### DIFF
--- a/Sources/FeLangRuntime/Interpreter.swift
+++ b/Sources/FeLangRuntime/Interpreter.swift
@@ -149,19 +149,19 @@ extension Interpreter {
     /// Creates an interpreter that captures output.
     public static func withOutputCapture() -> (interpreter: Interpreter, getOutput: @Sendable () -> String) {
         final class OutputBuffer: @unchecked Sendable {
-            private var output = ""
+            private var outputParts: [String] = []
             private let lock = NSLock()
 
             func append(_ text: String) {
                 lock.lock()
-                output += text
+                outputParts.append(text)
                 lock.unlock()
             }
 
             func get() -> String {
                 lock.lock()
                 defer { lock.unlock() }
-                return output
+                return outputParts.joined()
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes the O(n²) performance issue in `OutputBuffer` by replacing repeated string concatenation with array-based collection and final `joined()` call.

**Before**: `output += text` creates a new string copy on each append, resulting in O(n²) time for n output operations.

**After**: `outputParts.append(text)` is O(1) amortized, and `joined()` is O(n), giving O(n) total time.

Closes #387

## Review & Testing Checklist for Human

- [ ] Verify `joined()` with no separator produces identical output to repeated `+=` concatenation
- [ ] Consider if `get()` being called multiple times warrants caching the joined result (current implementation re-joins on each call)

### Notes

All 1207 tests pass locally. Thread safety is preserved with the existing `NSLock` pattern.

Link to Devin run: https://app.devin.ai/sessions/27d6315955474b23a96e3b70f9c2378d
Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/391">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * インタープリターの内部実装を最適化しました。ユーザーに見える機能への影響はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->