### PR TITLE
feat: add Japanese for loop keywords (まで, ずつ)

### DIFF
--- a/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
+++ b/Sources/FeLangCore/Tokenizer/TokenizerUtilities.swift
@@ -67,6 +67,8 @@ public enum TokenizerUtilities {
         ("変数", .variableKeyword),
         ("定数", .constantKeyword),
         ("大域", .globalKeyword),
+        ("まで", .toKeyword),
+        ("ずつ", .stepKeyword),
         ("or", .orKeyword),
         ("to", .toKeyword),
         ("in", .inKeyword),

--- a/Sources/FeLangServer/CompletionProvider.swift
+++ b/Sources/FeLangServer/CompletionProvider.swift
@@ -21,7 +21,9 @@ public struct CompletionProvider: Sendable {
         CompletionItem(label: "endwhile", kind: .keyword, detail: "End while loop"),
         CompletionItem(label: "for", kind: .keyword, detail: "For loop", insertText: "for "),
         CompletionItem(label: "to", kind: .keyword, detail: "Range end"),
+        CompletionItem(label: "まで", kind: .keyword, detail: "範囲終了 (to)"),
         CompletionItem(label: "step", kind: .keyword, detail: "Loop step"),
+        CompletionItem(label: "ずつ", kind: .keyword, detail: "ステップ (step)"),
         CompletionItem(label: "endfor", kind: .keyword, detail: "End for loop"),
         CompletionItem(label: "in", kind: .keyword, detail: "For-each iteration"),
 
@@ -288,7 +290,7 @@ public struct CompletionProvider: Sendable {
             // English keywords
             "if", "then", "else", "elif", "elseif", "endif",
             "while", "do", "endwhile",
-            "for", "to", "step", "endfor", "in",
+            "for", "to", "まで", "step", "ずつ", "endfor", "in",
             "function", "endfunction", "procedure", "endprocedure",
             "class", "endclass",
             "return", "break", "continue",

--- a/Sources/FeLangServer/DefinitionProvider.swift
+++ b/Sources/FeLangServer/DefinitionProvider.swift
@@ -155,7 +155,7 @@ public struct DefinitionProvider: Sendable {
         let keywords = Set([
             "if", "then", "else", "elif", "elseif", "endif",
             "while", "do", "endwhile",
-            "for", "to", "step", "endfor", "in",
+            "for", "to", "まで", "step", "ずつ", "endfor", "in",
             "function", "endfunction", "procedure", "endprocedure",
             "class", "endclass",
             "return", "break", "continue",

--- a/Sources/FeLangServer/HoverProvider.swift
+++ b/Sources/FeLangServer/HoverProvider.swift
@@ -21,7 +21,9 @@ public struct HoverProvider: Sendable {
         "endwhile": "**endwhile** - End while\n\nMarks the end of a while loop.",
         "for": "**for** - For loop\n\nIterates over a range or collection.\n\n```fe\nfor i ← 1 to 10 do\n    // code\nendfor\n```",
         "to": "**to** - Range end\n\nSpecifies the end of a range in a for loop.",
+        "まで": "**まで** (to) - 範囲終了\n\nforループの範囲の終了値を指定します。\n\n```fe\nfor i ← 1 まで 10 do\n    // code\nendfor\n```",
         "step": "**step** - Loop step\n\nSpecifies the increment value in a for loop.",
+        "ずつ": "**ずつ** (step) - ステップ\n\nforループの増分値を指定します。\n\n```fe\nfor i ← 1 まで 10 ずつ 2 do\n    // code\nendfor\n```",
         "endfor": "**endfor** - End for\n\nMarks the end of a for loop.",
         "in": "**in** - For-each iterator\n\nIterates over elements in a collection.\n\n```fe\nfor item in array do\n    // code\nendfor\n```",
 


### PR DESCRIPTION
## Summary

Closes #394

Adds Japanese equivalents for for loop keywords:
- `まで` (made) → `to` keyword (range end)
- `ずつ` (zutsu) → `step` keyword (loop increment)

This allows writing for loops with Japanese keywords like:
```fe
for i ← 1 まで 10 ずつ 2 do
    // code
endfor
```

The implementation maps the Japanese keywords to the same TokenTypes as their English equivalents, so no parser changes were needed.

## Review & Testing Checklist for Human

- [ ] Verify the Japanese keywords tokenize correctly by testing `for i ← 1 まで 10 do ... endfor` in the REPL or a test file
- [ ] Verify the step keyword works: `for i ← 1 まで 10 ずつ 2 do ... endfor`
- [ ] Check that LSP hover documentation displays correctly for `まで` and `ずつ`

**Recommended test plan:** Create a simple FE program using the Japanese for loop syntax and run it to verify end-to-end functionality. No explicit unit tests were added for the new keywords.

### Notes

- Link to Devin run: https://app.devin.ai/sessions/76aed4a676b34ce5a2db6cbead882bf0
- Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/397">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
