### PR TITLE
feat(runtime): implement short-circuit evaluation for AND/OR operators

### DIFF
--- a/Sources/FeLangRuntime/ExpressionEvaluator.swift
+++ b/Sources/FeLangRuntime/ExpressionEvaluator.swift
@@ -34,6 +34,11 @@ public struct ExpressionEvaluator: Sendable {
             return try environment.get(name)
 
         case .binary(let operatorType, let left, let right):
+            if operatorType == .and {
+                return try evaluateShortCircuitAnd(left, right)
+            } else if operatorType == .or {
+                return try evaluateShortCircuitOr(left, right)
+            }
             let leftValue = try evaluate(left)
             let rightValue = try evaluate(right)
             return try evaluateBinary(operatorType, left: leftValue, right: rightValue)
@@ -162,34 +167,41 @@ public struct ExpressionEvaluator: Sendable {
         case .rightShift:
             return try evaluateRightShift(left, right)
 
-        // Logical
-        case .and:
-            return try evaluateLogicalAnd(left, right)
-        case .or:
-            return try evaluateLogicalOr(left, right)
+        case .and, .or:
+            fatalError("Logical operators should be handled by short-circuit evaluation")
         }
     }
 
-    // MARK: - Logical Operations
+    // MARK: - Logical Operations (Short-Circuit Evaluation)
 
