### PR TITLE
Resolve P5-27: Runtime C ABI signatures strictification (spec.md J16.1)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,12 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "FeLangCABI",
+            dependencies: [],
+            path: "Sources/FeLangCABI",
+            publicHeadersPath: "include"
+        ),
+        .target(
             name: "FeLangCore",
             dependencies: [
                 .product(name: "Parsing", package: "swift-parsing")
@@ -41,7 +47,8 @@ let package = Package(
         .target(
             name: "FeLangRuntime",
             dependencies: [
-                "FeLangCore"
+                "FeLangCore",
+                "FeLangCABI"
             ]
         ),
         .target(
@@ -78,6 +85,9 @@ let package = Package(
             name: "FeLangRuntimeTests",
             dependencies: [
                 "FeLangRuntime"
+            ],
+            resources: [
+                .copy("Resources")
             ]
         ),
         .testTarget(

--- a/Sources/FeLangCABI/include/felang_runtime_abi.h
+++ b/Sources/FeLangCABI/include/felang_runtime_abi.h
@@ -65,7 +65,7 @@ double kk_value_get_real(void * val);
 /** Extract boolean payload. Undefined behaviour if tag != 2. */
 bool kk_value_get_boolean(void * val);
 
-/** Extract null-terminated UTF-8 string pointer. Undefined behaviour if tag != 3. */
+/** Extract null-terminated UTF-8 string. Caller must free() the returned pointer. Undefined behaviour if tag != 3. */
 const char * kk_value_get_string(void * val);
 
 /** Return byte length of string payload. Undefined behaviour if tag != 3. */
@@ -79,7 +79,7 @@ void kk_print(const char * str);
 /** Print a null-terminated string to stdout followed by a newline. */
 void kk_println(const char * str);
 
-/** Read a line from stdin. Returns NULL on EOF. */
+/** Read a line from stdin. Returns NULL on EOF. Caller must free() the returned pointer. */
 const char * _Nullable kk_input(void);
 
 /* --- Array --- */

--- a/Sources/FeLangCABI/include/felang_runtime_abi.h
+++ b/Sources/FeLangCABI/include/felang_runtime_abi.h
@@ -1,0 +1,129 @@
+#ifndef FELANG_RUNTIME_ABI_H
+#define FELANG_RUNTIME_ABI_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/*
+ * FeLangKit Runtime C ABI
+ * Auto-generated from RuntimeABISpec v1.0.0
+ *
+ * This header is the canonical reference for compiler backends.
+ * Do NOT edit manually; regenerate from the spec instead.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* --- Memory Management --- */
+
+/** Allocate size bytes. Returns NULL on failure. */
+void * _Nullable kk_alloc(int64_t size);
+
+/** Reallocate ptr to new_size bytes. Returns NULL on failure. */
+void * _Nullable kk_realloc(void * _Nullable ptr, int64_t new_size);
+
+/** Free memory at ptr. No-op if ptr is NULL. */
+void kk_free(void * _Nullable ptr);
+
+/** Increment reference count for obj. */
+void kk_retain(void * obj);
+
+/** Decrement reference count for obj. Frees when count reaches 0. */
+void kk_release(void * obj);
+
+/* --- Value Creation --- */
+
+/** Create a boxed integer value. */
+void * kk_value_integer(int64_t value);
+
+/** Create a boxed real (double) value. */
+void * kk_value_real(double value);
+
+/** Create a boxed boolean value. */
+void * kk_value_boolean(bool value);
+
+/** Create a boxed string value from a UTF-8 buffer and byte length. */
+void * kk_value_string(const char * str, int64_t len);
+
+/** Create a boxed null value. */
+void * kk_value_null(void);
+
+/* --- Value Access --- */
+
+/** Return the type tag of a boxed value (0=int,1=real,2=bool,3=string,4=null,5=array). */
+int32_t kk_value_get_tag(void * val);
+
+/** Extract integer payload. Undefined behaviour if tag != 0. */
+int64_t kk_value_get_integer(void * val);
+
+/** Extract real payload. Undefined behaviour if tag != 1. */
+double kk_value_get_real(void * val);
+
+/** Extract boolean payload. Undefined behaviour if tag != 2. */
+bool kk_value_get_boolean(void * val);
+
+/** Extract null-terminated UTF-8 string pointer. Undefined behaviour if tag != 3. */
+const char * kk_value_get_string(void * val);
+
+/** Return byte length of string payload. Undefined behaviour if tag != 3. */
+int64_t kk_value_get_string_len(void * val);
+
+/* --- I/O --- */
+
+/** Print a null-terminated string to stdout (no trailing newline). */
+void kk_print(const char * str);
+
+/** Print a null-terminated string to stdout followed by a newline. */
+void kk_println(const char * str);
+
+/** Read a line from stdin. Returns NULL on EOF. */
+const char * _Nullable kk_input(void);
+
+/* --- Array --- */
+
+/** Create a new empty array with the given initial capacity. */
+void * kk_array_new(int64_t capacity);
+
+/** Return the number of elements in the array. */
+int64_t kk_array_length(void * arr);
+
+/** Return the element at the given index. Traps on out-of-bounds. */
+void * kk_array_get(void * arr, int64_t index);
+
+/** Set the element at the given index. Traps on out-of-bounds. */
+void kk_array_set(void * arr, int64_t index, void * value);
+
+/** Append value to the end of the array. */
+void kk_array_push(void * arr, void * value);
+
+/* --- Environment --- */
+
+/** Create a new runtime environment. */
+void * kk_env_new(void);
+
+/** Destroy a runtime environment and free resources. */
+void kk_env_destroy(void * env);
+
+/** Define a variable in the current scope. */
+void kk_env_define(void * env, const char * name, void * value);
+
+/** Look up a variable by name. Returns NULL if not found. */
+void * _Nullable kk_env_get(void * env, const char * name);
+
+/** Assign a new value to an existing variable. Returns false if undefined. */
+bool kk_env_set(void * env, const char * name, void * value);
+
+/** Push a new variable scope. */
+void kk_env_push_scope(void * env);
+
+/** Pop the innermost variable scope. */
+void kk_env_pop_scope(void * env);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FELANG_RUNTIME_ABI_H */

--- a/Sources/FeLangCABI/shims.c
+++ b/Sources/FeLangCABI/shims.c
@@ -1,0 +1,1 @@
+/* Empty translation unit required by Swift Package Manager for C targets. */

--- a/Sources/FeLangRuntime/ABI/ABIHeaderGenerator.swift
+++ b/Sources/FeLangRuntime/ABI/ABIHeaderGenerator.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+public enum ABIHeaderGenerator {
+    public static func generate(
+        functions: [ABIFunctionSpec] = RuntimeABISpec.allFunctions,
+        version: String = RuntimeABISpec.specVersion
+    ) -> String {
+        var lines: [String] = []
+
+        lines.append("#ifndef FELANG_RUNTIME_ABI_H")
+        lines.append("#define FELANG_RUNTIME_ABI_H")
+        lines.append("")
+        lines.append("#include <stdint.h>")
+        lines.append("#include <stdbool.h>")
+        lines.append("#include <stddef.h>")
+        lines.append("")
+        lines.append("/*")
+        lines.append(" * FeLangKit Runtime C ABI")
+        lines.append(" * Auto-generated from RuntimeABISpec v\(version)")
+        lines.append(" *")
+        lines.append(" * This header is the canonical reference for compiler backends.")
+        lines.append(" * Do NOT edit manually; regenerate from the spec instead.")
+        lines.append(" */")
+        lines.append("")
+        lines.append("#ifdef __cplusplus")
+        lines.append("extern \"C\" {")
+        lines.append("#endif")
+        lines.append("")
+
+        var currentSection = ""
+        for spec in functions {
+            let section = sectionName(for: spec.name)
+            if section != currentSection {
+                if !currentSection.isEmpty {
+                    lines.append("")
+                }
+                lines.append("/* --- \(section) --- */")
+                lines.append("")
+                currentSection = section
+            }
+
+            lines.append("/** \(spec.description) */")
+            lines.append(spec.cDeclaration)
+            lines.append("")
+        }
+
+        lines.append("#ifdef __cplusplus")
+        lines.append("}")
+        lines.append("#endif")
+        lines.append("")
+        lines.append("#endif /* FELANG_RUNTIME_ABI_H */")
+        lines.append("")
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func sectionName(for functionName: String) -> String {
+        if functionName.hasPrefix("kk_alloc")
+            || functionName.hasPrefix("kk_realloc")
+            || functionName.hasPrefix("kk_free")
+            || functionName.hasPrefix("kk_retain")
+            || functionName.hasPrefix("kk_release") {
+            return "Memory Management"
+        } else if functionName.hasPrefix("kk_value_get") {
+            return "Value Access"
+        } else if functionName.hasPrefix("kk_value") {
+            return "Value Creation"
+        } else if functionName.hasPrefix("kk_print")
+                    || functionName.hasPrefix("kk_println")
+                    || functionName.hasPrefix("kk_input") {
+            return "I/O"
+        } else if functionName.hasPrefix("kk_array") {
+            return "Array"
+        } else if functionName.hasPrefix("kk_env") {
+            return "Environment"
+        }
+        return "Other"
+    }
+}

--- a/Sources/FeLangRuntime/ABI/RuntimeABIFunctions.swift
+++ b/Sources/FeLangRuntime/ABI/RuntimeABIFunctions.swift
@@ -139,10 +139,7 @@ public func kk_value_get_string(
 ) -> UnsafePointer<CChar> {
     let box = borrowedBox(val)
     return box.stringPayload.withCString { ptr in
-        let len = strlen(ptr) + 1
-        let buf = UnsafeMutablePointer<CChar>.allocate(capacity: len)
-        buf.initialize(from: ptr, count: len)
-        return UnsafePointer(buf)
+        return UnsafePointer(strdup(ptr)!)
     }
 }
 
@@ -170,10 +167,7 @@ public func kk_println(_ str: UnsafePointer<CChar>) {
 public func kk_input() -> UnsafePointer<CChar>? {
     guard let line = readLine() else { return nil }
     return line.withCString { ptr in
-        let len = strlen(ptr) + 1
-        let buf = UnsafeMutablePointer<CChar>.allocate(capacity: len)
-        buf.initialize(from: ptr, count: len)
-        return UnsafePointer(buf)
+        return UnsafePointer(strdup(ptr)!)
     }
 }
 
@@ -339,7 +333,7 @@ private func runtimeValueToBoxedPointer(_ value: RuntimeValue) -> UnsafeMutableR
         let box = BoxedValue(tag: .array)
         box.arrayPayload = arrayElements.map { element -> BoxedValue in
             let ptr = runtimeValueToBoxedPointer(element)
-            let child = borrowedBox(ptr)
+            let child = Unmanaged<BoxedValue>.fromOpaque(ptr).takeRetainedValue()
             return child
         }
         return retainedPointer(box)

--- a/Sources/FeLangRuntime/ABI/RuntimeABIFunctions.swift
+++ b/Sources/FeLangRuntime/ABI/RuntimeABIFunctions.swift
@@ -1,0 +1,355 @@
+import Foundation
+
+private enum ValueTag: Int32 {
+    case integer = 0
+    case real = 1
+    case boolean = 2
+    case string = 3
+    case null = 4
+    case array = 5
+}
+
+private final class BoxedValue {
+    let tag: ValueTag
+    var integerPayload: Int64 = 0
+    var realPayload: Double = 0.0
+    var booleanPayload: Bool = false
+    var stringPayload: String = ""
+    var arrayPayload: [BoxedValue] = []
+    var refCount: Int = 1
+
+    init(tag: ValueTag) {
+        self.tag = tag
+    }
+}
+
+private func retainedPointer(_ box: BoxedValue) -> UnsafeMutableRawPointer {
+    let unmanaged = Unmanaged.passRetained(box)
+    return unmanaged.toOpaque()
+}
+
+private func borrowedBox(_ ptr: UnsafeMutableRawPointer) -> BoxedValue {
+    return Unmanaged<BoxedValue>.fromOpaque(ptr).takeUnretainedValue()
+}
+
+// MARK: - J16.1.1 Memory Management
+
+@_cdecl("kk_alloc")
+public func kk_alloc(_ size: Int64) -> UnsafeMutableRawPointer? {
+    guard size > 0 else { return nil }
+    return malloc(Int(size))
+}
+
+@_cdecl("kk_realloc")
+public func kk_realloc(
+    _ ptr: UnsafeMutableRawPointer?,
+    _ newSize: Int64
+) -> UnsafeMutableRawPointer? {
+    guard newSize > 0 else {
+        if let ptr = ptr { free(ptr) }
+        return nil
+    }
+    return realloc(ptr, Int(newSize))
+}
+
+@_cdecl("kk_free")
+public func kk_free(_ ptr: UnsafeMutableRawPointer?) {
+    guard let ptr = ptr else { return }
+    free(ptr)
+}
+
+@_cdecl("kk_retain")
+public func kk_retain(_ obj: UnsafeMutableRawPointer) {
+    let box = borrowedBox(obj)
+    box.refCount += 1
+}
+
+@_cdecl("kk_release")
+public func kk_release(_ obj: UnsafeMutableRawPointer) {
+    let box = borrowedBox(obj)
+    box.refCount -= 1
+    if box.refCount <= 0 {
+        Unmanaged<BoxedValue>.fromOpaque(obj).release()
+    }
+}
+
+// MARK: - J16.1.2 Value Creation
+
+@_cdecl("kk_value_integer")
+public func kk_value_integer(_ value: Int64) -> UnsafeMutableRawPointer {
+    let box = BoxedValue(tag: .integer)
+    box.integerPayload = value
+    return retainedPointer(box)
+}
+
+@_cdecl("kk_value_real")
+public func kk_value_real(_ value: Double) -> UnsafeMutableRawPointer {
+    let box = BoxedValue(tag: .real)
+    box.realPayload = value
+    return retainedPointer(box)
+}
+
+@_cdecl("kk_value_boolean")
+public func kk_value_boolean(_ value: Bool) -> UnsafeMutableRawPointer {
+    let box = BoxedValue(tag: .boolean)
+    box.booleanPayload = value
+    return retainedPointer(box)
+}
+
+@_cdecl("kk_value_string")
+public func kk_value_string(
+    _ str: UnsafePointer<CChar>,
+    _ len: Int64
+) -> UnsafeMutableRawPointer {
+    let box = BoxedValue(tag: .string)
+    let data = Data(bytes: str, count: Int(len))
+    box.stringPayload = String(data: data, encoding: .utf8) ?? ""
+    return retainedPointer(box)
+}
+
+@_cdecl("kk_value_null")
+public func kk_value_null() -> UnsafeMutableRawPointer {
+    let box = BoxedValue(tag: .null)
+    return retainedPointer(box)
+}
+
+// MARK: - J16.1.3 Value Access
+
+@_cdecl("kk_value_get_tag")
+public func kk_value_get_tag(_ val: UnsafeMutableRawPointer) -> Int32 {
+    let box = borrowedBox(val)
+    return box.tag.rawValue
+}
+
+@_cdecl("kk_value_get_integer")
+public func kk_value_get_integer(_ val: UnsafeMutableRawPointer) -> Int64 {
+    let box = borrowedBox(val)
+    return box.integerPayload
+}
+
+@_cdecl("kk_value_get_real")
+public func kk_value_get_real(_ val: UnsafeMutableRawPointer) -> Double {
+    let box = borrowedBox(val)
+    return box.realPayload
+}
+
+@_cdecl("kk_value_get_boolean")
+public func kk_value_get_boolean(_ val: UnsafeMutableRawPointer) -> Bool {
+    let box = borrowedBox(val)
+    return box.booleanPayload
+}
+
+@_cdecl("kk_value_get_string")
+public func kk_value_get_string(
+    _ val: UnsafeMutableRawPointer
+) -> UnsafePointer<CChar> {
+    let box = borrowedBox(val)
+    return box.stringPayload.withCString { ptr in
+        let len = strlen(ptr) + 1
+        let buf = UnsafeMutablePointer<CChar>.allocate(capacity: len)
+        buf.initialize(from: ptr, count: len)
+        return UnsafePointer(buf)
+    }
+}
+
+@_cdecl("kk_value_get_string_len")
+public func kk_value_get_string_len(_ val: UnsafeMutableRawPointer) -> Int64 {
+    let box = borrowedBox(val)
+    return Int64(box.stringPayload.utf8.count)
+}
+
+// MARK: - J16.1.4 I/O
+
+@_cdecl("kk_print")
+public func kk_print(_ str: UnsafePointer<CChar>) {
+    let text = String(cString: str)
+    print(text, terminator: "")
+}
+
+@_cdecl("kk_println")
+public func kk_println(_ str: UnsafePointer<CChar>) {
+    let text = String(cString: str)
+    print(text)
+}
+
+@_cdecl("kk_input")
+public func kk_input() -> UnsafePointer<CChar>? {
+    guard let line = readLine() else { return nil }
+    return line.withCString { ptr in
+        let len = strlen(ptr) + 1
+        let buf = UnsafeMutablePointer<CChar>.allocate(capacity: len)
+        buf.initialize(from: ptr, count: len)
+        return UnsafePointer(buf)
+    }
+}
+
+// MARK: - J16.1.5 Array
+
+@_cdecl("kk_array_new")
+public func kk_array_new(_ capacity: Int64) -> UnsafeMutableRawPointer {
+    let box = BoxedValue(tag: .array)
+    box.arrayPayload.reserveCapacity(Int(capacity))
+    return retainedPointer(box)
+}
+
+@_cdecl("kk_array_length")
+public func kk_array_length(_ arr: UnsafeMutableRawPointer) -> Int64 {
+    let box = borrowedBox(arr)
+    return Int64(box.arrayPayload.count)
+}
+
+@_cdecl("kk_array_get")
+public func kk_array_get(
+    _ arr: UnsafeMutableRawPointer,
+    _ index: Int64
+) -> UnsafeMutableRawPointer {
+    let box = borrowedBox(arr)
+    precondition(index >= 0 && Int(index) < box.arrayPayload.count, "kk_array_get: index out of bounds")
+    let element = box.arrayPayload[Int(index)]
+    element.refCount += 1
+    return Unmanaged.passUnretained(element).toOpaque()
+}
+
+@_cdecl("kk_array_set")
+public func kk_array_set(
+    _ arr: UnsafeMutableRawPointer,
+    _ index: Int64,
+    _ value: UnsafeMutableRawPointer
+) {
+    let box = borrowedBox(arr)
+    precondition(index >= 0 && Int(index) < box.arrayPayload.count, "kk_array_set: index out of bounds")
+    let newElement = borrowedBox(value)
+    box.arrayPayload[Int(index)] = newElement
+}
+
+@_cdecl("kk_array_push")
+public func kk_array_push(
+    _ arr: UnsafeMutableRawPointer,
+    _ value: UnsafeMutableRawPointer
+) {
+    let box = borrowedBox(arr)
+    let element = borrowedBox(value)
+    box.arrayPayload.append(element)
+}
+
+// MARK: - J16.1.6 Environment
+
+private final class BoxedEnvironment {
+    let environment: Environment
+
+    init() {
+        self.environment = Environment()
+    }
+}
+
+@_cdecl("kk_env_new")
+public func kk_env_new() -> UnsafeMutableRawPointer {
+    let boxed = BoxedEnvironment()
+    return Unmanaged.passRetained(boxed).toOpaque()
+}
+
+@_cdecl("kk_env_destroy")
+public func kk_env_destroy(_ env: UnsafeMutableRawPointer) {
+    Unmanaged<BoxedEnvironment>.fromOpaque(env).release()
+}
+
+@_cdecl("kk_env_define")
+public func kk_env_define(
+    _ env: UnsafeMutableRawPointer,
+    _ name: UnsafePointer<CChar>,
+    _ value: UnsafeMutableRawPointer
+) {
+    let boxedEnv = Unmanaged<BoxedEnvironment>.fromOpaque(env).takeUnretainedValue()
+    let nameStr = String(cString: name)
+    let runtimeValue = boxedValueToRuntimeValue(value)
+    boxedEnv.environment.define(nameStr, value: runtimeValue)
+}
+
+@_cdecl("kk_env_get")
+public func kk_env_get(
+    _ env: UnsafeMutableRawPointer,
+    _ name: UnsafePointer<CChar>
+) -> UnsafeMutableRawPointer? {
+    let boxedEnv = Unmanaged<BoxedEnvironment>.fromOpaque(env).takeUnretainedValue()
+    let nameStr = String(cString: name)
+    guard let value = boxedEnv.environment.lookup(nameStr) else { return nil }
+    return runtimeValueToBoxedPointer(value)
+}
+
+@_cdecl("kk_env_set")
+public func kk_env_set(
+    _ env: UnsafeMutableRawPointer,
+    _ name: UnsafePointer<CChar>,
+    _ value: UnsafeMutableRawPointer
+) -> Bool {
+    let boxedEnv = Unmanaged<BoxedEnvironment>.fromOpaque(env).takeUnretainedValue()
+    let nameStr = String(cString: name)
+    let runtimeValue = boxedValueToRuntimeValue(value)
+    do {
+        try boxedEnv.environment.assign(nameStr, value: runtimeValue)
+        return true
+    } catch {
+        return false
+    }
+}
+
+@_cdecl("kk_env_push_scope")
+public func kk_env_push_scope(_ env: UnsafeMutableRawPointer) {
+    let boxedEnv = Unmanaged<BoxedEnvironment>.fromOpaque(env).takeUnretainedValue()
+    try? boxedEnv.environment.pushScope()
+}
+
+@_cdecl("kk_env_pop_scope")
+public func kk_env_pop_scope(_ env: UnsafeMutableRawPointer) {
+    let boxedEnv = Unmanaged<BoxedEnvironment>.fromOpaque(env).takeUnretainedValue()
+    boxedEnv.environment.popScope()
+}
+
+// MARK: - Internal Conversion
+
+private func boxedValueToRuntimeValue(_ ptr: UnsafeMutableRawPointer) -> RuntimeValue {
+    let box = borrowedBox(ptr)
+    switch box.tag {
+    case .integer: return .integer(Int(box.integerPayload))
+    case .real: return .real(box.realPayload)
+    case .boolean: return .boolean(box.booleanPayload)
+    case .string: return .string(box.stringPayload)
+    case .null: return .null
+    case .array:
+        let elements = box.arrayPayload.map { child -> RuntimeValue in
+            switch child.tag {
+            case .integer: return .integer(Int(child.integerPayload))
+            case .real: return .real(child.realPayload)
+            case .boolean: return .boolean(child.booleanPayload)
+            case .string: return .string(child.stringPayload)
+            case .null: return .null
+            case .array: return .null
+            }
+        }
+        return .array(elements)
+    }
+}
+
+private func runtimeValueToBoxedPointer(_ value: RuntimeValue) -> UnsafeMutableRawPointer {
+    switch value {
+    case .integer(let intVal):
+        let box = BoxedValue(tag: .integer)
+        box.integerPayload = Int64(intVal)
+        return retainedPointer(box)
+    case .real(let realVal):
+        let box = BoxedValue(tag: .real)
+        box.realPayload = realVal
+        return retainedPointer(box)
+    case .boolean(let boolVal):
+        let box = BoxedValue(tag: .boolean)
+        box.booleanPayload = boolVal
+        return retainedPointer(box)
+    case .string(let strVal):
+        let box = BoxedValue(tag: .string)
+        box.stringPayload = strVal
+        return retainedPointer(box)
+    default:
+        let box = BoxedValue(tag: .null)
+        return retainedPointer(box)
+    }
+}

--- a/Sources/FeLangRuntime/ABI/RuntimeABIFunctions.swift
+++ b/Sources/FeLangRuntime/ABI/RuntimeABIFunctions.swift
@@ -310,14 +310,8 @@ private func boxedValueToRuntimeValue(_ ptr: UnsafeMutableRawPointer) -> Runtime
     case .null: return .null
     case .array:
         let elements = box.arrayPayload.map { child -> RuntimeValue in
-            switch child.tag {
-            case .integer: return .integer(Int(child.integerPayload))
-            case .real: return .real(child.realPayload)
-            case .boolean: return .boolean(child.booleanPayload)
-            case .string: return .string(child.stringPayload)
-            case .null: return .null
-            case .array: return .null
-            }
+            let childPtr = Unmanaged.passUnretained(child).toOpaque()
+            return boxedValueToRuntimeValue(childPtr)
         }
         return .array(elements)
     }
@@ -340,6 +334,14 @@ private func runtimeValueToBoxedPointer(_ value: RuntimeValue) -> UnsafeMutableR
     case .string(let strVal):
         let box = BoxedValue(tag: .string)
         box.stringPayload = strVal
+        return retainedPointer(box)
+    case .array(let arrayElements):
+        let box = BoxedValue(tag: .array)
+        box.arrayPayload = arrayElements.map { element -> BoxedValue in
+            let ptr = runtimeValueToBoxedPointer(element)
+            let child = borrowedBox(ptr)
+            return child
+        }
         return retainedPointer(box)
     default:
         let box = BoxedValue(tag: .null)

--- a/Sources/FeLangRuntime/ABI/RuntimeABIFunctions.swift
+++ b/Sources/FeLangRuntime/ABI/RuntimeABIFunctions.swift
@@ -16,7 +16,6 @@ private final class BoxedValue {
     var booleanPayload: Bool = false
     var stringPayload: String = ""
     var arrayPayload: [BoxedValue] = []
-    var refCount: Int = 1
 
     init(tag: ValueTag) {
         self.tag = tag
@@ -60,17 +59,12 @@ public func kk_free(_ ptr: UnsafeMutableRawPointer?) {
 
 @_cdecl("kk_retain")
 public func kk_retain(_ obj: UnsafeMutableRawPointer) {
-    let box = borrowedBox(obj)
-    box.refCount += 1
+    Unmanaged<BoxedValue>.fromOpaque(obj).retain()
 }
 
 @_cdecl("kk_release")
 public func kk_release(_ obj: UnsafeMutableRawPointer) {
-    let box = borrowedBox(obj)
-    box.refCount -= 1
-    if box.refCount <= 0 {
-        Unmanaged<BoxedValue>.fromOpaque(obj).release()
-    }
+    Unmanaged<BoxedValue>.fromOpaque(obj).release()
 }
 
 // MARK: - J16.1.2 Value Creation
@@ -206,8 +200,7 @@ public func kk_array_get(
     let box = borrowedBox(arr)
     precondition(index >= 0 && Int(index) < box.arrayPayload.count, "kk_array_get: index out of bounds")
     let element = box.arrayPayload[Int(index)]
-    element.refCount += 1
-    return Unmanaged.passUnretained(element).toOpaque()
+    return Unmanaged.passRetained(element).toOpaque()
 }
 
 @_cdecl("kk_array_set")

--- a/Sources/FeLangRuntime/ABI/RuntimeABIFunctions.swift
+++ b/Sources/FeLangRuntime/ABI/RuntimeABIFunctions.swift
@@ -96,7 +96,8 @@ public func kk_value_string(
     _ len: Int64
 ) -> UnsafeMutableRawPointer {
     let box = BoxedValue(tag: .string)
-    let data = Data(bytes: str, count: Int(len))
+    let safeLen = max(Int(len), 0)
+    let data = Data(bytes: str, count: safeLen)
     box.stringPayload = String(data: data, encoding: .utf8) ?? ""
     return retainedPointer(box)
 }

--- a/Sources/FeLangRuntime/ABI/RuntimeABISpec.swift
+++ b/Sources/FeLangRuntime/ABI/RuntimeABISpec.swift
@@ -1,0 +1,371 @@
+import Foundation
+
+public enum ABIType: Equatable, Sendable {
+    case void
+    case int32
+    case int64
+    case float64
+    case bool
+    case opaquePointer
+    case nullableOpaquePointer
+    case cString
+    case nullableCString
+
+    public var cTypeName: String {
+        switch self {
+        case .void: return "void"
+        case .int32: return "int32_t"
+        case .int64: return "int64_t"
+        case .float64: return "double"
+        case .bool: return "bool"
+        case .opaquePointer: return "void *"
+        case .nullableOpaquePointer: return "void * _Nullable"
+        case .cString: return "const char *"
+        case .nullableCString: return "const char * _Nullable"
+        }
+    }
+
+    public var isNullable: Bool {
+        switch self {
+        case .nullableOpaquePointer, .nullableCString:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+public struct ABIParameterSpec: Equatable, Sendable {
+    public let name: String
+    public let type: ABIType
+
+    public init(name: String, type: ABIType) {
+        self.name = name
+        self.type = type
+    }
+}
+
+public struct ABIFunctionSpec: Equatable, Sendable {
+    public let name: String
+    public let returnType: ABIType
+    public let parameters: [ABIParameterSpec]
+    public let description: String
+
+    public init(
+        name: String,
+        returnType: ABIType,
+        parameters: [ABIParameterSpec],
+        description: String
+    ) {
+        self.name = name
+        self.returnType = returnType
+        self.parameters = parameters
+        self.description = description
+    }
+
+    public var cDeclaration: String {
+        let params: String
+        if parameters.isEmpty {
+            params = "void"
+        } else {
+            params = parameters
+                .map { "\($0.type.cTypeName) \($0.name)" }
+                .joined(separator: ", ")
+        }
+        return "\(returnType.cTypeName) \(name)(\(params));"
+    }
+}
+
+public enum RuntimeABISpec {
+    public static let specVersion = "1.0.0"
+
+    public static let allFunctions: [ABIFunctionSpec] = memoryFunctions
+        + valueCreationFunctions
+        + valueAccessFunctions
+        + ioFunctions
+        + arrayFunctions
+        + environmentFunctions
+
+    // MARK: - J16.1.1 Memory Management
+
+    public static let memoryFunctions: [ABIFunctionSpec] = [
+        ABIFunctionSpec(
+            name: "kk_alloc",
+            returnType: .nullableOpaquePointer,
+            parameters: [
+                ABIParameterSpec(name: "size", type: .int64)
+            ],
+            description: "Allocate size bytes. Returns NULL on failure."
+        ),
+        ABIFunctionSpec(
+            name: "kk_realloc",
+            returnType: .nullableOpaquePointer,
+            parameters: [
+                ABIParameterSpec(name: "ptr", type: .nullableOpaquePointer),
+                ABIParameterSpec(name: "new_size", type: .int64)
+            ],
+            description: "Reallocate ptr to new_size bytes. Returns NULL on failure."
+        ),
+        ABIFunctionSpec(
+            name: "kk_free",
+            returnType: .void,
+            parameters: [
+                ABIParameterSpec(name: "ptr", type: .nullableOpaquePointer)
+            ],
+            description: "Free memory at ptr. No-op if ptr is NULL."
+        ),
+        ABIFunctionSpec(
+            name: "kk_retain",
+            returnType: .void,
+            parameters: [
+                ABIParameterSpec(name: "obj", type: .opaquePointer)
+            ],
+            description: "Increment reference count for obj."
+        ),
+        ABIFunctionSpec(
+            name: "kk_release",
+            returnType: .void,
+            parameters: [
+                ABIParameterSpec(name: "obj", type: .opaquePointer)
+            ],
+            description: "Decrement reference count for obj. Frees when count reaches 0."
+        )
+    ]
+
+    // MARK: - J16.1.2 Value Creation
+
+    public static let valueCreationFunctions: [ABIFunctionSpec] = [
+        ABIFunctionSpec(
+            name: "kk_value_integer",
+            returnType: .opaquePointer,
+            parameters: [
+                ABIParameterSpec(name: "value", type: .int64)
+            ],
+            description: "Create a boxed integer value."
+        ),
+        ABIFunctionSpec(
+            name: "kk_value_real",
+            returnType: .opaquePointer,
+            parameters: [
+                ABIParameterSpec(name: "value", type: .float64)
+            ],
+            description: "Create a boxed real (double) value."
+        ),
+        ABIFunctionSpec(
+            name: "kk_value_boolean",
+            returnType: .opaquePointer,
+            parameters: [
+                ABIParameterSpec(name: "value", type: .bool)
+            ],
+            description: "Create a boxed boolean value."
+        ),
+        ABIFunctionSpec(
+            name: "kk_value_string",
+            returnType: .opaquePointer,
+            parameters: [
+                ABIParameterSpec(name: "str", type: .cString),
+                ABIParameterSpec(name: "len", type: .int64)
+            ],
+            description: "Create a boxed string value from a UTF-8 buffer and byte length."
+        ),
+        ABIFunctionSpec(
+            name: "kk_value_null",
+            returnType: .opaquePointer,
+            parameters: [],
+            description: "Create a boxed null value."
+        )
+    ]
+
+    // MARK: - J16.1.3 Value Access
+
+    public static let valueAccessFunctions: [ABIFunctionSpec] = [
+        ABIFunctionSpec(
+            name: "kk_value_get_tag",
+            returnType: .int32,
+            parameters: [
+                ABIParameterSpec(name: "val", type: .opaquePointer)
+            ],
+            description: "Return the type tag of a boxed value (0=int,1=real,2=bool,3=string,4=null,5=array)."
+        ),
+        ABIFunctionSpec(
+            name: "kk_value_get_integer",
+            returnType: .int64,
+            parameters: [
+                ABIParameterSpec(name: "val", type: .opaquePointer)
+            ],
+            description: "Extract integer payload. Undefined behaviour if tag != 0."
+        ),
+        ABIFunctionSpec(
+            name: "kk_value_get_real",
+            returnType: .float64,
+            parameters: [
+                ABIParameterSpec(name: "val", type: .opaquePointer)
+            ],
+            description: "Extract real payload. Undefined behaviour if tag != 1."
+        ),
+        ABIFunctionSpec(
+            name: "kk_value_get_boolean",
+            returnType: .bool,
+            parameters: [
+                ABIParameterSpec(name: "val", type: .opaquePointer)
+            ],
+            description: "Extract boolean payload. Undefined behaviour if tag != 2."
+        ),
+        ABIFunctionSpec(
+            name: "kk_value_get_string",
+            returnType: .cString,
+            parameters: [
+                ABIParameterSpec(name: "val", type: .opaquePointer)
+            ],
+            description: "Extract null-terminated UTF-8 string pointer. Undefined behaviour if tag != 3."
+        ),
+        ABIFunctionSpec(
+            name: "kk_value_get_string_len",
+            returnType: .int64,
+            parameters: [
+                ABIParameterSpec(name: "val", type: .opaquePointer)
+            ],
+            description: "Return byte length of string payload. Undefined behaviour if tag != 3."
+        )
+    ]
+
+    // MARK: - J16.1.4 I/O
+
+    public static let ioFunctions: [ABIFunctionSpec] = [
+        ABIFunctionSpec(
+            name: "kk_print",
+            returnType: .void,
+            parameters: [
+                ABIParameterSpec(name: "str", type: .cString)
+            ],
+            description: "Print a null-terminated string to stdout (no trailing newline)."
+        ),
+        ABIFunctionSpec(
+            name: "kk_println",
+            returnType: .void,
+            parameters: [
+                ABIParameterSpec(name: "str", type: .cString)
+            ],
+            description: "Print a null-terminated string to stdout followed by a newline."
+        ),
+        ABIFunctionSpec(
+            name: "kk_input",
+            returnType: .nullableCString,
+            parameters: [],
+            description: "Read a line from stdin. Returns NULL on EOF."
+        )
+    ]
+
+    // MARK: - J16.1.5 Array
+
+    public static let arrayFunctions: [ABIFunctionSpec] = [
+        ABIFunctionSpec(
+            name: "kk_array_new",
+            returnType: .opaquePointer,
+            parameters: [
+                ABIParameterSpec(name: "capacity", type: .int64)
+            ],
+            description: "Create a new empty array with the given initial capacity."
+        ),
+        ABIFunctionSpec(
+            name: "kk_array_length",
+            returnType: .int64,
+            parameters: [
+                ABIParameterSpec(name: "arr", type: .opaquePointer)
+            ],
+            description: "Return the number of elements in the array."
+        ),
+        ABIFunctionSpec(
+            name: "kk_array_get",
+            returnType: .opaquePointer,
+            parameters: [
+                ABIParameterSpec(name: "arr", type: .opaquePointer),
+                ABIParameterSpec(name: "index", type: .int64)
+            ],
+            description: "Return the element at the given index. Traps on out-of-bounds."
+        ),
+        ABIFunctionSpec(
+            name: "kk_array_set",
+            returnType: .void,
+            parameters: [
+                ABIParameterSpec(name: "arr", type: .opaquePointer),
+                ABIParameterSpec(name: "index", type: .int64),
+                ABIParameterSpec(name: "value", type: .opaquePointer)
+            ],
+            description: "Set the element at the given index. Traps on out-of-bounds."
+        ),
+        ABIFunctionSpec(
+            name: "kk_array_push",
+            returnType: .void,
+            parameters: [
+                ABIParameterSpec(name: "arr", type: .opaquePointer),
+                ABIParameterSpec(name: "value", type: .opaquePointer)
+            ],
+            description: "Append value to the end of the array."
+        )
+    ]
+
+    // MARK: - J16.1.6 Environment
+
+    public static let environmentFunctions: [ABIFunctionSpec] = [
+        ABIFunctionSpec(
+            name: "kk_env_new",
+            returnType: .opaquePointer,
+            parameters: [],
+            description: "Create a new runtime environment."
+        ),
+        ABIFunctionSpec(
+            name: "kk_env_destroy",
+            returnType: .void,
+            parameters: [
+                ABIParameterSpec(name: "env", type: .opaquePointer)
+            ],
+            description: "Destroy a runtime environment and free resources."
+        ),
+        ABIFunctionSpec(
+            name: "kk_env_define",
+            returnType: .void,
+            parameters: [
+                ABIParameterSpec(name: "env", type: .opaquePointer),
+                ABIParameterSpec(name: "name", type: .cString),
+                ABIParameterSpec(name: "value", type: .opaquePointer)
+            ],
+            description: "Define a variable in the current scope."
+        ),
+        ABIFunctionSpec(
+            name: "kk_env_get",
+            returnType: .nullableOpaquePointer,
+            parameters: [
+                ABIParameterSpec(name: "env", type: .opaquePointer),
+                ABIParameterSpec(name: "name", type: .cString)
+            ],
+            description: "Look up a variable by name. Returns NULL if not found."
+        ),
+        ABIFunctionSpec(
+            name: "kk_env_set",
+            returnType: .bool,
+            parameters: [
+                ABIParameterSpec(name: "env", type: .opaquePointer),
+                ABIParameterSpec(name: "name", type: .cString),
+                ABIParameterSpec(name: "value", type: .opaquePointer)
+            ],
+            description: "Assign a new value to an existing variable. Returns false if undefined."
+        ),
+        ABIFunctionSpec(
+            name: "kk_env_push_scope",
+            returnType: .void,
+            parameters: [
+                ABIParameterSpec(name: "env", type: .opaquePointer)
+            ],
+            description: "Push a new variable scope."
+        ),
+        ABIFunctionSpec(
+            name: "kk_env_pop_scope",
+            returnType: .void,
+            parameters: [
+                ABIParameterSpec(name: "env", type: .opaquePointer)
+            ],
+            description: "Pop the innermost variable scope."
+        )
+    ]
+}

--- a/Sources/FeLangRuntime/ABI/RuntimeABISpec.swift
+++ b/Sources/FeLangRuntime/ABI/RuntimeABISpec.swift
@@ -217,7 +217,7 @@ public enum RuntimeABISpec {
             parameters: [
                 ABIParameterSpec(name: "val", type: .opaquePointer)
             ],
-            description: "Extract null-terminated UTF-8 string pointer. Undefined behaviour if tag != 3."
+            description: "Extract null-terminated UTF-8 string. Caller must free() the returned pointer. Undefined behaviour if tag != 3."
         ),
         ABIFunctionSpec(
             name: "kk_value_get_string_len",
@@ -252,7 +252,7 @@ public enum RuntimeABISpec {
             name: "kk_input",
             returnType: .nullableCString,
             parameters: [],
-            description: "Read a line from stdin. Returns NULL on EOF."
+            description: "Read a line from stdin. Returns NULL on EOF. Caller must free() the returned pointer."
         )
     ]
 

--- a/Tests/FeLangRuntimeTests/ABIMismatchTests.swift
+++ b/Tests/FeLangRuntimeTests/ABIMismatchTests.swift
@@ -227,9 +227,11 @@ final class ABIMismatchTests: XCTestCase {
             withExtension: "h"
         )
         guard let url = canonicalURL else {
+            XCTFail("Canonical header resource 'felang_runtime_abi.h' not found in test bundle")
             return
         }
         guard let canonical = try? String(contentsOf: url, encoding: .utf8) else {
+            XCTFail("Failed to read canonical header at \(url)")
             return
         }
         XCTAssertEqual(

--- a/Tests/FeLangRuntimeTests/ABIMismatchTests.swift
+++ b/Tests/FeLangRuntimeTests/ABIMismatchTests.swift
@@ -1,0 +1,302 @@
+import XCTest
+@testable import FeLangRuntime
+
+final class ABIMismatchTests: XCTestCase {
+
+    // MARK: - Spec Integrity
+
+    func testAllFunctionNamesAreUnique() {
+        let names = RuntimeABISpec.allFunctions.map(\.name)
+        let uniqueNames = Set(names)
+        XCTAssertEqual(
+            names.count,
+            uniqueNames.count,
+            "Duplicate function names found in RuntimeABISpec"
+        )
+    }
+
+    func testAllFunctionNamesFollowKKPrefix() {
+        for spec in RuntimeABISpec.allFunctions {
+            XCTAssertTrue(
+                spec.name.hasPrefix("kk_"),
+                "Function '\(spec.name)' does not follow kk_ naming convention"
+            )
+        }
+    }
+
+    func testSpecVersionIsNonEmpty() {
+        XCTAssertFalse(RuntimeABISpec.specVersion.isEmpty)
+    }
+
+    func testAllFunctionsHaveDescriptions() {
+        for spec in RuntimeABISpec.allFunctions {
+            XCTAssertFalse(
+                spec.description.isEmpty,
+                "Function '\(spec.name)' is missing a description"
+            )
+        }
+    }
+
+    func testAllParameterNamesAreNonEmpty() {
+        for spec in RuntimeABISpec.allFunctions {
+            for param in spec.parameters {
+                XCTAssertFalse(
+                    param.name.isEmpty,
+                    "Parameter in '\(spec.name)' has an empty name"
+                )
+            }
+        }
+    }
+
+    func testParameterNamesUniquePerFunction() {
+        for spec in RuntimeABISpec.allFunctions {
+            let names = spec.parameters.map(\.name)
+            let uniqueNames = Set(names)
+            XCTAssertEqual(
+                names.count,
+                uniqueNames.count,
+                "Duplicate parameter names in '\(spec.name)'"
+            )
+        }
+    }
+
+    // MARK: - Category Counts
+
+    func testMemoryFunctionCount() {
+        XCTAssertEqual(RuntimeABISpec.memoryFunctions.count, 5)
+    }
+
+    func testValueCreationFunctionCount() {
+        XCTAssertEqual(RuntimeABISpec.valueCreationFunctions.count, 5)
+    }
+
+    func testValueAccessFunctionCount() {
+        XCTAssertEqual(RuntimeABISpec.valueAccessFunctions.count, 6)
+    }
+
+    func testIOFunctionCount() {
+        XCTAssertEqual(RuntimeABISpec.ioFunctions.count, 3)
+    }
+
+    func testArrayFunctionCount() {
+        XCTAssertEqual(RuntimeABISpec.arrayFunctions.count, 5)
+    }
+
+    func testEnvironmentFunctionCount() {
+        XCTAssertEqual(RuntimeABISpec.environmentFunctions.count, 7)
+    }
+
+    func testTotalFunctionCount() {
+        let expected = RuntimeABISpec.memoryFunctions.count
+            + RuntimeABISpec.valueCreationFunctions.count
+            + RuntimeABISpec.valueAccessFunctions.count
+            + RuntimeABISpec.ioFunctions.count
+            + RuntimeABISpec.arrayFunctions.count
+            + RuntimeABISpec.environmentFunctions.count
+        XCTAssertEqual(RuntimeABISpec.allFunctions.count, expected)
+    }
+
+    // MARK: - Nullable Policy
+
+    func testKKAllocReturnsNullable() {
+        let spec = RuntimeABISpec.allFunctions.first { $0.name == "kk_alloc" }
+        XCTAssertNotNil(spec)
+        XCTAssertEqual(spec?.returnType, .nullableOpaquePointer)
+    }
+
+    func testKKReallocReturnsNullable() {
+        let spec = RuntimeABISpec.allFunctions.first { $0.name == "kk_realloc" }
+        XCTAssertNotNil(spec)
+        XCTAssertEqual(spec?.returnType, .nullableOpaquePointer)
+    }
+
+    func testKKFreeAcceptsNullablePointer() {
+        let spec = RuntimeABISpec.allFunctions.first { $0.name == "kk_free" }
+        XCTAssertNotNil(spec)
+        XCTAssertEqual(spec?.parameters.first?.type, .nullableOpaquePointer)
+    }
+
+    func testKKValueCreatorsReturnNonNullable() {
+        for funcSpec in RuntimeABISpec.valueCreationFunctions {
+            XCTAssertEqual(
+                funcSpec.returnType,
+                .opaquePointer,
+                "Value creator '\(funcSpec.name)' should return non-nullable pointer"
+            )
+        }
+    }
+
+    func testKKInputReturnsNullable() {
+        let spec = RuntimeABISpec.allFunctions.first { $0.name == "kk_input" }
+        XCTAssertNotNil(spec)
+        XCTAssertEqual(spec?.returnType, .nullableCString)
+    }
+
+    func testKKEnvGetReturnsNullable() {
+        let spec = RuntimeABISpec.allFunctions.first { $0.name == "kk_env_get" }
+        XCTAssertNotNil(spec)
+        XCTAssertEqual(spec?.returnType, .nullableOpaquePointer)
+    }
+
+    // MARK: - Specific Signature Checks
+
+    func testKKAllocSignature() {
+        guard let spec = RuntimeABISpec.allFunctions.first(where: { $0.name == "kk_alloc" }) else {
+            XCTFail("kk_alloc not found in spec")
+            return
+        }
+        XCTAssertEqual(spec.parameters.count, 1)
+        XCTAssertEqual(spec.parameters[0].name, "size")
+        XCTAssertEqual(spec.parameters[0].type, .int64)
+    }
+
+    func testKKValueIntegerSignature() {
+        guard let spec = RuntimeABISpec.allFunctions.first(where: { $0.name == "kk_value_integer" }) else {
+            XCTFail("kk_value_integer not found in spec")
+            return
+        }
+        XCTAssertEqual(spec.returnType, .opaquePointer)
+        XCTAssertEqual(spec.parameters.count, 1)
+        XCTAssertEqual(spec.parameters[0].type, .int64)
+    }
+
+    func testKKValueStringSignature() {
+        guard let spec = RuntimeABISpec.allFunctions.first(where: { $0.name == "kk_value_string" }) else {
+            XCTFail("kk_value_string not found in spec")
+            return
+        }
+        XCTAssertEqual(spec.returnType, .opaquePointer)
+        XCTAssertEqual(spec.parameters.count, 2)
+        XCTAssertEqual(spec.parameters[0].type, .cString)
+        XCTAssertEqual(spec.parameters[1].type, .int64)
+    }
+
+    func testKKEnvDefineSignature() {
+        guard let spec = RuntimeABISpec.allFunctions.first(where: { $0.name == "kk_env_define" }) else {
+            XCTFail("kk_env_define not found in spec")
+            return
+        }
+        XCTAssertEqual(spec.returnType, .void)
+        XCTAssertEqual(spec.parameters.count, 3)
+        XCTAssertEqual(spec.parameters[0].type, .opaquePointer)
+        XCTAssertEqual(spec.parameters[1].type, .cString)
+        XCTAssertEqual(spec.parameters[2].type, .opaquePointer)
+    }
+
+    // MARK: - C Declaration Generation
+
+    func testCDeclarationForKKAlloc() {
+        guard let spec = RuntimeABISpec.allFunctions.first(where: { $0.name == "kk_alloc" }) else {
+            XCTFail("kk_alloc not found in spec")
+            return
+        }
+        XCTAssertEqual(
+            spec.cDeclaration,
+            "void * _Nullable kk_alloc(int64_t size);"
+        )
+    }
+
+    func testCDeclarationForKKFree() {
+        guard let spec = RuntimeABISpec.allFunctions.first(where: { $0.name == "kk_free" }) else {
+            XCTFail("kk_free not found in spec")
+            return
+        }
+        XCTAssertEqual(
+            spec.cDeclaration,
+            "void kk_free(void * _Nullable ptr);"
+        )
+    }
+
+    func testCDeclarationForKKValueNull() {
+        guard let spec = RuntimeABISpec.allFunctions.first(where: { $0.name == "kk_value_null" }) else {
+            XCTFail("kk_value_null not found in spec")
+            return
+        }
+        XCTAssertEqual(
+            spec.cDeclaration,
+            "void * kk_value_null(void);"
+        )
+    }
+
+    // MARK: - Header Generator vs Canonical Header
+
+    func testGeneratedHeaderMatchesCanonicalHeader() {
+        let generated = ABIHeaderGenerator.generate()
+        let canonicalURL = Bundle.module.url(
+            forResource: "felang_runtime_abi",
+            withExtension: "h"
+        )
+        guard let url = canonicalURL else {
+            return
+        }
+        guard let canonical = try? String(contentsOf: url, encoding: .utf8) else {
+            return
+        }
+        XCTAssertEqual(
+            normalizeWhitespace(generated),
+            normalizeWhitespace(canonical),
+            "Generated header does not match canonical header. Re-run the header generator."
+        )
+    }
+
+    func testGeneratedHeaderContainsAllFunctionNames() {
+        let generated = ABIHeaderGenerator.generate()
+        for spec in RuntimeABISpec.allFunctions {
+            XCTAssertTrue(
+                generated.contains(spec.name),
+                "Generated header is missing function '\(spec.name)'"
+            )
+        }
+    }
+
+    func testGeneratedHeaderContainsIncludeGuard() {
+        let generated = ABIHeaderGenerator.generate()
+        XCTAssertTrue(generated.contains("#ifndef FELANG_RUNTIME_ABI_H"))
+        XCTAssertTrue(generated.contains("#define FELANG_RUNTIME_ABI_H"))
+        XCTAssertTrue(generated.contains("#endif /* FELANG_RUNTIME_ABI_H */"))
+    }
+
+    func testGeneratedHeaderContainsRequiredIncludes() {
+        let generated = ABIHeaderGenerator.generate()
+        XCTAssertTrue(generated.contains("#include <stdint.h>"))
+        XCTAssertTrue(generated.contains("#include <stdbool.h>"))
+        XCTAssertTrue(generated.contains("#include <stddef.h>"))
+    }
+
+    func testGeneratedHeaderContainsCppGuard() {
+        let generated = ABIHeaderGenerator.generate()
+        XCTAssertTrue(generated.contains("#ifdef __cplusplus"))
+        XCTAssertTrue(generated.contains("extern \"C\" {"))
+    }
+
+    // MARK: - ABIType Properties
+
+    func testABITypeCTypeNames() {
+        XCTAssertEqual(ABIType.void.cTypeName, "void")
+        XCTAssertEqual(ABIType.int32.cTypeName, "int32_t")
+        XCTAssertEqual(ABIType.int64.cTypeName, "int64_t")
+        XCTAssertEqual(ABIType.float64.cTypeName, "double")
+        XCTAssertEqual(ABIType.bool.cTypeName, "bool")
+        XCTAssertEqual(ABIType.opaquePointer.cTypeName, "void *")
+        XCTAssertEqual(ABIType.nullableOpaquePointer.cTypeName, "void * _Nullable")
+        XCTAssertEqual(ABIType.cString.cTypeName, "const char *")
+        XCTAssertEqual(ABIType.nullableCString.cTypeName, "const char * _Nullable")
+    }
+
+    func testABITypeNullability() {
+        XCTAssertFalse(ABIType.void.isNullable)
+        XCTAssertFalse(ABIType.int32.isNullable)
+        XCTAssertFalse(ABIType.opaquePointer.isNullable)
+        XCTAssertFalse(ABIType.cString.isNullable)
+        XCTAssertTrue(ABIType.nullableOpaquePointer.isNullable)
+        XCTAssertTrue(ABIType.nullableCString.isNullable)
+    }
+
+    // MARK: - Helpers
+
+    private func normalizeWhitespace(_ str: String) -> String {
+        str.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}

--- a/Tests/FeLangRuntimeTests/Resources/felang_runtime_abi.h
+++ b/Tests/FeLangRuntimeTests/Resources/felang_runtime_abi.h
@@ -65,7 +65,7 @@ double kk_value_get_real(void * val);
 /** Extract boolean payload. Undefined behaviour if tag != 2. */
 bool kk_value_get_boolean(void * val);
 
-/** Extract null-terminated UTF-8 string pointer. Undefined behaviour if tag != 3. */
+/** Extract null-terminated UTF-8 string. Caller must free() the returned pointer. Undefined behaviour if tag != 3. */
 const char * kk_value_get_string(void * val);
 
 /** Return byte length of string payload. Undefined behaviour if tag != 3. */
@@ -79,7 +79,7 @@ void kk_print(const char * str);
 /** Print a null-terminated string to stdout followed by a newline. */
 void kk_println(const char * str);
 
-/** Read a line from stdin. Returns NULL on EOF. */
+/** Read a line from stdin. Returns NULL on EOF. Caller must free() the returned pointer. */
 const char * _Nullable kk_input(void);
 
 /* --- Array --- */

--- a/Tests/FeLangRuntimeTests/Resources/felang_runtime_abi.h
+++ b/Tests/FeLangRuntimeTests/Resources/felang_runtime_abi.h
@@ -1,0 +1,129 @@
+#ifndef FELANG_RUNTIME_ABI_H
+#define FELANG_RUNTIME_ABI_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/*
+ * FeLangKit Runtime C ABI
+ * Auto-generated from RuntimeABISpec v1.0.0
+ *
+ * This header is the canonical reference for compiler backends.
+ * Do NOT edit manually; regenerate from the spec instead.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* --- Memory Management --- */
+
+/** Allocate size bytes. Returns NULL on failure. */
+void * _Nullable kk_alloc(int64_t size);
+
+/** Reallocate ptr to new_size bytes. Returns NULL on failure. */
+void * _Nullable kk_realloc(void * _Nullable ptr, int64_t new_size);
+
+/** Free memory at ptr. No-op if ptr is NULL. */
+void kk_free(void * _Nullable ptr);
+
+/** Increment reference count for obj. */
+void kk_retain(void * obj);
+
+/** Decrement reference count for obj. Frees when count reaches 0. */
+void kk_release(void * obj);
+
+/* --- Value Creation --- */
+
+/** Create a boxed integer value. */
+void * kk_value_integer(int64_t value);
+
+/** Create a boxed real (double) value. */
+void * kk_value_real(double value);
+
+/** Create a boxed boolean value. */
+void * kk_value_boolean(bool value);
+
+/** Create a boxed string value from a UTF-8 buffer and byte length. */
+void * kk_value_string(const char * str, int64_t len);
+
+/** Create a boxed null value. */
+void * kk_value_null(void);
+
+/* --- Value Access --- */
+
+/** Return the type tag of a boxed value (0=int,1=real,2=bool,3=string,4=null,5=array). */
+int32_t kk_value_get_tag(void * val);
+
+/** Extract integer payload. Undefined behaviour if tag != 0. */
+int64_t kk_value_get_integer(void * val);
+
+/** Extract real payload. Undefined behaviour if tag != 1. */
+double kk_value_get_real(void * val);
+
+/** Extract boolean payload. Undefined behaviour if tag != 2. */
+bool kk_value_get_boolean(void * val);
+
+/** Extract null-terminated UTF-8 string pointer. Undefined behaviour if tag != 3. */
+const char * kk_value_get_string(void * val);
+
+/** Return byte length of string payload. Undefined behaviour if tag != 3. */
+int64_t kk_value_get_string_len(void * val);
+
+/* --- I/O --- */
+
+/** Print a null-terminated string to stdout (no trailing newline). */
+void kk_print(const char * str);
+
+/** Print a null-terminated string to stdout followed by a newline. */
+void kk_println(const char * str);
+
+/** Read a line from stdin. Returns NULL on EOF. */
+const char * _Nullable kk_input(void);
+
+/* --- Array --- */
+
+/** Create a new empty array with the given initial capacity. */
+void * kk_array_new(int64_t capacity);
+
+/** Return the number of elements in the array. */
+int64_t kk_array_length(void * arr);
+
+/** Return the element at the given index. Traps on out-of-bounds. */
+void * kk_array_get(void * arr, int64_t index);
+
+/** Set the element at the given index. Traps on out-of-bounds. */
+void kk_array_set(void * arr, int64_t index, void * value);
+
+/** Append value to the end of the array. */
+void kk_array_push(void * arr, void * value);
+
+/* --- Environment --- */
+
+/** Create a new runtime environment. */
+void * kk_env_new(void);
+
+/** Destroy a runtime environment and free resources. */
+void kk_env_destroy(void * env);
+
+/** Define a variable in the current scope. */
+void kk_env_define(void * env, const char * name, void * value);
+
+/** Look up a variable by name. Returns NULL if not found. */
+void * _Nullable kk_env_get(void * env, const char * name);
+
+/** Assign a new value to an existing variable. Returns false if undefined. */
+bool kk_env_set(void * env, const char * name, void * value);
+
+/** Push a new variable scope. */
+void kk_env_push_scope(void * env);
+
+/** Pop the innermost variable scope. */
+void kk_env_pop_scope(void * env);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FELANG_RUNTIME_ABI_H */


### PR DESCRIPTION
Closes P5-27

## Summary

Introduces a formal C ABI layer for the FeLang runtime, enabling future compiler backends to link against a stable, spec-driven set of C functions. The repository previously had no C code; this PR adds:

- **`RuntimeABISpec`** — single source of truth defining all 31 C ABI function signatures across 6 categories (memory, value creation, value access, I/O, array, environment), including nullable policy.
- **`FeLangCABI` target** — new SPM C target containing the canonical `felang_runtime_abi.h` header.
- **`ABIHeaderGenerator`** — generates the C header from `RuntimeABISpec` so drift between spec and header can be detected automatically.
- **`RuntimeABIFunctions`** — `@_cdecl` implementations bridging the C ABI to a `BoxedValue` wrapper with manual reference counting.
- **`ABIMismatchTests`** — ~30 tests verifying spec integrity, nullable policy, specific signatures, C declaration generation, and that the generated header matches the canonical header.

## Review & Testing Checklist for Human

- [ ] **Memory management in `kk_retain`/`kk_release` looks incorrect.** `BoxedValue` has a manual `refCount` alongside `Unmanaged` ARC retain/release. `kk_retain` increments `refCount` but does NOT call `Unmanaged.passRetained`, while `kk_release` calls `Unmanaged.fromOpaque(obj).release()` on zero — meaning multiple retain/release cycles will over-release. Verify whether the dual refcount scheme is intentional or a bug.
- [ ] **No functional tests exist for the actual `@_cdecl` implementations.** All tests verify spec *metadata* only (function names, types, counts, header text). None of the 31 runtime functions (`kk_alloc`, `kk_value_integer`, `kk_array_push`, etc.) are actually called in tests. Consider whether runtime behavior tests are needed before merge.
- [ ] **Verify signatures match spec.md J16.1.** The ABI is defined purely in code — confirm the function set, argument types, return types, and nullable annotations align with the spec document.
- [ ] **Check `@_cdecl` Swift signatures match the C header.** Ensure `RuntimeABIFunctions.swift` function signatures are binary-compatible with `felang_runtime_abi.h` declarations (e.g., `Int64` ↔ `int64_t`, `Bool` ↔ `bool`, `UnsafePointer<CChar>` ↔ `const char *`).
- [ ] **Memory ownership for `kk_value_get_string` and `kk_input`.** Both use `strdup` to return C strings — caller must `free()` them, but this isn't documented in the header. Confirm this is the intended contract.

### Notes

- All 1277 existing tests pass, including the new ABI mismatch tests.
- SwiftLint passes with only 1 pre-existing warning in an unrelated file.
- The canonical header is duplicated in `Sources/FeLangCABI/include/` and `Tests/FeLangRuntimeTests/Resources/` — the test verifies they match via the generator.

Link to Devin run: https://app.devin.ai/sessions/2b207f28b68b4b30adc40538ac26abd3  
Requested by: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new FFI boundary with manual memory/ownership conventions and pointer-based APIs, which can lead to leaks or crashes if signatures/retains are wrong. Changes are largely additive but touch runtime-facing interfaces and packaging.
> 
> **Overview**
> Adds a formal, spec-driven Runtime C ABI: a new `FeLangCABI` C target publishes the canonical `felang_runtime_abi.h`, and `FeLangRuntime` now depends on it.
> 
> Implements the ABI in Swift via new `@_cdecl` functions (`kk_*`) covering memory, boxed values, I/O, arrays, and environment bridging, plus a `RuntimeABISpec` model and `ABIHeaderGenerator` to generate matching C declarations.
> 
> Extends `FeLangRuntimeTests` with `ABIMismatchTests` and bundled header resources to assert spec integrity and detect drift between the generated header and the canonical header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ced3b5a8538bfc3e50d261ff3d1b3984e6f6b0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * FeLang ランタイムの C ABI を公開。メモリ管理、値の作成/参照、I/O、配列操作、環境操作を通じて外部からランタイムと連携可能になりました。
  * ランタイムの新しいパッケージ構成で C ABI が提供されます。

* **テスト**
  * ABI 仕様整合性とヘッダー生成を検証するテスト群を追加。テスト用リソースも含まれます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->