### PR TITLE
perf: remove NSLock overhead from OutputBuffer

### DIFF
--- a/Sources/FeLangRuntime/Interpreter.swift
+++ b/Sources/FeLangRuntime/Interpreter.swift
@@ -147,21 +147,23 @@ extension Interpreter {
     }
 
     /// Creates an interpreter that captures output.
+    ///
+    /// - Note: The returned closures are designed for single-threaded use where
+    ///   `printHandler` is called during execution and `getOutput` is called after
+    ///   execution completes. They should not be called concurrently.
     public static func withOutputCapture() -> (interpreter: Interpreter, getOutput: @Sendable () -> String) {
+        // OutputBuffer is marked @unchecked Sendable because the closures need to be Sendable,
+        // but the buffer is only accessed sequentially (append during execution, get after).
+        // NSLock was removed to eliminate unnecessary synchronization overhead.
         final class OutputBuffer: @unchecked Sendable {
             private var outputParts: [String] = []
-            private let lock = NSLock()
 
             func append(_ text: String) {
-                lock.lock()
                 outputParts.append(text)
-                lock.unlock()
             }
 
             func get() -> String {
-                lock.lock()
-                defer { lock.unlock() }
-                return outputParts.joined()
+                outputParts.joined()
             }
         }
 

--- a/Sources/FeLangRuntime/Interpreter.swift
+++ b/Sources/FeLangRuntime/Interpreter.swift
@@ -154,7 +154,12 @@ extension Interpreter {
     public static func withOutputCapture() -> (interpreter: Interpreter, getOutput: @Sendable () -> String) {
         // OutputBuffer is marked @unchecked Sendable because the closures need to be Sendable,
         // but the buffer is only accessed sequentially (append during execution, get after).
-        // NSLock was removed to eliminate unnecessary synchronization overhead.
+        // NSLock was removed to avoid taking and releasing a lock on every print call, which
+        // would add unnecessary synchronization overhead in the common single-threaded case.
+        //
+        // Callers MUST ensure that all accesses to OutputBuffer are sequential (no concurrent
+        // calls to the returned printHandler and getOutput). Violating this assumption can
+        // lead to data races and undefined behavior.
         final class OutputBuffer: @unchecked Sendable {
             private var outputParts: [String] = []
 


### PR DESCRIPTION
## Summary

Removes unnecessary `NSLock` synchronization from the `OutputBuffer` class in `withOutputCapture()`. Since the interpreter executes in a single thread, the buffer is only accessed sequentially: `append()` is called during execution and `get()` is called after execution completes. The lock/unlock operations on every print call added overhead without providing any benefit.

Added documentation to clarify the single-threaded usage assumption.

Closes #390

## Review & Testing Checklist for Human

- [ ] **Verify the single-threaded assumption is valid for all callers** - The class remains marked `@unchecked Sendable` but no longer has actual thread-safety. Confirm no code path calls `printHandler` and `getOutput` concurrently.
- [ ] **Check if `InProcessTestHelper`'s global lock is sufficient** - That helper serializes execution, but verify other test files or production code don't use `withOutputCapture()` in concurrent scenarios.

### Notes

The `@unchecked Sendable` annotation is kept because the closures need to conform to `Sendable`, but the actual synchronization is removed. This is safe only if the documented single-threaded usage pattern is followed.

Link to Devin run: https://app.devin.ai/sessions/488c2c874f6d4ba3b2e46a396f80f60d
Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/398">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