-    private func evaluateLogicalAnd(_ left: RuntimeValue, _ right: RuntimeValue) throws -> RuntimeValue {
-        guard case .boolean(let leftBool) = left else {
-            throw RuntimeError.typeMismatch(expected: "Boolean", actual: left.typeName, operation: "and")
+    private func evaluateShortCircuitAnd(_ left: FEExpression, _ right: FEExpression) throws -> RuntimeValue {
+        let leftValue = try evaluate(left)
+        guard case .boolean(let leftBool) = leftValue else {
+            throw RuntimeError.typeMismatch(expected: "Boolean", actual: leftValue.typeName, operation: "and")
         }
-        guard case .boolean(let rightBool) = right else {
-            throw RuntimeError.typeMismatch(expected: "Boolean", actual: right.typeName, operation: "and")
+        if !leftBool {
+            return .boolean(false)
         }
-        return .boolean(leftBool && rightBool)
+        let rightValue = try evaluate(right)
+        guard case .boolean(let rightBool) = rightValue else {
+            throw RuntimeError.typeMismatch(expected: "Boolean", actual: rightValue.typeName, operation: "and")
+        }
+        return .boolean(rightBool)
     }
 
-    private func evaluateLogicalOr(_ left: RuntimeValue, _ right: RuntimeValue) throws -> RuntimeValue {
-        guard case .boolean(let leftBool) = left else {
-            throw RuntimeError.typeMismatch(expected: "Boolean", actual: left.typeName, operation: "or")
+    private func evaluateShortCircuitOr(_ left: FEExpression, _ right: FEExpression) throws -> RuntimeValue {
+        let leftValue = try evaluate(left)
+        guard case .boolean(let leftBool) = leftValue else {
+            throw RuntimeError.typeMismatch(expected: "Boolean", actual: leftValue.typeName, operation: "or")
         }
-        guard case .boolean(let rightBool) = right else {
-            throw RuntimeError.typeMismatch(expected: "Boolean", actual: right.typeName, operation: "or")
+        if leftBool {
+            return .boolean(true)
         }
-        return .boolean(leftBool || rightBool)
+        let rightValue = try evaluate(right)
+        guard case .boolean(let rightBool) = rightValue else {
+            throw RuntimeError.typeMismatch(expected: "Boolean", actual: rightValue.typeName, operation: "or")
+        }
+        return .boolean(rightBool)
     }
 
     private func evaluateBitwiseAnd(_ left: RuntimeValue, _ right: RuntimeValue) throws -> RuntimeValue {

--- a/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/FeLangRuntimeTests.swift
@@ -3,6 +3,14 @@ import FeLangCore
 import Foundation
 import Testing
 
+final class EvaluationTracker: @unchecked Sendable {
+    private(set) var wasEvaluated = false
+
+    func markEvaluated() {
+        wasEvaluated = true
+    }
+}
+
 // MARK: - RuntimeValue Tests
 
 struct RuntimeValueTests {
@@ -466,6 +474,126 @@ struct ExpressionEvaluatorTests {
 
         #expect(try evaluator.evaluate(falseOrTrue) == .boolean(true))
         #expect(try evaluator.evaluate(falseOrFalse) == .boolean(false))
+    }
+
+    // MARK: - Short-Circuit Evaluation Tests
+
+    @Test func testAndShortCircuitSkipsRightWhenLeftIsFalse() throws {
+        let tracker = EvaluationTracker()
+        let env = Environment()
+        let evaluator = ExpressionEvaluator(environment: env) { name, _ in
+            if name == "sideEffect" {
+                tracker.markEvaluated()
+                return .boolean(true)
+            }
+            throw RuntimeError.undefinedFunction(name: name)
+        }
+
+        let expr = Expression.binary(
+            .and,
+            .literal(.boolean(false)),
+            .functionCall("sideEffect", [])
+        )
+        let result = try evaluator.evaluate(expr)
+
+        #expect(result == .boolean(false))
+        #expect(tracker.wasEvaluated == false)
+    }
+
+    @Test func testAndEvaluatesRightWhenLeftIsTrue() throws {
+        let tracker = EvaluationTracker()
+        let env = Environment()
+        let evaluator = ExpressionEvaluator(environment: env) { name, _ in
+            if name == "sideEffect" {
+                tracker.markEvaluated()
+                return .boolean(true)
+            }
+            throw RuntimeError.undefinedFunction(name: name)
+        }
+
+        let expr = Expression.binary(
+            .and,
+            .literal(.boolean(true)),
+            .functionCall("sideEffect", [])
+        )
+        let result = try evaluator.evaluate(expr)
+
+        #expect(result == .boolean(true))
+        #expect(tracker.wasEvaluated == true)
+    }
+
+    @Test func testOrShortCircuitSkipsRightWhenLeftIsTrue() throws {
+        let tracker = EvaluationTracker()
+        let env = Environment()
+        let evaluator = ExpressionEvaluator(environment: env) { name, _ in
+            if name == "sideEffect" {
+                tracker.markEvaluated()
+                return .boolean(false)
+            }
+            throw RuntimeError.undefinedFunction(name: name)
+        }
+
+        let expr = Expression.binary(
+            .or,
+            .literal(.boolean(true)),
+            .functionCall("sideEffect", [])
+        )
+        let result = try evaluator.evaluate(expr)
+
+        #expect(result == .boolean(true))
+        #expect(tracker.wasEvaluated == false)
+    }
+
+    @Test func testOrEvaluatesRightWhenLeftIsFalse() throws {
+        let tracker = EvaluationTracker()
+        let env = Environment()
+        let evaluator = ExpressionEvaluator(environment: env) { name, _ in
+            if name == "sideEffect" {
+                tracker.markEvaluated()
+                return .boolean(true)
+            }
+            throw RuntimeError.undefinedFunction(name: name)
+        }
+
+        let expr = Expression.binary(
+            .or,
+            .literal(.boolean(false)),
+            .functionCall("sideEffect", [])
+        )
+        let result = try evaluator.evaluate(expr)
+
+        #expect(result == .boolean(true))
+        #expect(tracker.wasEvaluated == true)
+    }
+
+    @Test func testAndShortCircuitAvoidsErrorInRight() throws {
+        let env = Environment()
+        let evaluator = ExpressionEvaluator(environment: env) { name, _ in
+            throw RuntimeError.undefinedFunction(name: name)
+        }
+
+        let expr = Expression.binary(
+            .and,
+            .literal(.boolean(false)),
+            .functionCall("throwingFunction", [])
+        )
+        let result = try evaluator.evaluate(expr)
+        #expect(result == .boolean(false))
+    }
+
+    @Test func testOrShortCircuitAvoidsErrorInRight() throws {
+        let env = Environment()
+        let evaluator = ExpressionEvaluator(environment: env) { name, _ in
+            throw RuntimeError.undefinedFunction(name: name)
+        }
+
+        let expr = Expression.binary(
+            .or,
+            .literal(.boolean(true)),
+            .functionCall("throwingFunction", [])
+        )
+        let result = try evaluator.evaluate(expr)
+        #expect(result == .boolean(true))
     }
 
     // MARK: - Bitwise Operations


### PR DESCRIPTION
# feat(runtime): implement short-circuit evaluation for AND/OR operators

Closes #386

## Summary

Implements short-circuit (lazy) evaluation for logical AND (`and`) and OR (`or`) operators in the expression evaluator. Previously, both operands were always evaluated before applying the operator, which caused unnecessary computation and incorrect behavior when the right operand had side effects or errors.

**Changes:**
- AND operator: If left operand is `false`, returns `false` immediately without evaluating right operand
- OR operator: If left operand is `true`, returns `true` immediately without evaluating right operand
- Added 6 new tests verifying short-circuit behavior using side-effect tracking

## Review & Testing Checklist for Human

- [ ] Verify the short-circuit logic matches FE language specification (AND short-circuits on false, OR short-circuits on true)
- [ ] Confirm the `fatalError` in `evaluateBinary` for `.and, .or` cases is truly unreachable (these operators are now handled before `evaluateBinary` is called)
- [ ] Test with a FE program like `false and heavyFunction()` to verify the right side is not executed

**Suggested test:**
```
// This should NOT call the undefined function due to short-circuit
false and undefinedFunction()
// This should NOT call the undefined function due to short-circuit  
true or undefinedFunction()
```

### Notes

- The `EvaluationTracker` test helper uses `@unchecked Sendable` to work around Swift 6 concurrency restrictions in tests
- All 1213 existing tests pass

Link to Devin run: https://app.devin.ai/sessions/77a19b7a36be4356bf29e44655954c15
Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/393">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- 論理演算子（AND/OR）の短絡評価機能を実装しました。AND演算子では左辺がfalseの場合、右辺は評価されません。OR演算子では左辺がtrueの場合、右辺は評価されません。この変更により、不必要な計算を削減できます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->