### PR TITLE
Resolve P5-24: CST 粒度を spec 最低ラインへ引き上げる

### DIFF
--- a/Sources/FeLangCore/CST/ASTBuilder.swift
+++ b/Sources/FeLangCore/CST/ASTBuilder.swift
@@ -1,0 +1,602 @@
+import Foundation
+
+/// Converts a concrete syntax tree (CST) produced by `CSTParser` into the
+/// existing `Statement` / `Expression` AST without re-scanning tokens.
+///
+/// By walking the already-parsed CST, `ASTBuilder` eliminates the need for
+/// a second parse pass and makes the AST construction deterministic from the
+/// tree structure alone.
+public struct ASTBuilder {
+
+    private let tokens: [Token]
+
+    public init(tokens: [Token]) {
+        self.tokens = tokens
+    }
+
+    // MARK: - Public API
+
+    /// Builds an array of `Statement` from a `sourceFile` CST node.
+    public func build(from root: SyntaxNode) throws -> [Statement] {
+        guard root.kind == .sourceFile else {
+            throw ASTBuildError.expectedKind(.sourceFile, got: root.kind)
+        }
+        var statements: [Statement] = []
+        for child in root.children {
+            switch child.kind {
+            case .importList, .declarationList:
+                for stmt in child.children {
+                    statements.append(try buildStatement(stmt))
+                }
+            default:
+                statements.append(try buildStatement(child))
+            }
+        }
+        return statements
+    }
+
+    // MARK: - Statement Building
+
+    private func buildStatement(_ node: SyntaxNode) throws -> Statement {
+        switch node.kind {
+        case .ifStatement:
+            return .ifStatement(try buildIfStatement(node))
+        case .whileStatement:
+            return .whileStatement(try buildWhileStatement(node))
+        case .doWhileStatement:
+            return .doWhileStatement(try buildDoWhileStatement(node))
+        case .forStatement:
+            return .forStatement(try buildForStatement(node))
+        case .variableDeclaration:
+            return .variableDeclaration(try buildVariableDeclaration(node))
+        case .constantDeclaration:
+            return .constantDeclaration(try buildConstantDeclaration(node))
+        case .globalDeclaration:
+            return .globalDeclaration(try buildGlobalDeclaration(node))
+        case .functionDeclaration:
+            return .functionDeclaration(try buildFunctionDeclaration(node))
+        case .procedureDeclaration:
+            return .procedureDeclaration(try buildProcedureDeclaration(node))
+        case .classDeclaration:
+            return .classDeclaration(try buildClassDeclaration(node))
+        case .returnStatement:
+            return .returnStatement(try buildReturnStatement(node))
+        case .breakStatement:
+            return .breakStatement
+        case .continueStatement:
+            return .continueStatement
+        case .assignmentStatement:
+            return .assignment(try buildAssignment(node))
+        case .expressionStatement:
+            guard let exprChild = node.children.first else {
+                throw ASTBuildError.missingChild("expression", parent: node.kind)
+            }
+            return .expressionStatement(try buildExpression(exprChild))
+        case .block:
+            let stmts = try node.children.map { try buildStatement($0) }
+            return .block(stmts)
+        default:
+            throw ASTBuildError.unexpectedKind(node.kind)
+        }
+    }
+
+    // MARK: - Control Flow
+
+    private func buildIfStatement(_ node: SyntaxNode) throws -> IfStatement {
+        let condClause = node.firstChild(ofKind: .conditionClause)
+        guard let condExprNode = condClause?.children.first else {
+            throw ASTBuildError.missingChild("condition", parent: .ifStatement)
+        }
+        let condition = try buildExpression(condExprNode)
+
+        let thenClause = node.firstChild(ofKind: .thenClause)
+        let thenBody: [Statement]
+        if let block = thenClause?.children.first {
+            thenBody = try buildBlock(block)
+        } else {
+            thenBody = []
+        }
+
+        let elseIfs: [IfStatement.ElseIf] = try node.children(ofKind: .elseIfClause).map { clause in
+            let elifCond = clause.firstChild(ofKind: .conditionClause)
+            guard let elifCondExpr = elifCond?.children.first else {
+                throw ASTBuildError.missingChild("condition", parent: .elseIfClause)
+            }
+            let elifThen = clause.firstChild(ofKind: .thenClause)
+            let elifBody: [Statement]
+            if let block = elifThen?.children.first {
+                elifBody = try buildBlock(block)
+            } else {
+                elifBody = []
+            }
+            return IfStatement.ElseIf(condition: try buildExpression(elifCondExpr), body: elifBody)
+        }
+
+        var elseBody: [Statement]?
+        if let elseClause = node.firstChild(ofKind: .elseClause) {
+            let blocks = elseClause.children(ofKind: .block)
+            if let block = blocks.first {
+                elseBody = try buildBlock(block)
+            }
+        }
+
+        return IfStatement(condition: condition, thenBody: thenBody, elseIfs: elseIfs, elseBody: elseBody)
+    }
+
+    private func buildWhileStatement(_ node: SyntaxNode) throws -> WhileStatement {
+        guard let condExpr = node.firstChild(ofKind: .conditionClause)?.children.first else {
+            throw ASTBuildError.missingChild("condition", parent: .whileStatement)
+        }
+        let condition = try buildExpression(condExpr)
+
+        let blocks = node.children(ofKind: .block)
+        let body = try buildBlock(blocks.first ?? SyntaxNode(kind: .block, children: []))
+
+        return WhileStatement(condition: condition, body: body)
+    }
+
+    private func buildDoWhileStatement(_ node: SyntaxNode) throws -> DoWhileStatement {
+        guard let condExpr = node.firstChild(ofKind: .conditionClause)?.children.first else {
+            throw ASTBuildError.missingChild("condition", parent: .doWhileStatement)
+        }
+        let condition = try buildExpression(condExpr)
+
+        let blocks = node.children(ofKind: .block)
+        let body = try buildBlock(blocks.first ?? SyntaxNode(kind: .block, children: []))
+
+        return DoWhileStatement(body: body, condition: condition)
+    }
+
+    private func buildForStatement(_ node: SyntaxNode) throws -> ForStatement {
+        let identNodes = node.children.filter { $0.kind == .identifierExpr || ($0.isToken && tokenAt($0)?.type == .identifier) }
+        guard let varNode = identNodes.first else {
+            throw ASTBuildError.missingChild("variable", parent: .forStatement)
+        }
+        let variable = tokenLexeme(varNode)
+
+        if let rangeClause = node.firstChild(ofKind: .forRangeClause) {
+            let exprs = rangeClause.children.filter { $0.kind != .token }
+            guard exprs.count >= 2 else {
+                throw ASTBuildError.missingChild("range expressions", parent: .forRangeClause)
+            }
+            let start = try buildExpression(exprs[0])
+            let end = try buildExpression(exprs[1])
+            let step: Expression? = exprs.count > 2 ? try buildExpression(exprs[2]) : nil
+
+            let blocks = node.children(ofKind: .block)
+            let body = try buildBlock(blocks.first ?? SyntaxNode(kind: .block, children: []))
+
+            return .range(ForStatement.RangeFor(variable: variable, start: start, end: end, step: step, body: body))
+        } else if let forEachClause = node.firstChild(ofKind: .forEachClause) {
+            let exprs = forEachClause.children.filter { $0.kind != .token }
+            guard let iterExpr = exprs.first else {
+                throw ASTBuildError.missingChild("iterable", parent: .forEachClause)
+            }
+            let iterable = try buildExpression(iterExpr)
+            let blocks = node.children(ofKind: .block)
+            let body = try buildBlock(blocks.first ?? SyntaxNode(kind: .block, children: []))
+
+            return .forEach(ForStatement.ForEachLoop(variable: variable, iterable: iterable, body: body))
+        }
+
+        throw ASTBuildError.missingChild("for clause", parent: .forStatement)
+    }
+
+    // MARK: - Declarations
+
+    private func buildVariableDeclaration(_ node: SyntaxNode) throws -> VariableDeclaration {
+        let position = tokenAt(node.children.first)?.position
+        let name = identifierName(in: node)
+        let type = try buildDataType(node.firstChild(ofKind: .typeAnnotation))
+        let exprChildren = node.children.filter { $0.kind.isExpression }
+        let initialValue: Expression? = exprChildren.isEmpty ? nil : try buildExpression(exprChildren[0])
+
+        return VariableDeclaration(name: name, type: type, initialValue: initialValue, position: position)
+    }
+
+    private func buildConstantDeclaration(_ node: SyntaxNode) throws -> ConstantDeclaration {
+        let position = tokenAt(node.children.first)?.position
+        let name = identifierName(in: node)
+        let type = try buildDataType(node.firstChild(ofKind: .typeAnnotation))
+        let exprChildren = node.children.filter { $0.kind.isExpression }
+        guard let exprNode = exprChildren.first else {
+            throw ASTBuildError.missingChild("initial value", parent: .constantDeclaration)
+        }
+        let initialValue = try buildExpression(exprNode)
+
+        return ConstantDeclaration(name: name, type: type, initialValue: initialValue, position: position)
+    }
+
+    private func buildGlobalDeclaration(_ node: SyntaxNode) throws -> GlobalDeclaration {
+        let position = tokenAt(node.children.first)?.position
+        let name = identifierName(in: node)
+        let type = try buildDataType(node.firstChild(ofKind: .typeAnnotation))
+        let exprChildren = node.children.filter { $0.kind.isExpression }
+        let initialValue: Expression? = exprChildren.isEmpty ? nil : try buildExpression(exprChildren[0])
+
+        return GlobalDeclaration(name: name, type: type, initialValue: initialValue, position: position)
+    }
+
+    private func buildFunctionDeclaration(_ node: SyntaxNode) throws -> FunctionDeclaration {
+        let position = tokenAt(node.children.first)?.position
+        let name = identifierName(in: node)
+        let paramList = node.firstChild(ofKind: .parameterList)
+        let parameters = try buildParameterList(paramList)
+
+        let typeAnnotations = node.children(ofKind: .typeAnnotation)
+        let returnType: DataType? = typeAnnotations.isEmpty ? nil : try buildDataType(typeAnnotations.first)
+
+        let blocks = node.children(ofKind: .block)
+        let body = try buildBlock(blocks.first ?? SyntaxNode(kind: .block, children: []))
+
+        return FunctionDeclaration(
+            name: name,
+            parameters: parameters,
+            returnType: returnType,
+            localVariables: [],
+            body: body,
+            position: position
+        )
+    }
+
+    private func buildProcedureDeclaration(_ node: SyntaxNode) throws -> ProcedureDeclaration {
+        let position = tokenAt(node.children.first)?.position
+        let name = identifierName(in: node)
+        let paramList = node.firstChild(ofKind: .parameterList)
+        let parameters = try buildParameterList(paramList)
+
+        let blocks = node.children(ofKind: .block)
+        let body = try buildBlock(blocks.first ?? SyntaxNode(kind: .block, children: []))
+
+        return ProcedureDeclaration(
+            name: name,
+            parameters: parameters,
+            localVariables: [],
+            body: body,
+            position: position
+        )
+    }
+
+    private func buildClassDeclaration(_ node: SyntaxNode) throws -> ClassDeclaration {
+        let position = tokenAt(node.children.first)?.position
+        let name = identifierName(in: node)
+
+        let members = try node.children(ofKind: .memberDeclaration).map { member -> MemberDeclaration in
+            let memberName = identifierName(in: member)
+            let type = try buildDataType(member.firstChild(ofKind: .typeAnnotation))
+            return MemberDeclaration(name: memberName, type: type)
+        }
+
+        var constructor: ConstructorDeclaration?
+        if let ctorNode = node.firstChild(ofKind: .constructorDeclaration) {
+            let params = try buildParameterList(ctorNode.firstChild(ofKind: .parameterList))
+            let blocks = ctorNode.children(ofKind: .block)
+            let body = try buildBlock(blocks.first ?? SyntaxNode(kind: .block, children: []))
+            constructor = ConstructorDeclaration(parameters: params, body: body)
+        }
+
+        let methods = try node.children(ofKind: .methodDeclaration).map { method -> MethodDeclaration in
+            let methodName = identifierName(in: method)
+            let params = try buildParameterList(method.firstChild(ofKind: .parameterList))
+            let typeAnnotations = method.children(ofKind: .typeAnnotation)
+            let retType: DataType? = typeAnnotations.isEmpty ? nil : try buildDataType(typeAnnotations.first)
+            let blocks = method.children(ofKind: .block)
+            let body = try buildBlock(blocks.first ?? SyntaxNode(kind: .block, children: []))
+            return MethodDeclaration(name: methodName, parameters: params, returnType: retType, body: body)
+        }
+
+        return ClassDeclaration(
+            name: name,
+            superclass: nil,
+            members: members,
+            constructor: constructor,
+            methods: methods,
+            position: position
+        )
+    }
+
+    private func buildReturnStatement(_ node: SyntaxNode) throws -> ReturnStatement {
+        let exprChildren = node.children.filter { $0.kind.isExpression }
+        let expression: Expression? = exprChildren.isEmpty ? nil : try buildExpression(exprChildren[0])
+        return ReturnStatement(expression: expression)
+    }
+
+    // MARK: - Assignment
+
+    private func buildAssignment(_ node: SyntaxNode) throws -> Assignment {
+        let tokenChildren = node.children.filter { $0.isToken }
+        let exprChildren = node.children.filter { $0.kind.isExpression }
+
+        guard let firstToken = tokenChildren.first, let firstTok = tokenAt(firstToken) else {
+            throw ASTBuildError.missingChild("identifier", parent: .assignmentStatement)
+        }
+        let identifier = firstTok.lexeme
+
+        let hasLeftBracket = tokenChildren.contains { tokenAt($0)?.type == .leftBracket }
+        let hasDot = tokenChildren.contains { tokenAt($0)?.type == .dot }
+
+        if hasLeftBracket {
+            let indexExprs = exprChildren.dropLast()
+            guard let valueExpr = exprChildren.last else {
+                throw ASTBuildError.missingChild("value", parent: .assignmentStatement)
+            }
+            var arrayExpr: Expression = .identifier(identifier)
+            for indexNode in indexExprs {
+                let indexExpr = try buildExpression(indexNode)
+                arrayExpr = .arrayAccess(arrayExpr, indexExpr)
+            }
+            if case let .arrayAccess(array, index) = arrayExpr {
+                return .arrayElement(Assignment.ArrayAccess(array: array, index: index), try buildExpression(valueExpr))
+            }
+            return .variable(identifier, try buildExpression(valueExpr))
+        } else if hasDot {
+            let fieldTokens = tokenChildren.filter { tokenAt($0)?.type == .identifier }
+            guard let valueExpr = exprChildren.last else {
+                throw ASTBuildError.missingChild("value", parent: .assignmentStatement)
+            }
+            var currentExpr: Expression = .identifier(identifier)
+            for fieldTok in fieldTokens.dropFirst() {
+                currentExpr = .fieldAccess(currentExpr, tokenAt(fieldTok)?.lexeme ?? "")
+            }
+            if case let .fieldAccess(obj, field) = currentExpr {
+                return .fieldAccess(Assignment.FieldAccess(object: obj, field: field), try buildExpression(valueExpr))
+            }
+            return .variable(identifier, try buildExpression(valueExpr))
+        } else {
+            guard let valueExpr = exprChildren.last else {
+                throw ASTBuildError.missingChild("value", parent: .assignmentStatement)
+            }
+            return .variable(identifier, try buildExpression(valueExpr))
+        }
+    }
+
+    // MARK: - Expression Building
+
+    private func buildExpression(_ node: SyntaxNode) throws -> Expression {
+        switch node.kind {
+        case .literalExpr:
+            guard let tokNode = node.children.first, let tok = tokenAt(tokNode) else {
+                throw ASTBuildError.missingChild("literal token", parent: .literalExpr)
+            }
+            guard let literal = Literal(token: tok) else {
+                throw ASTBuildError.invalidLiteral(tok.lexeme)
+            }
+            return .literal(literal)
+
+        case .identifierExpr:
+            guard let tokNode = node.children.first, let tok = tokenAt(tokNode) else {
+                throw ASTBuildError.missingChild("identifier token", parent: .identifierExpr)
+            }
+            return .identifier(tok.lexeme)
+
+        case .binaryExpr:
+            guard node.children.count >= 3 else {
+                throw ASTBuildError.missingChild("operands", parent: .binaryExpr)
+            }
+            let left = try buildExpression(node.children[0])
+            guard let opTok = tokenAt(node.children[1]),
+                  let op = BinaryOperator(tokenType: opTok.type) else {
+                throw ASTBuildError.missingChild("operator", parent: .binaryExpr)
+            }
+            let right = try buildExpression(node.children[2])
+            return .binary(op, left, right)
+
+        case .unaryExpr:
+            guard node.children.count >= 2 else {
+                throw ASTBuildError.missingChild("operand", parent: .unaryExpr)
+            }
+            guard let opTok = tokenAt(node.children[0]),
+                  let op = UnaryOperator(tokenType: opTok.type) else {
+                throw ASTBuildError.missingChild("operator", parent: .unaryExpr)
+            }
+            let operand = try buildExpression(node.children[1])
+            return .unary(op, operand)
+
+        case .callExpr:
+            guard let nameNode = node.children.first else {
+                throw ASTBuildError.missingChild("name", parent: .callExpr)
+            }
+            let name: String
+            if nameNode.kind == .identifierExpr, let tok = nameNode.children.first, let resolved = tokenAt(tok) {
+                name = resolved.lexeme
+            } else if let resolved = tokenAt(nameNode) {
+                name = resolved.lexeme
+            } else {
+                throw ASTBuildError.missingChild("name token", parent: .callExpr)
+            }
+
+            let argList = node.firstChild(ofKind: .argumentList)
+            let args = try buildArgumentList(argList)
+            return .functionCall(name, args)
+
+        case .methodCallExpr:
+            let nonTokenChildren = node.children.filter { !$0.isToken }
+            guard let receiverNode = nonTokenChildren.first else {
+                throw ASTBuildError.missingChild("receiver", parent: .methodCallExpr)
+            }
+            let receiver = try buildExpression(receiverNode)
+
+            let identTokens = node.children.filter { $0.isToken && tokenAt($0)?.type == .identifier }
+            guard let methodToken = identTokens.last, let methodTok = tokenAt(methodToken) else {
+                throw ASTBuildError.missingChild("method name", parent: .methodCallExpr)
+            }
+
+            let argList = node.firstChild(ofKind: .argumentList)
+            let args = try buildArgumentList(argList)
+            return .methodCall(receiver, methodTok.lexeme, args)
+
+        case .arrayAccessExpr:
+            let nonTokenChildren = node.children.filter { !$0.isToken }
+            guard nonTokenChildren.count >= 2 else {
+                throw ASTBuildError.missingChild("array and index", parent: .arrayAccessExpr)
+            }
+            var arrayExpr = try buildExpression(nonTokenChildren[0])
+            for indexNode in nonTokenChildren.dropFirst() {
+                let indexExpr = try buildExpression(indexNode)
+                arrayExpr = .arrayAccess(arrayExpr, indexExpr)
+            }
+            return arrayExpr
+
+        case .fieldAccessExpr:
+            let nonTokenChildren = node.children.filter { !$0.isToken }
+            guard let objNode = nonTokenChildren.first else {
+                throw ASTBuildError.missingChild("object", parent: .fieldAccessExpr)
+            }
+            let obj = try buildExpression(objNode)
+            let identTokens = node.children.filter { $0.isToken && tokenAt($0)?.type == .identifier }
+            guard let fieldToken = identTokens.last, let fieldTok = tokenAt(fieldToken) else {
+                throw ASTBuildError.missingChild("field name", parent: .fieldAccessExpr)
+            }
+            return .fieldAccess(obj, fieldTok.lexeme)
+
+        case .arrayLiteralExpr:
+            let exprChildren = node.children.filter { $0.kind.isExpression }
+            let elements = try exprChildren.map { try buildExpression($0) }
+            return .arrayLiteral(elements)
+
+        case .parenExpr:
+            let exprChildren = node.children.filter { $0.kind.isExpression }
+            guard let inner = exprChildren.first else {
+                throw ASTBuildError.missingChild("inner expression", parent: .parenExpr)
+            }
+            return try buildExpression(inner)
+
+        default:
+            throw ASTBuildError.unexpectedKind(node.kind)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func buildBlock(_ node: SyntaxNode) throws -> [Statement] {
+        guard node.kind == .block else {
+            return [try buildStatement(node)]
+        }
+        return try node.children.map { try buildStatement($0) }
+    }
+
+    private func buildParameterList(_ node: SyntaxNode?) throws -> [Parameter] {
+        guard let paramList = node else { return [] }
+        return try paramList.children(ofKind: .parameter).map { paramNode in
+            let name = identifierName(in: paramNode)
+            let type = try buildDataType(paramNode.firstChild(ofKind: .typeAnnotation))
+            return Parameter(name: name, type: type)
+        }
+    }
+
+    private func buildArgumentList(_ node: SyntaxNode?) throws -> [Expression] {
+        guard let argList = node else { return [] }
+        let exprChildren = argList.children.filter { $0.kind.isExpression }
+        return try exprChildren.map { try buildExpression($0) }
+    }
+
+    private func buildDataType(_ node: SyntaxNode?) throws -> DataType {
+        guard let typeNode = node else {
+            throw ASTBuildError.missingChild("type", parent: .typeAnnotation)
+        }
+        guard let firstToken = typeNode.children.first, let tok = tokenAt(firstToken) else {
+            throw ASTBuildError.missingChild("type token", parent: .typeAnnotation)
+        }
+
+        if let basicType = DataType(tokenType: tok.type) {
+            return basicType
+        }
+
+        if tok.type == .identifier {
+            let typeName = tok.lexeme.lowercased()
+            switch typeName {
+            case "integer", "int", "整数型", "整数":
+                return .integer
+            case "real", "double", "float", "実数型", "実数":
+                return .real
+            case "string", "str", "文字列型", "文字列":
+                return .string
+            case "character", "char", "文字型", "文字":
+                return .character
+            case "boolean", "bool", "論理型", "論理", "ブール":
+                return .boolean
+            case "array", "配列型", "配列":
+                let nestedTypes = typeNode.children(ofKind: .typeAnnotation)
+                if let nested = nestedTypes.first {
+                    return .array(try buildDataType(nested))
+                }
+                return .array(.integer)
+            case "record", "レコード型", "レコード":
+                let identTokens = typeNode.children.filter { $0.isToken && tokenAt($0)?.type == .identifier }
+                if let nameToken = identTokens.dropFirst().first, let nameTok = tokenAt(nameToken) {
+                    return .record(nameTok.lexeme)
+                }
+                return .record(tok.lexeme)
+            default:
+                return .record(tok.lexeme)
+            }
+        }
+
+        if tok.type == .arrayType {
+            let nestedTypes = typeNode.children(ofKind: .typeAnnotation)
+            if let nested = nestedTypes.first {
+                return .array(try buildDataType(nested))
+            }
+            return .array(.integer)
+        }
+        if tok.type == .recordType {
+            let identTokens = typeNode.children.filter { $0.isToken && tokenAt($0)?.type == .identifier }
+            if let nameToken = identTokens.first, let nameTok = tokenAt(nameToken) {
+                return .record(nameTok.lexeme)
+            }
+        }
+
+        throw ASTBuildError.unknownType(tok.lexeme)
+    }
+
+    private func tokenAt(_ node: SyntaxNode?) -> Token? {
+        guard let syntaxNode = node, let idx = syntaxNode.tokenIndex, idx < tokens.count else { return nil }
+        return tokens[idx]
+    }
+
+    private func tokenLexeme(_ node: SyntaxNode) -> String {
+        if let idx = node.tokenIndex, idx < tokens.count {
+            return tokens[idx].lexeme
+        }
+        if let first = node.children.first {
+            return tokenLexeme(first)
+        }
+        return ""
+    }
+
+    private func identifierName(in node: SyntaxNode) -> String {
+        for child in node.children {
+            if child.isToken, let tok = tokenAt(child), tok.type == .identifier {
+                return tok.lexeme
+            }
+        }
+        return ""
+    }
+}
+
+// MARK: - ASTBuildError
+
+public enum ASTBuildError: Error, Equatable, Sendable {
+    case expectedKind(SyntaxKind, got: SyntaxKind)
+    case unexpectedKind(SyntaxKind)
+    case missingChild(String, parent: SyntaxKind)
+    case invalidLiteral(String)
+    case unknownType(String)
+}
+
+extension ASTBuildError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .expectedKind(let expected, let got):
+            return "Expected CST node kind '\(expected)' but got '\(got)'"
+        case .unexpectedKind(let kind):
+            return "Unexpected CST node kind '\(kind)'"
+        case .missingChild(let desc, parent: let parent):
+            return "Missing \(desc) in \(parent) node"
+        case .invalidLiteral(let text):
+            return "Invalid literal: '\(text)'"
+        case .unknownType(let name):
+            return "Unknown type: '\(name)'"
+        }
+    }
+}

--- a/Sources/FeLangCore/CST/CSTParser.swift
+++ b/Sources/FeLangCore/CST/CSTParser.swift
@@ -1,0 +1,879 @@
+import Foundation
+
+/// Parses a token stream into a concrete syntax tree (CST).
+///
+/// Unlike `StatementParser` which directly builds AST nodes, `CSTParser`
+/// preserves the full token structure so that an `ASTBuilder` can later
+/// convert the tree without re-scanning the token stream.
+public struct CSTParser {
+
+    public init() {}
+
+    // MARK: - Public API
+
+    /// Parses tokens into a CST rooted at a `sourceFile` node.
+    ///
+    /// The source file is structured as:
+    /// ```
+    /// sourceFile {
+    ///   importList { ... }      // top-level declarations (variable, constant, global)
+    ///   declarationList { ... } // function, procedure, class declarations
+    /// }
+    /// ```
+    public func parse(_ tokens: [Token]) throws -> SyntaxNode {
+        guard tokens.count <= 100_000 else {
+            throw CSTParsingError.inputTooLarge
+        }
+
+        var stream = CSTTokenStream(tokens)
+        var importChildren: [SyntaxNode] = []
+        var declChildren: [SyntaxNode] = []
+        var nestingDepth = 0
+        let maxNestingDepth = 100
+
+        while let token = stream.peek(), token.type != .eof {
+            if token.type == .whitespace || token.type == .newline {
+                _ = stream.advance()
+                continue
+            }
+
+            switch token.type {
+            case .ifKeyword, .whileKeyword, .forKeyword,
+                 .functionKeyword, .procedureKeyword, .classKeyword:
+                nestingDepth += 1
+                guard nestingDepth <= maxNestingDepth else {
+                    throw CSTParsingError.nestingTooDeep
+                }
+            case .endifKeyword, .endwhileKeyword, .endforKeyword,
+                 .endfunctionKeyword, .endprocedureKeyword, .endclassKeyword:
+                nestingDepth = max(0, nestingDepth - 1)
+            default:
+                break
+            }
+
+            let isTopLevelDecl = token.type == .variableKeyword
+                || token.type == .constantKeyword
+                || token.type == .globalKeyword
+            let isFuncOrClass = token.type == .functionKeyword
+                || token.type == .procedureKeyword
+                || token.type == .classKeyword
+
+            if isTopLevelDecl && declChildren.isEmpty {
+                let node = try parseStatement(&stream, nestingDepth: nestingDepth)
+                importChildren.append(node)
+            } else if isFuncOrClass {
+                let node = try parseStatement(&stream, nestingDepth: nestingDepth)
+                declChildren.append(node)
+            } else {
+                let node = try parseStatement(&stream, nestingDepth: nestingDepth)
+                declChildren.append(node)
+            }
+        }
+
+        let importList = SyntaxNode(
+            kind: .importList,
+            children: importChildren,
+            startTokenIndex: 0,
+            endTokenIndex: importChildren.last?.endTokenIndex ?? 0
+        )
+        let declList = SyntaxNode(
+            kind: .declarationList,
+            children: declChildren,
+            startTokenIndex: importList.endTokenIndex,
+            endTokenIndex: declChildren.last?.endTokenIndex ?? importList.endTokenIndex
+        )
+
+        return SyntaxNode(
+            kind: .sourceFile,
+            children: [importList, declList],
+            startTokenIndex: 0,
+            endTokenIndex: stream.index
+        )
+    }
+
+    // MARK: - Statement Parsing
+
+    private func parseStatement(_ stream: inout CSTTokenStream, nestingDepth: Int = 0) throws -> SyntaxNode {
+        guard let token = stream.peek() else {
+            throw CSTParsingError.unexpectedEndOfInput
+        }
+
+        switch token.type {
+        case .ifKeyword:
+            return try parseIfStatement(&stream, nestingDepth: nestingDepth)
+        case .whileKeyword:
+            return try parseWhileStatement(&stream, nestingDepth: nestingDepth)
+        case .doKeyword:
+            return try parseDoWhileStatement(&stream, nestingDepth: nestingDepth)
+        case .forKeyword:
+            return try parseForStatement(&stream, nestingDepth: nestingDepth)
+        case .variableKeyword:
+            return try parseVariableDeclaration(&stream)
+        case .constantKeyword:
+            return try parseConstantDeclaration(&stream)
+        case .globalKeyword:
+            return try parseGlobalDeclaration(&stream)
+        case .functionKeyword:
+            return try parseFunctionDeclaration(&stream, nestingDepth: nestingDepth)
+        case .procedureKeyword:
+            return try parseProcedureDeclaration(&stream, nestingDepth: nestingDepth)
+        case .classKeyword:
+            return try parseClassDeclaration(&stream, nestingDepth: nestingDepth)
+        case .returnKeyword:
+            return try parseReturnStatement(&stream)
+        case .breakKeyword:
+            let idx = stream.index
+            _ = stream.advance()
+            return SyntaxNode(kind: .breakStatement, children: [SyntaxNode(token: idx)])
+        case .continueKeyword:
+            let idx = stream.index
+            _ = stream.advance()
+            return SyntaxNode(kind: .continueStatement, children: [SyntaxNode(token: idx)])
+        case .identifier:
+            return try parseAssignmentOrExpressionStatement(&stream)
+        default:
+            return try parseExpressionStatement(&stream)
+        }
+    }
+
+    // MARK: - Control Flow
+
+    private func parseIfStatement(_ stream: inout CSTTokenStream, nestingDepth: Int) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .ifKeyword))
+
+        let condition = try parseExpression(&stream)
+        children.append(SyntaxNode(kind: .conditionClause, children: [condition]))
+
+        children.append(try consumeToken(&stream, .thenKeyword))
+
+        let thenBody = try parseBlock(&stream,
+                                       until: [.elseKeyword, .elifKeyword, .elseifKeyword, .endifKeyword],
+                                       nestingDepth: nestingDepth)
+        children.append(SyntaxNode(kind: .thenClause, children: [thenBody]))
+
+        while stream.peek()?.type == .elifKeyword || stream.peek()?.type == .elseifKeyword {
+            var elseIfChildren: [SyntaxNode] = []
+            elseIfChildren.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            let elifCond = try parseExpression(&stream)
+            elseIfChildren.append(SyntaxNode(kind: .conditionClause, children: [elifCond]))
+            elseIfChildren.append(try consumeToken(&stream, .thenKeyword))
+            let elifBody = try parseBlock(&stream,
+                                           until: [.elseKeyword, .elifKeyword, .elseifKeyword, .endifKeyword],
+                                           nestingDepth: nestingDepth)
+            elseIfChildren.append(SyntaxNode(kind: .thenClause, children: [elifBody]))
+            children.append(SyntaxNode(kind: .elseIfClause, children: elseIfChildren))
+        }
+
+        if stream.peek()?.type == .elseKeyword {
+            var elseChildren: [SyntaxNode] = []
+            elseChildren.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            let elseBody = try parseBlock(&stream, until: [.endifKeyword], nestingDepth: nestingDepth)
+            elseChildren.append(elseBody)
+            children.append(SyntaxNode(kind: .elseClause, children: elseChildren))
+        }
+
+        children.append(try consumeToken(&stream, .endifKeyword))
+
+        return SyntaxNode(kind: .ifStatement, children: children)
+    }
+
+    private func parseWhileStatement(_ stream: inout CSTTokenStream, nestingDepth: Int) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .whileKeyword))
+        let cond = try parseExpression(&stream)
+        children.append(SyntaxNode(kind: .conditionClause, children: [cond]))
+        children.append(try consumeToken(&stream, .doKeyword))
+        let body = try parseBlock(&stream, until: [.endwhileKeyword], nestingDepth: nestingDepth)
+        children.append(body)
+        children.append(try consumeToken(&stream, .endwhileKeyword))
+        return SyntaxNode(kind: .whileStatement, children: children)
+    }
+
+    private func parseDoWhileStatement(_ stream: inout CSTTokenStream, nestingDepth: Int) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .doKeyword))
+        let body = try parseDoWhileBody(&stream, nestingDepth: nestingDepth)
+        children.append(body)
+        children.append(try consumeToken(&stream, .whileKeyword))
+        children.append(try consumeToken(&stream, .leftParen))
+        let cond = try parseExpression(&stream)
+        children.append(SyntaxNode(kind: .conditionClause, children: [cond]))
+        children.append(try consumeToken(&stream, .rightParen))
+        return SyntaxNode(kind: .doWhileStatement, children: children)
+    }
+
+    private func parseDoWhileBody(_ stream: inout CSTTokenStream, nestingDepth: Int) throws -> SyntaxNode {
+        guard nestingDepth < 100 else { throw CSTParsingError.nestingTooDeep }
+        var stmts: [SyntaxNode] = []
+        while let token = stream.peek(), token.type != .eof {
+            if token.type == .newline || token.type == .whitespace {
+                _ = stream.advance()
+                continue
+            }
+            if token.type == .whileKeyword {
+                if let next = stream.peek(offset: 1), next.type == .leftParen {
+                    break
+                }
+            }
+            stmts.append(try parseStatement(&stream, nestingDepth: nestingDepth + 1))
+        }
+        return SyntaxNode(kind: .block, children: stmts)
+    }
+
+    private func parseForStatement(_ stream: inout CSTTokenStream, nestingDepth: Int) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .forKeyword))
+
+        guard let varToken = stream.peek(), varToken.type == .identifier else {
+            throw CSTParsingError.expectedIdentifier
+        }
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+
+        if stream.peek()?.type == .assign {
+            var rangeChildren: [SyntaxNode] = []
+            rangeChildren.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            rangeChildren.append(try parseExpression(&stream))
+            rangeChildren.append(try consumeToken(&stream, .toKeyword))
+            rangeChildren.append(try parseExpression(&stream))
+            if stream.peek()?.type == .stepKeyword {
+                rangeChildren.append(SyntaxNode(token: stream.index))
+                _ = stream.advance()
+                rangeChildren.append(try parseExpression(&stream))
+            }
+            children.append(SyntaxNode(kind: .forRangeClause, children: rangeChildren))
+        } else if stream.peek()?.type == .inKeyword {
+            var forEachChildren: [SyntaxNode] = []
+            forEachChildren.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            forEachChildren.append(try parseExpression(&stream))
+            children.append(SyntaxNode(kind: .forEachClause, children: forEachChildren))
+        } else {
+            throw CSTParsingError.expectedToken(.assign)
+        }
+
+        children.append(try consumeToken(&stream, .doKeyword))
+        let body = try parseBlock(&stream, until: [.endforKeyword], nestingDepth: nestingDepth)
+        children.append(body)
+        children.append(try consumeToken(&stream, .endforKeyword))
+
+        return SyntaxNode(kind: .forStatement, children: children)
+    }
+
+    // MARK: - Declarations
+
+    private func parseVariableDeclaration(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .variableKeyword))
+        guard stream.peek()?.type == .identifier else { throw CSTParsingError.expectedIdentifier }
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+        children.append(try consumeToken(&stream, .colon))
+        children.append(try parseTypeAnnotation(&stream))
+        if stream.peek()?.type == .assign {
+            children.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            children.append(try parseExpression(&stream))
+        }
+        return SyntaxNode(kind: .variableDeclaration, children: children)
+    }
+
+    private func parseConstantDeclaration(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .constantKeyword))
+        guard stream.peek()?.type == .identifier else { throw CSTParsingError.expectedIdentifier }
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+        children.append(try consumeToken(&stream, .colon))
+        children.append(try parseTypeAnnotation(&stream))
+        children.append(try consumeToken(&stream, .assign))
+        children.append(try parseExpression(&stream))
+        return SyntaxNode(kind: .constantDeclaration, children: children)
+    }
+
+    private func parseGlobalDeclaration(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .globalKeyword))
+        children.append(try consumeToken(&stream, .colon))
+        children.append(try parseTypeAnnotation(&stream))
+        children.append(try consumeToken(&stream, .colon))
+        guard stream.peek()?.type == .identifier else { throw CSTParsingError.expectedIdentifier }
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+        if stream.peek()?.type == .assign {
+            children.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            children.append(try parseExpression(&stream))
+        }
+        return SyntaxNode(kind: .globalDeclaration, children: children)
+    }
+
+    private func parseFunctionDeclaration(_ stream: inout CSTTokenStream, nestingDepth: Int) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .functionKeyword))
+        guard stream.peek()?.type == .identifier else { throw CSTParsingError.expectedIdentifier }
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+        children.append(try consumeToken(&stream, .leftParen))
+        children.append(try parseParameterList(&stream))
+        children.append(try consumeToken(&stream, .rightParen))
+        if stream.peek()?.type == .colon {
+            children.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            children.append(try parseTypeAnnotation(&stream))
+        }
+        let body = try parseFunctionBody(&stream, endToken: .endfunctionKeyword, nestingDepth: nestingDepth)
+        children.append(body)
+        children.append(try consumeToken(&stream, .endfunctionKeyword))
+        return SyntaxNode(kind: .functionDeclaration, children: children)
+    }
+
+    private func parseProcedureDeclaration(_ stream: inout CSTTokenStream, nestingDepth: Int) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .procedureKeyword))
+        guard stream.peek()?.type == .identifier else { throw CSTParsingError.expectedIdentifier }
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+        children.append(try consumeToken(&stream, .leftParen))
+        children.append(try parseParameterList(&stream))
+        children.append(try consumeToken(&stream, .rightParen))
+        let body = try parseFunctionBody(&stream, endToken: .endprocedureKeyword, nestingDepth: nestingDepth)
+        children.append(body)
+        children.append(try consumeToken(&stream, .endprocedureKeyword))
+        return SyntaxNode(kind: .procedureDeclaration, children: children)
+    }
+
+    private func parseClassDeclaration(_ stream: inout CSTTokenStream, nestingDepth: Int) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .classKeyword))
+        guard stream.peek()?.type == .identifier else { throw CSTParsingError.expectedIdentifier }
+        let className = stream.peek()!.lexeme
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+
+        while let token = stream.peek(), token.type != .endclassKeyword && token.type != .eof {
+            if token.type == .newline || token.type == .whitespace {
+                _ = stream.advance()
+                continue
+            }
+            if token.type == .identifier && token.lexeme == className {
+                if let next = stream.peek(offset: 1), next.type == .leftParen {
+                    children.append(try parseConstructorDecl(&stream))
+                    continue
+                }
+            }
+            if token.type == .functionKeyword {
+                children.append(try parseMethodDecl(&stream, nestingDepth: nestingDepth))
+                continue
+            }
+            if token.type == .identifier {
+                if let next = stream.peek(offset: 1), next.type == .colon {
+                    children.append(try parseMemberDecl(&stream))
+                    continue
+                }
+            }
+            throw CSTParsingError.unexpectedToken(token)
+        }
+
+        children.append(try consumeToken(&stream, .endclassKeyword))
+        return SyntaxNode(kind: .classDeclaration, children: children)
+    }
+
+    private func parseMemberDecl(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+        children.append(try consumeToken(&stream, .colon))
+        children.append(try parseTypeAnnotation(&stream))
+        return SyntaxNode(kind: .memberDeclaration, children: children)
+    }
+
+    private func parseConstructorDecl(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+        children.append(try consumeToken(&stream, .leftParen))
+        children.append(try parseParameterList(&stream))
+        children.append(try consumeToken(&stream, .rightParen))
+        let body = try parseClassMemberBody(&stream)
+        children.append(body)
+        return SyntaxNode(kind: .constructorDeclaration, children: children)
+    }
+
+    private func parseMethodDecl(_ stream: inout CSTTokenStream, nestingDepth: Int) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .functionKeyword))
+        guard stream.peek()?.type == .identifier else { throw CSTParsingError.expectedIdentifier }
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+        children.append(try consumeToken(&stream, .leftParen))
+        children.append(try parseParameterList(&stream))
+        children.append(try consumeToken(&stream, .rightParen))
+        if stream.peek()?.type == .colon {
+            children.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            children.append(try parseTypeAnnotation(&stream))
+        }
+        let body = try parseBlock(&stream, until: [.endfunctionKeyword], nestingDepth: nestingDepth)
+        children.append(body)
+        children.append(try consumeToken(&stream, .endfunctionKeyword))
+        return SyntaxNode(kind: .methodDeclaration, children: children)
+    }
+
+    private func parseClassMemberBody(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        var stmts: [SyntaxNode] = []
+        while let token = stream.peek() {
+            if token.type == .newline || token.type == .whitespace {
+                _ = stream.advance()
+                continue
+            }
+            if token.type == .endclassKeyword || token.type == .functionKeyword || token.type == .eof {
+                break
+            }
+            if token.type == .identifier {
+                if let next = stream.peek(offset: 1) {
+                    if next.type == .colon || next.type == .leftParen { break }
+                }
+            }
+            stmts.append(try parseStatement(&stream))
+        }
+        return SyntaxNode(kind: .block, children: stmts)
+    }
+
+    private func parseReturnStatement(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(try consumeToken(&stream, .returnKeyword))
+        if let token = stream.peek(), token.type != .newline && token.type != .eof {
+            children.append(try parseExpression(&stream))
+        }
+        return SyntaxNode(kind: .returnStatement, children: children)
+    }
+
+    // MARK: - Assignment / Expression Statement
+
+    private func parseAssignmentOrExpressionStatement(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        guard let first = stream.peek(), first.type == .identifier else {
+            return try parseExpressionStatement(&stream)
+        }
+
+        if let next = stream.peek(offset: 1), next.type == .assign {
+            return try parseAssignment(&stream)
+        }
+
+        if let next = stream.peek(offset: 1), next.type == .leftBracket {
+            if isArrayAssignment(&stream) {
+                return try parseAssignment(&stream)
+            }
+        }
+
+        if let next = stream.peek(offset: 1), next.type == .dot {
+            if isFieldAssignment(&stream) {
+                return try parseAssignment(&stream)
+            }
+        }
+
+        return try parseExpressionStatement(&stream)
+    }
+
+    private func isArrayAssignment(_ stream: inout CSTTokenStream) -> Bool {
+        var offset = 2
+        var bracketCount = 1
+        while bracketCount > 0 {
+            guard let token = stream.peek(offset: offset) else { return false }
+            if token.type == .leftBracket { bracketCount += 1 }
+            if token.type == .rightBracket { bracketCount -= 1 }
+            offset += 1
+        }
+        return stream.peek(offset: offset)?.type == .assign
+    }
+
+    private func isFieldAssignment(_ stream: inout CSTTokenStream) -> Bool {
+        var offset = 2
+        while let token = stream.peek(offset: offset) {
+            if token.type == .identifier {
+                offset += 1
+                if stream.peek(offset: offset)?.type == .dot {
+                    offset += 1
+                    continue
+                }
+                break
+            } else {
+                break
+            }
+        }
+        return stream.peek(offset: offset)?.type == .assign
+    }
+
+    private func parseAssignment(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+
+        if stream.peek()?.type == .leftBracket {
+            children.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            children.append(try parseExpression(&stream))
+            while stream.peek()?.type == .comma {
+                children.append(SyntaxNode(token: stream.index))
+                _ = stream.advance()
+                children.append(try parseExpression(&stream))
+            }
+            children.append(try consumeToken(&stream, .rightBracket))
+        } else if stream.peek()?.type == .dot {
+            while stream.peek()?.type == .dot {
+                children.append(SyntaxNode(token: stream.index))
+                _ = stream.advance()
+                guard stream.peek()?.type == .identifier else { throw CSTParsingError.expectedIdentifier }
+                children.append(SyntaxNode(token: stream.index))
+                _ = stream.advance()
+            }
+        }
+
+        children.append(try consumeToken(&stream, .assign))
+        children.append(try parseExpression(&stream))
+
+        return SyntaxNode(kind: .assignmentStatement, children: children)
+    }
+
+    private func parseExpressionStatement(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        let expr = try parseExpression(&stream)
+        return SyntaxNode(kind: .expressionStatement, children: [expr])
+    }
+
+    // MARK: - Expression Parsing
+
+    private func parseExpression(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        return try parseExpressionWithPrecedence(&stream, minPrecedence: 0)
+    }
+
+    private func parseExpressionWithPrecedence(_ stream: inout CSTTokenStream, minPrecedence: Int) throws -> SyntaxNode {
+        var left = try parseUnaryExpression(&stream)
+
+        while let token = stream.peek(),
+              let op = BinaryOperator(tokenType: token.type),
+              op.precedence >= minPrecedence {
+            let opNode = SyntaxNode(token: stream.index)
+            _ = stream.advance()
+            let nextMin = op.isLeftAssociative ? op.precedence + 1 : op.precedence
+            let right = try parseExpressionWithPrecedence(&stream, minPrecedence: nextMin)
+            left = SyntaxNode(kind: .binaryExpr, children: [left, opNode, right])
+        }
+
+        return left
+    }
+
+    private func parseUnaryExpression(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        if let token = stream.peek(), UnaryOperator(tokenType: token.type) != nil {
+            let opNode = SyntaxNode(token: stream.index)
+            _ = stream.advance()
+            let operand = try parseUnaryExpression(&stream)
+            return SyntaxNode(kind: .unaryExpr, children: [opNode, operand])
+        }
+        return try parsePostfixExpression(&stream)
+    }
+
+    private func parsePostfixExpression(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        var expr = try parsePrimaryExpression(&stream)
+
+        while true {
+            if stream.peek()?.type == .leftBracket {
+                var children: [SyntaxNode] = [expr]
+                children.append(SyntaxNode(token: stream.index))
+                _ = stream.advance()
+                children.append(try parseExpression(&stream))
+                while stream.peek()?.type == .comma {
+                    children.append(SyntaxNode(token: stream.index))
+                    _ = stream.advance()
+                    children.append(try parseExpression(&stream))
+                }
+                children.append(try consumeToken(&stream, .rightBracket))
+                expr = SyntaxNode(kind: .arrayAccessExpr, children: children)
+            } else if stream.peek()?.type == .dot {
+                let dotNode = SyntaxNode(token: stream.index)
+                _ = stream.advance()
+                guard let field = stream.peek(), field.type == .identifier else {
+                    throw CSTParsingError.expectedIdentifier
+                }
+                let fieldNode = SyntaxNode(token: stream.index)
+                _ = stream.advance()
+
+                if stream.peek()?.type == .leftParen {
+                    var children: [SyntaxNode] = [expr, dotNode, fieldNode]
+                    children.append(SyntaxNode(token: stream.index))
+                    _ = stream.advance()
+                    children.append(try parseArgumentList(&stream))
+                    children.append(try consumeToken(&stream, .rightParen))
+                    expr = SyntaxNode(kind: .methodCallExpr, children: children)
+                } else {
+                    expr = SyntaxNode(kind: .fieldAccessExpr, children: [expr, dotNode, fieldNode])
+                }
+            } else if stream.peek()?.type == .leftParen,
+                      case .identifierExpr = expr.kind {
+                var children: [SyntaxNode] = [expr]
+                children.append(SyntaxNode(token: stream.index))
+                _ = stream.advance()
+                children.append(try parseArgumentList(&stream))
+                children.append(try consumeToken(&stream, .rightParen))
+                expr = SyntaxNode(kind: .callExpr, children: children)
+            } else {
+                break
+            }
+        }
+
+        return expr
+    }
+
+    private func parsePrimaryExpression(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        guard let token = stream.peek() else {
+            throw CSTParsingError.unexpectedEndOfInput
+        }
+
+        if Literal(token: token) != nil {
+            let node = SyntaxNode(kind: .literalExpr, children: [SyntaxNode(token: stream.index)])
+            _ = stream.advance()
+            return node
+        }
+
+        if token.type == .identifier {
+            let node = SyntaxNode(kind: .identifierExpr, children: [SyntaxNode(token: stream.index)])
+            _ = stream.advance()
+            return node
+        }
+
+        if token.type == .leftParen {
+            var children: [SyntaxNode] = []
+            children.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            children.append(try parseExpression(&stream))
+            children.append(try consumeToken(&stream, .rightParen))
+            return SyntaxNode(kind: .parenExpr, children: children)
+        }
+
+        if token.type == .leftBracket {
+            return try parseArrayLiteral(&stream, closing: .rightBracket)
+        }
+        if token.type == .leftBrace {
+            return try parseArrayLiteral(&stream, closing: .rightBrace)
+        }
+
+        throw CSTParsingError.expectedExpression(token)
+    }
+
+    private func parseArrayLiteral(_ stream: inout CSTTokenStream, closing: TokenType) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+
+        if stream.peek()?.type != closing {
+            children.append(try parseExpression(&stream))
+            while stream.peek()?.type == .comma {
+                children.append(SyntaxNode(token: stream.index))
+                _ = stream.advance()
+                children.append(try parseExpression(&stream))
+            }
+        }
+
+        children.append(try consumeToken(&stream, closing))
+        return SyntaxNode(kind: .arrayLiteralExpr, children: children)
+    }
+
+    // MARK: - Helpers
+
+    private func parseBlock(
+        _ stream: inout CSTTokenStream,
+        until endTokens: [TokenType],
+        nestingDepth: Int = 0
+    ) throws -> SyntaxNode {
+        guard nestingDepth < 100 else { throw CSTParsingError.nestingTooDeep }
+        var stmts: [SyntaxNode] = []
+        while let token = stream.peek(), !endTokens.contains(token.type) && token.type != .eof {
+            if token.type == .newline || token.type == .whitespace {
+                _ = stream.advance()
+                continue
+            }
+            stmts.append(try parseStatement(&stream, nestingDepth: nestingDepth + 1))
+        }
+        return SyntaxNode(kind: .block, children: stmts)
+    }
+
+    private func parseFunctionBody(
+        _ stream: inout CSTTokenStream,
+        endToken: TokenType,
+        nestingDepth: Int
+    ) throws -> SyntaxNode {
+        guard nestingDepth < 100 else { throw CSTParsingError.nestingTooDeep }
+        var stmts: [SyntaxNode] = []
+        while let token = stream.peek(), token.type != endToken && token.type != .eof {
+            if token.type == .newline || token.type == .whitespace {
+                _ = stream.advance()
+                continue
+            }
+            stmts.append(try parseStatement(&stream, nestingDepth: nestingDepth + 1))
+        }
+        return SyntaxNode(kind: .block, children: stmts)
+    }
+
+    private func parseParameterList(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        let start = stream.index
+        var params: [SyntaxNode] = []
+        if stream.peek()?.type == .rightParen {
+            return SyntaxNode(kind: .parameterList, children: [], startTokenIndex: start, endTokenIndex: start)
+        }
+        params.append(try parseParameter(&stream))
+        while stream.peek()?.type == .comma {
+            params.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            params.append(try parseParameter(&stream))
+        }
+        return SyntaxNode(kind: .parameterList, children: params)
+    }
+
+    private func parseParameter(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        var children: [SyntaxNode] = []
+        guard stream.peek()?.type == .identifier else { throw CSTParsingError.expectedIdentifier }
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+        children.append(try consumeToken(&stream, .colon))
+        children.append(try parseTypeAnnotation(&stream))
+        return SyntaxNode(kind: .parameter, children: children)
+    }
+
+    private func parseTypeAnnotation(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        guard let token = stream.peek() else {
+            throw CSTParsingError.unexpectedEndOfInput
+        }
+        var children: [SyntaxNode] = []
+        children.append(SyntaxNode(token: stream.index))
+        _ = stream.advance()
+
+        if token.type == .arrayType || (token.type == .identifier && isArrayTypeName(token.lexeme)) {
+            if stream.peek()?.lexeme == "of" || stream.peek()?.lexeme == "の" {
+                children.append(SyntaxNode(token: stream.index))
+                _ = stream.advance()
+                children.append(try parseTypeAnnotation(&stream))
+            }
+        } else if token.type == .recordType || (token.type == .identifier && isRecordTypeName(token.lexeme)) {
+            if stream.peek()?.type == .identifier {
+                children.append(SyntaxNode(token: stream.index))
+                _ = stream.advance()
+            }
+        }
+
+        return SyntaxNode(kind: .typeAnnotation, children: children)
+    }
+
+    private func isArrayTypeName(_ name: String) -> Bool {
+        let lower = name.lowercased()
+        return lower == "array" || lower == "配列型" || lower == "配列"
+    }
+
+    private func isRecordTypeName(_ name: String) -> Bool {
+        let lower = name.lowercased()
+        return lower == "record" || lower == "レコード型" || lower == "レコード"
+    }
+
+    private func parseArgumentList(_ stream: inout CSTTokenStream) throws -> SyntaxNode {
+        let start = stream.index
+        var args: [SyntaxNode] = []
+        if stream.peek()?.type == .rightParen {
+            return SyntaxNode(kind: .argumentList, children: [], startTokenIndex: start, endTokenIndex: start)
+        }
+        args.append(try parseExpression(&stream))
+        while stream.peek()?.type == .comma {
+            args.append(SyntaxNode(token: stream.index))
+            _ = stream.advance()
+            args.append(try parseExpression(&stream))
+        }
+        return SyntaxNode(kind: .argumentList, children: args)
+    }
+
+    @discardableResult
+    private func consumeToken(_ stream: inout CSTTokenStream, _ expected: TokenType) throws -> SyntaxNode {
+        guard let token = stream.peek() else {
+            throw CSTParsingError.unexpectedEndOfInput
+        }
+        guard token.type == expected else {
+            throw CSTParsingError.unexpectedTokenExpecting(token, expected: expected)
+        }
+        let node = SyntaxNode(token: stream.index)
+        _ = stream.advance()
+        return node
+    }
+}
+
+// MARK: - CSTTokenStream
+
+/// Token stream used by CSTParser that exposes index for CST node construction.
+public struct CSTTokenStream: Sendable {
+    public let tokens: [Token]
+    public var index: Int = 0
+    private let endIndex: Int
+
+    public init(_ tokens: [Token]) {
+        self.tokens = tokens
+        self.endIndex = tokens.count
+    }
+
+    @inline(__always)
+    public func peek() -> Token? {
+        guard index < endIndex else { return nil }
+        return tokens[index]
+    }
+
+    @inline(__always)
+    public func peek(offset: Int) -> Token? {
+        let target = index + offset
+        guard target >= 0 && target < endIndex else { return nil }
+        return tokens[target]
+    }
+
+    @inline(__always)
+    @discardableResult
+    public mutating func advance() -> Token? {
+        guard index < endIndex else { return nil }
+        let token = tokens[index]
+        index += 1
+        return token
+    }
+}
+
+// MARK: - CSTParsingError
+
+public enum CSTParsingError: Error, Equatable, Sendable {
+    case unexpectedEndOfInput
+    case unexpectedToken(Token)
+    case unexpectedTokenExpecting(Token, expected: TokenType)
+    case expectedIdentifier
+    case expectedExpression(Token)
+    case expectedToken(TokenType)
+    case inputTooLarge
+    case nestingTooDeep
+}
+
+extension CSTParsingError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unexpectedEndOfInput:
+            return "Unexpected end of input"
+        case .unexpectedToken(let token):
+            return "Unexpected token '\(token.lexeme)' at \(token.position)"
+        case .unexpectedTokenExpecting(let token, let expected):
+            return "Expected \(expected) but found '\(token.lexeme)' at \(token.position)"
+        case .expectedIdentifier:
+            return "Expected identifier"
+        case .expectedExpression(let token):
+            return "Expected expression at \(token.position), got '\(token.lexeme)'"
+        case .expectedToken(let expected):
+            return "Expected token: \(expected)"
+        case .inputTooLarge:
+            return "Input too large for safe processing"
+        case .nestingTooDeep:
+            return "Nesting depth too deep"
+        }
+    }
+}

--- a/Sources/FeLangCore/CST/SyntaxKind.swift
+++ b/Sources/FeLangCore/CST/SyntaxKind.swift
@@ -1,0 +1,139 @@
+/// Identifies the kind of a concrete syntax tree (CST) node.
+///
+/// CST nodes preserve the full syntactic structure of the source code,
+/// including tokens that are discarded during AST construction (keywords,
+/// delimiters, whitespace). This enables lossless round-tripping and
+/// fine-grained IDE tooling such as syntax highlighting and refactoring.
+public enum SyntaxKind: String, Equatable, Hashable, Sendable, CaseIterable {
+
+    // MARK: - Top-Level Structure
+
+    /// Root node representing an entire source file.
+    case sourceFile
+
+    /// A list of top-level declarations (variables, constants, globals)
+    /// that appear before function/procedure definitions.
+    case importList
+
+    /// A list of function, procedure, and class declarations.
+    case declarationList
+
+    // MARK: - Statements
+
+    case ifStatement
+    case whileStatement
+    case doWhileStatement
+    case forStatement
+    case variableDeclaration
+    case constantDeclaration
+    case globalDeclaration
+    case functionDeclaration
+    case procedureDeclaration
+    case classDeclaration
+    case returnStatement
+    case breakStatement
+    case continueStatement
+    case assignmentStatement
+    case expressionStatement
+    case block
+
+    // MARK: - Expressions
+
+    /// Function call expression – `name(args)`.
+    case callExpr
+
+    /// Method call expression – `receiver.name(args)`.
+    case methodCallExpr
+
+    /// If-then-else treated as an expression node in the CST.
+    case ifExpr
+
+    /// Pattern-matching / switch expression (reserved for future grammar).
+    case whenExpr
+
+    /// Try expression for error handling (reserved for future grammar).
+    case tryExpr
+
+    /// Binary operator expression – `lhs op rhs`.
+    case binaryExpr
+
+    /// Unary operator expression – `op operand`.
+    case unaryExpr
+
+    /// Literal value (integer, real, string, character, boolean, undefined).
+    case literalExpr
+
+    /// Identifier reference.
+    case identifierExpr
+
+    /// Array subscript – `expr[index]`.
+    case arrayAccessExpr
+
+    /// Field access – `expr.field`.
+    case fieldAccessExpr
+
+    /// Array literal – `[e1, e2, ...]` or `{e1, e2, ...}`.
+    case arrayLiteralExpr
+
+    /// Parenthesized expression – `(expr)`.
+    case parenExpr
+
+    // MARK: - Clauses & Fragments
+
+    case elseIfClause
+    case elseClause
+    case thenClause
+    case conditionClause
+    case parameterList
+    case parameter
+    case argumentList
+    case typeAnnotation
+    case forRangeClause
+    case forEachClause
+    case memberDeclaration
+    case constructorDeclaration
+    case methodDeclaration
+
+    // MARK: - Leaf
+
+    /// A leaf node that wraps a single token.
+    case token
+}
+
+extension SyntaxKind {
+    /// Whether this kind represents an expression node.
+    public var isExpression: Bool {
+        switch self {
+        case .callExpr, .methodCallExpr, .ifExpr, .whenExpr, .tryExpr,
+             .binaryExpr, .unaryExpr, .literalExpr, .identifierExpr,
+             .arrayAccessExpr, .fieldAccessExpr, .arrayLiteralExpr, .parenExpr:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Whether this kind represents a statement node.
+    public var isStatement: Bool {
+        switch self {
+        case .ifStatement, .whileStatement, .doWhileStatement, .forStatement,
+             .variableDeclaration, .constantDeclaration, .globalDeclaration,
+             .functionDeclaration, .procedureDeclaration, .classDeclaration,
+             .returnStatement, .breakStatement, .continueStatement,
+             .assignmentStatement, .expressionStatement, .block:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Whether this kind represents a top-level structural node.
+    public var isTopLevel: Bool {
+        switch self {
+        case .sourceFile, .importList, .declarationList:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/FeLangCore/CST/SyntaxNode.swift
+++ b/Sources/FeLangCore/CST/SyntaxNode.swift
@@ -1,0 +1,102 @@
+/// A node in the concrete syntax tree (CST).
+///
+/// Every node records the token range it covers so that source positions
+/// can be recovered without storing redundant copies of position data.
+/// Leaf nodes wrap a single token; internal nodes contain ordered children.
+public struct SyntaxNode: Equatable, Sendable {
+    public let kind: SyntaxKind
+    public let children: [SyntaxNode]
+    public let tokenIndex: Int?
+    public let startTokenIndex: Int
+    public let endTokenIndex: Int
+
+    /// Creates a leaf node that wraps a single token.
+    public init(token index: Int) {
+        self.kind = .token
+        self.children = []
+        self.tokenIndex = index
+        self.startTokenIndex = index
+        self.endTokenIndex = index + 1
+    }
+
+    /// Creates an internal node with the given kind and children.
+    public init(kind: SyntaxKind, children: [SyntaxNode]) {
+        self.kind = kind
+        self.children = children
+        self.tokenIndex = nil
+        if let first = children.first, let last = children.last {
+            self.startTokenIndex = first.startTokenIndex
+            self.endTokenIndex = last.endTokenIndex
+        } else {
+            self.startTokenIndex = 0
+            self.endTokenIndex = 0
+        }
+    }
+
+    /// Creates an internal node with explicit token range (useful for empty nodes).
+    public init(kind: SyntaxKind, children: [SyntaxNode], startTokenIndex: Int, endTokenIndex: Int) {
+        self.kind = kind
+        self.children = children
+        self.tokenIndex = nil
+        self.startTokenIndex = startTokenIndex
+        self.endTokenIndex = endTokenIndex
+    }
+}
+
+// MARK: - Child Access Helpers
+
+extension SyntaxNode {
+    /// Returns the first child matching the given kind, or `nil`.
+    public func firstChild(ofKind kind: SyntaxKind) -> SyntaxNode? {
+        children.first { $0.kind == kind }
+    }
+
+    /// Returns all children matching the given kind.
+    public func children(ofKind kind: SyntaxKind) -> [SyntaxNode] {
+        children.filter { $0.kind == kind }
+    }
+
+    /// Returns all direct children whose kind satisfies the predicate.
+    public func children(where predicate: (SyntaxKind) -> Bool) -> [SyntaxNode] {
+        children.filter { predicate($0.kind) }
+    }
+
+    /// Returns the token nodes among the direct children.
+    public var tokens: [SyntaxNode] {
+        children.filter { $0.kind == .token }
+    }
+
+    /// Whether this node is a leaf (wraps a single token).
+    public var isToken: Bool {
+        kind == .token
+    }
+
+    /// The number of tokens covered by this subtree.
+    public var tokenCount: Int {
+        endTokenIndex - startTokenIndex
+    }
+}
+
+// MARK: - Debug Description
+
+extension SyntaxNode: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        buildDescription(indent: 0)
+    }
+
+    private func buildDescription(indent: Int) -> String {
+        let prefix = String(repeating: "  ", count: indent)
+        if isToken {
+            return "\(prefix)token[\(startTokenIndex)]"
+        }
+        var result = "\(prefix)\(kind.rawValue)"
+        if !children.isEmpty {
+            result += " {\n"
+            for child in children {
+                result += child.buildDescription(indent: indent + 1) + "\n"
+            }
+            result += "\(prefix)}"
+        }
+        return result
+    }
+}

--- a/Sources/FeLangCore/Parser/Parser.swift
+++ b/Sources/FeLangCore/Parser/Parser.swift
@@ -147,6 +147,41 @@ extension Parser {
     }
 }
 
+// MARK: - CST API
+
+extension Parser {
+    /// Parses source code into a concrete syntax tree (CST).
+    ///
+    /// The CST preserves the full token structure including keywords and
+    /// delimiters, enabling lossless round-tripping and fine-grained tooling.
+    ///
+    /// - Parameter sourceCode: The source code string to parse
+    /// - Returns: A `SyntaxNode` rooted at `.sourceFile`
+    /// - Throws: `CSTParsingError` if parsing fails
+    public func parseCST(_ sourceCode: String) throws -> SyntaxNode {
+        let tokens = try tokenizer.tokenize(sourceCode)
+        let cstParser = CSTParser()
+        return try cstParser.parse(tokens)
+    }
+
+    /// Parses source code via the CST path and converts the result to AST.
+    ///
+    /// This method demonstrates the reduced re-parse dependency: tokens are
+    /// scanned once by `CSTParser`, then `ASTBuilder` walks the tree without
+    /// re-scanning.
+    ///
+    /// - Parameter sourceCode: The source code string to parse
+    /// - Returns: Array of `Statement` objects equivalent to `parse(_:)`
+    /// - Throws: `CSTParsingError` or `ASTBuildError`
+    public func parseViaCST(_ sourceCode: String) throws -> [Statement] {
+        let tokens = try tokenizer.tokenize(sourceCode)
+        let cstParser = CSTParser()
+        let cst = try cstParser.parse(tokens)
+        let builder = ASTBuilder(tokens: tokens)
+        return try builder.build(from: cst)
+    }
+}
+
 // MARK: - Convenience Methods
 
 extension Parser {

--- a/Tests/FeLangCoreTests/CST/ASTBuilderTests.swift
+++ b/Tests/FeLangCoreTests/CST/ASTBuilderTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import FeLangCore
+
+final class ASTBuilderTests: XCTestCase {
+
+    private let parser = Parser()
+
+    // MARK: - Round-Trip: CST → AST matches direct parse
+
+    func testVariableDeclarationRoundTrip() throws {
+        let source = "variable x: integer ← 42"
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testConstantDeclarationRoundTrip() throws {
+        let source = "constant PI: real ← 3.14"
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testSimpleAssignmentRoundTrip() throws {
+        let source = "x ← 42"
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testBinaryExpressionRoundTrip() throws {
+        let source = "x ← 1 + 2 * 3"
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testFunctionCallRoundTrip() throws {
+        let source = "print(42)"
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testIfStatementRoundTrip() throws {
+        let source = """
+        if x > 0 then
+            y ← 1
+        endif
+        """
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testIfElseRoundTrip() throws {
+        let source = """
+        if x > 0 then
+            y ← 1
+        else
+            y ← 0
+        endif
+        """
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testWhileStatementRoundTrip() throws {
+        let source = """
+        while x > 0 do
+            x ← x - 1
+        endwhile
+        """
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testForRangeRoundTrip() throws {
+        let source = """
+        for i ← 1 to 10 do
+            x ← x + i
+        endfor
+        """
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testForEachRoundTrip() throws {
+        let source = """
+        for item in items do
+            x ← item
+        endfor
+        """
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testFunctionDeclarationRoundTrip() throws {
+        let source = """
+        function add(a: integer, b: integer): integer
+            return a + b
+        endfunction
+        """
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testProcedureDeclarationRoundTrip() throws {
+        let source = """
+        procedure greet(name: string)
+            print(name)
+        endprocedure
+        """
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testReturnStatementRoundTrip() throws {
+        let source = """
+        function f(): integer
+            return 42
+        endfunction
+        """
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testUnaryExpressionRoundTrip() throws {
+        let source = "x ← -5"
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testArrayLiteralRoundTrip() throws {
+        let source = "x ← {1, 2, 3}"
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    func testBreakContinueRoundTrip() throws {
+        let source = """
+        while true do
+            break
+        endwhile
+        """
+        let direct = try parser.parse(source)
+        let viaCST = try parser.parseViaCST(source)
+        XCTAssertEqual(direct, viaCST)
+    }
+
+    // MARK: - ASTBuilder error handling
+
+    func testBuildFromNonSourceFileThrows() {
+        let node = SyntaxNode(kind: .block, children: [])
+        let builder = ASTBuilder(tokens: [])
+        XCTAssertThrowsError(try builder.build(from: node)) { error in
+            XCTAssertTrue(error is ASTBuildError)
+        }
+    }
+}

--- a/Tests/FeLangCoreTests/CST/CSTParserTests.swift
+++ b/Tests/FeLangCoreTests/CST/CSTParserTests.swift
@@ -1,0 +1,302 @@
+import XCTest
+@testable import FeLangCore
+
+final class CSTParserTests: XCTestCase {
+
+    private let tokenizer = ParsingTokenizer()
+    private let cstParser = CSTParser()
+
+    private func parseCST(_ source: String) throws -> SyntaxNode {
+        let tokens = try tokenizer.tokenize(source)
+        return try cstParser.parse(tokens)
+    }
+
+    // MARK: - Top-Level Structure
+
+    func testSourceFileStructure() throws {
+        let cst = try parseCST("variable x: integer ← 42")
+        XCTAssertEqual(cst.kind, .sourceFile)
+        XCTAssertEqual(cst.children.count, 2)
+        XCTAssertEqual(cst.children[0].kind, .importList)
+        XCTAssertEqual(cst.children[1].kind, .declarationList)
+    }
+
+    func testImportListContainsTopLevelDeclarations() throws {
+        let cst = try parseCST("variable x: integer ← 1\nvariable y: integer ← 2")
+        let importList = cst.firstChild(ofKind: .importList)!
+        XCTAssertEqual(importList.children.count, 2)
+        XCTAssertEqual(importList.children[0].kind, .variableDeclaration)
+        XCTAssertEqual(importList.children[1].kind, .variableDeclaration)
+    }
+
+    func testDeclarationListContainsFunctions() throws {
+        let source = """
+        function add(a: integer, b: integer): integer
+            return a + b
+        endfunction
+        """
+        let cst = try parseCST(source)
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        XCTAssertEqual(declList.children.count, 1)
+        XCTAssertEqual(declList.children[0].kind, .functionDeclaration)
+    }
+
+    // MARK: - Variable / Constant Declarations
+
+    func testVariableDeclaration() throws {
+        let cst = try parseCST("variable x: integer ← 10")
+        let importList = cst.firstChild(ofKind: .importList)!
+        let varDecl = importList.children[0]
+        XCTAssertEqual(varDecl.kind, .variableDeclaration)
+    }
+
+    func testConstantDeclaration() throws {
+        let cst = try parseCST("constant PI: real ← 3.14")
+        let importList = cst.firstChild(ofKind: .importList)!
+        let constDecl = importList.children[0]
+        XCTAssertEqual(constDecl.kind, .constantDeclaration)
+    }
+
+    // MARK: - Control Flow
+
+    func testIfStatement() throws {
+        let source = """
+        if x > 0 then
+            y ← 1
+        endif
+        """
+        let cst = try parseCST(source)
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let ifStmt = declList.children[0]
+        XCTAssertEqual(ifStmt.kind, .ifStatement)
+        XCTAssertNotNil(ifStmt.firstChild(ofKind: .conditionClause))
+        XCTAssertNotNil(ifStmt.firstChild(ofKind: .thenClause))
+    }
+
+    func testIfElseStatement() throws {
+        let source = """
+        if x > 0 then
+            y ← 1
+        else
+            y ← 0
+        endif
+        """
+        let cst = try parseCST(source)
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let ifStmt = declList.children[0]
+        XCTAssertEqual(ifStmt.kind, .ifStatement)
+        XCTAssertNotNil(ifStmt.firstChild(ofKind: .elseClause))
+    }
+
+    func testIfElseIfStatement() throws {
+        let source = """
+        if x > 0 then
+            y ← 1
+        elseif x < 0 then
+            y ← -1
+        else
+            y ← 0
+        endif
+        """
+        let cst = try parseCST(source)
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let ifStmt = declList.children[0]
+        XCTAssertFalse(ifStmt.children(ofKind: .elseIfClause).isEmpty)
+        XCTAssertNotNil(ifStmt.firstChild(ofKind: .elseClause))
+    }
+
+    func testWhileStatement() throws {
+        let source = """
+        while x > 0 do
+            x ← x - 1
+        endwhile
+        """
+        let cst = try parseCST(source)
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let whileStmt = declList.children[0]
+        XCTAssertEqual(whileStmt.kind, .whileStatement)
+        XCTAssertNotNil(whileStmt.firstChild(ofKind: .conditionClause))
+    }
+
+    func testForRangeStatement() throws {
+        let source = """
+        for i ← 1 to 10 do
+            x ← x + i
+        endfor
+        """
+        let cst = try parseCST(source)
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let forStmt = declList.children[0]
+        XCTAssertEqual(forStmt.kind, .forStatement)
+        XCTAssertNotNil(forStmt.firstChild(ofKind: .forRangeClause))
+    }
+
+    func testForRangeWithStep() throws {
+        let source = """
+        for i ← 0 to 100 step 2 do
+            x ← x + i
+        endfor
+        """
+        let cst = try parseCST(source)
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let forStmt = declList.children[0]
+        let rangeClause = forStmt.firstChild(ofKind: .forRangeClause)!
+        XCTAssertGreaterThan(rangeClause.children.count, 3)
+    }
+
+    func testForEachStatement() throws {
+        let source = """
+        for item in items do
+            x ← item
+        endfor
+        """
+        let cst = try parseCST(source)
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let forStmt = declList.children[0]
+        XCTAssertEqual(forStmt.kind, .forStatement)
+        XCTAssertNotNil(forStmt.firstChild(ofKind: .forEachClause))
+    }
+
+    // MARK: - Expressions
+
+    func testCallExpr() throws {
+        let cst = try parseCST("print(42)")
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let exprStmt = declList.children[0]
+        XCTAssertEqual(exprStmt.kind, .expressionStatement)
+        let callExpr = exprStmt.children[0]
+        XCTAssertEqual(callExpr.kind, .callExpr)
+        XCTAssertNotNil(callExpr.firstChild(ofKind: .argumentList))
+    }
+
+    func testBinaryExpr() throws {
+        let cst = try parseCST("x ← 1 + 2")
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let assign = declList.children[0]
+        XCTAssertEqual(assign.kind, .assignmentStatement)
+        let exprChildren = assign.children.filter { $0.kind.isExpression }
+        guard let binExpr = exprChildren.first else {
+            XCTFail("Expected binary expression")
+            return
+        }
+        XCTAssertEqual(binExpr.kind, .binaryExpr)
+    }
+
+    func testUnaryExpr() throws {
+        let cst = try parseCST("x ← -5")
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let assign = declList.children[0]
+        let exprChildren = assign.children.filter { $0.kind.isExpression }
+        guard let unaryExpr = exprChildren.first else {
+            XCTFail("Expected unary expression")
+            return
+        }
+        XCTAssertEqual(unaryExpr.kind, .unaryExpr)
+    }
+
+    func testLiteralExpr() throws {
+        let cst = try parseCST("x ← 42")
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let assign = declList.children[0]
+        let exprChildren = assign.children.filter { $0.kind.isExpression }
+        guard let litExpr = exprChildren.first else {
+            XCTFail("Expected literal expression")
+            return
+        }
+        XCTAssertEqual(litExpr.kind, .literalExpr)
+    }
+
+    func testArrayLiteralExpr() throws {
+        let cst = try parseCST("x ← {1, 2, 3}")
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let assign = declList.children[0]
+        let exprChildren = assign.children.filter { $0.kind.isExpression }
+        guard let arrExpr = exprChildren.first else {
+            XCTFail("Expected array literal expression")
+            return
+        }
+        XCTAssertEqual(arrExpr.kind, .arrayLiteralExpr)
+    }
+
+    // MARK: - Function / Procedure
+
+    func testFunctionDeclaration() throws {
+        let source = """
+        function add(a: integer, b: integer): integer
+            return a + b
+        endfunction
+        """
+        let cst = try parseCST(source)
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let funcDecl = declList.children[0]
+        XCTAssertEqual(funcDecl.kind, .functionDeclaration)
+        XCTAssertNotNil(funcDecl.firstChild(ofKind: .parameterList))
+        XCTAssertNotNil(funcDecl.firstChild(ofKind: .typeAnnotation))
+        XCTAssertNotNil(funcDecl.firstChild(ofKind: .block))
+    }
+
+    func testProcedureDeclaration() throws {
+        let source = """
+        procedure greet(name: string)
+            print(name)
+        endprocedure
+        """
+        let cst = try parseCST(source)
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        let procDecl = declList.children[0]
+        XCTAssertEqual(procDecl.kind, .procedureDeclaration)
+        XCTAssertNotNil(procDecl.firstChild(ofKind: .parameterList))
+    }
+
+    // MARK: - Assignment
+
+    func testSimpleAssignment() throws {
+        let cst = try parseCST("x ← 42")
+        let declList = cst.firstChild(ofKind: .declarationList)!
+        XCTAssertEqual(declList.children[0].kind, .assignmentStatement)
+    }
+
+    // MARK: - Return / Break / Continue
+
+    func testReturnStatement() throws {
+        let source = """
+        function f(): integer
+            return 42
+        endfunction
+        """
+        let cst = try parseCST(source)
+        let funcDecl = cst.firstChild(ofKind: .declarationList)!.children[0]
+        let body = funcDecl.firstChild(ofKind: .block)!
+        let retStmt = body.children[0]
+        XCTAssertEqual(retStmt.kind, .returnStatement)
+    }
+
+    func testBreakStatement() throws {
+        let source = """
+        while true do
+            break
+        endwhile
+        """
+        let cst = try parseCST(source)
+        let whileStmt = cst.firstChild(ofKind: .declarationList)!.children[0]
+        let body = whileStmt.children(ofKind: .block)
+        let block = body.first!
+        let breakStmt = block.children[0]
+        XCTAssertEqual(breakStmt.kind, .breakStatement)
+    }
+
+    // MARK: - Error Handling
+
+    func testNestingTooDeep() {
+        var source = ""
+        for _ in 0..<105 {
+            source += "if true then\n"
+        }
+        for _ in 0..<105 {
+            source += "endif\n"
+        }
+        XCTAssertThrowsError(try parseCST(source)) { error in
+            XCTAssertTrue(error is CSTParsingError)
+        }
+    }
+}

--- a/Tests/FeLangCoreTests/CST/SyntaxKindTests.swift
+++ b/Tests/FeLangCoreTests/CST/SyntaxKindTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import FeLangCore
+
+final class SyntaxKindTests: XCTestCase {
+
+    func testIsExpression() {
+        let expressionKinds: [SyntaxKind] = [
+            .callExpr, .methodCallExpr, .ifExpr, .whenExpr, .tryExpr,
+            .binaryExpr, .unaryExpr, .literalExpr, .identifierExpr,
+            .arrayAccessExpr, .fieldAccessExpr, .arrayLiteralExpr, .parenExpr
+        ]
+        for kind in expressionKinds {
+            XCTAssertTrue(kind.isExpression, "\(kind) should be expression")
+        }
+        XCTAssertFalse(SyntaxKind.ifStatement.isExpression)
+        XCTAssertFalse(SyntaxKind.sourceFile.isExpression)
+        XCTAssertFalse(SyntaxKind.token.isExpression)
+    }
+
+    func testIsStatement() {
+        let statementKinds: [SyntaxKind] = [
+            .ifStatement, .whileStatement, .doWhileStatement, .forStatement,
+            .variableDeclaration, .constantDeclaration, .globalDeclaration,
+            .functionDeclaration, .procedureDeclaration, .classDeclaration,
+            .returnStatement, .breakStatement, .continueStatement,
+            .assignmentStatement, .expressionStatement, .block
+        ]
+        for kind in statementKinds {
+            XCTAssertTrue(kind.isStatement, "\(kind) should be statement")
+        }
+        XCTAssertFalse(SyntaxKind.callExpr.isStatement)
+        XCTAssertFalse(SyntaxKind.sourceFile.isStatement)
+    }
+
+    func testIsTopLevel() {
+        XCTAssertTrue(SyntaxKind.sourceFile.isTopLevel)
+        XCTAssertTrue(SyntaxKind.importList.isTopLevel)
+        XCTAssertTrue(SyntaxKind.declarationList.isTopLevel)
+        XCTAssertFalse(SyntaxKind.ifStatement.isTopLevel)
+        XCTAssertFalse(SyntaxKind.callExpr.isTopLevel)
+    }
+
+    func testCaseIterable() {
+        XCTAssertGreaterThan(SyntaxKind.allCases.count, 0)
+        XCTAssertTrue(SyntaxKind.allCases.contains(.sourceFile))
+        XCTAssertTrue(SyntaxKind.allCases.contains(.token))
+    }
+}

--- a/Tests/FeLangCoreTests/CST/SyntaxNodeTests.swift
+++ b/Tests/FeLangCoreTests/CST/SyntaxNodeTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import FeLangCore
+
+final class SyntaxNodeTests: XCTestCase {
+
+    func testLeafNode() {
+        let node = SyntaxNode(token: 5)
+        XCTAssertEqual(node.kind, .token)
+        XCTAssertEqual(node.tokenIndex, 5)
+        XCTAssertEqual(node.startTokenIndex, 5)
+        XCTAssertEqual(node.endTokenIndex, 6)
+        XCTAssertTrue(node.isToken)
+        XCTAssertTrue(node.children.isEmpty)
+        XCTAssertEqual(node.tokenCount, 1)
+    }
+
+    func testInternalNode() {
+        let child1 = SyntaxNode(token: 0)
+        let child2 = SyntaxNode(token: 1)
+        let child3 = SyntaxNode(token: 2)
+        let node = SyntaxNode(kind: .binaryExpr, children: [child1, child2, child3])
+
+        XCTAssertEqual(node.kind, .binaryExpr)
+        XCTAssertNil(node.tokenIndex)
+        XCTAssertEqual(node.startTokenIndex, 0)
+        XCTAssertEqual(node.endTokenIndex, 3)
+        XCTAssertFalse(node.isToken)
+        XCTAssertEqual(node.children.count, 3)
+        XCTAssertEqual(node.tokenCount, 3)
+    }
+
+    func testEmptyInternalNode() {
+        let node = SyntaxNode(kind: .block, children: [])
+        XCTAssertEqual(node.startTokenIndex, 0)
+        XCTAssertEqual(node.endTokenIndex, 0)
+        XCTAssertEqual(node.tokenCount, 0)
+    }
+
+    func testExplicitTokenRange() {
+        let node = SyntaxNode(kind: .importList, children: [], startTokenIndex: 3, endTokenIndex: 3)
+        XCTAssertEqual(node.startTokenIndex, 3)
+        XCTAssertEqual(node.endTokenIndex, 3)
+    }
+
+    func testFirstChildOfKind() {
+        let lit = SyntaxNode(kind: .literalExpr, children: [SyntaxNode(token: 0)])
+        let ident = SyntaxNode(kind: .identifierExpr, children: [SyntaxNode(token: 1)])
+        let parent = SyntaxNode(kind: .block, children: [lit, ident])
+
+        XCTAssertEqual(parent.firstChild(ofKind: .literalExpr), lit)
+        XCTAssertEqual(parent.firstChild(ofKind: .identifierExpr), ident)
+        XCTAssertNil(parent.firstChild(ofKind: .callExpr))
+    }
+
+    func testChildrenOfKind() {
+        let lit1 = SyntaxNode(kind: .literalExpr, children: [SyntaxNode(token: 0)])
+        let ident = SyntaxNode(kind: .identifierExpr, children: [SyntaxNode(token: 1)])
+        let lit2 = SyntaxNode(kind: .literalExpr, children: [SyntaxNode(token: 2)])
+        let parent = SyntaxNode(kind: .block, children: [lit1, ident, lit2])
+
+        XCTAssertEqual(parent.children(ofKind: .literalExpr).count, 2)
+        XCTAssertEqual(parent.children(ofKind: .identifierExpr).count, 1)
+    }
+
+    func testTokensProperty() {
+        let tok1 = SyntaxNode(token: 0)
+        let expr = SyntaxNode(kind: .literalExpr, children: [SyntaxNode(token: 1)])
+        let tok2 = SyntaxNode(token: 2)
+        let parent = SyntaxNode(kind: .block, children: [tok1, expr, tok2])
+
+        XCTAssertEqual(parent.tokens.count, 2)
+    }
+
+    func testDebugDescription() {
+        let node = SyntaxNode(kind: .literalExpr, children: [SyntaxNode(token: 0)])
+        let desc = node.debugDescription
+        XCTAssertTrue(desc.contains("literalExpr"))
+        XCTAssertTrue(desc.contains("token[0]"))
+    }
+}


### PR DESCRIPTION
# Add CST layer with SyntaxKind, CSTParser, and ASTBuilder (P5-24)

## Summary

Introduces a concrete syntax tree (CST) layer between tokenization and AST construction. This adds:

- **`SyntaxKind`** enum (~50 cases) classifying all CST node types: top-level structure (`sourceFile`, `importList`, `declarationList`), statements, expressions (`callExpr`, `methodCallExpr`, `binaryExpr`, `ifExpr`, `whenExpr`, `tryExpr`, etc.), clauses, and leaf tokens.
- **`SyntaxNode`** struct representing CST nodes with children and token-index ranges.
- **`CSTParser`** (~880 LOC) – a recursive-descent parser that builds `SyntaxNode` trees directly from the token stream, producing `importList` for top-level declarations and `declarationList` for functions/procedures/classes.
- **`ASTBuilder`** (~600 LOC) – walks the CST and produces the existing `Statement`/`Expression` AST without re-scanning tokens, reducing the "statement re-parse" dependency.
- **`Parser.parseCST(_:)`** and **`Parser.parseViaCST(_:)`** public API on the existing `Parser` facade.
- **4 test files** with ~55 test methods covering SyntaxKind classification, SyntaxNode construction, CSTParser output structure, and ASTBuilder round-trip equivalence.

All 1277 existing tests continue to pass. The original `parse(_:)` path is unchanged; CST is opt-in via the new methods.

## Review & Testing Checklist for Human

- [ ] **CSTParser ↔ StatementParser parity**: The CSTParser is a parallel reimplementation of the statement/expression parsing logic. Verify behavior matches for edge cases not covered by tests: do-while loops, class declarations with constructors, nested array assignments, field-access assignments, multi-dimensional arrays, and mixed Japanese/English keywords.
- [ ] **`importList` vs `declarationList` split logic** (CSTParser.swift lines 56–72): Top-level variable/constant/global declarations go into `importList` only when no function/class has appeared yet. Confirm this matches the intended spec.md J5.1 semantics.
- [ ] **ASTBuilder child-matching heuristics** (e.g. `node.children.filter { $0.isToken && tokenAt($0)?.type == .identifier }`): These rely on positional/type filtering of children. Check that `buildForStatement`, `buildAssignment`, and `buildClassDeclaration` handle ambiguous cases correctly.
- [ ] **Reserved but unused SyntaxKinds**: `whenExpr`, `tryExpr`, and `ifExpr` are defined but never generated by `CSTParser`. Confirm this is acceptable as forward-declared placeholders.
- [ ] **Run a round-trip test with a complex real-world FE program** (multiple functions, classes, Japanese keywords, nested control flow) through `parseViaCST` and compare output to `parse` to gain confidence in equivalence.

### Notes
- `spec.md J5.1` was not found in the repository; the implementation was inferred from the task checklist items.
- SwiftLint warnings remain: cyclomatic complexity 17 in `ASTBuilder.buildExpression`, force unwrapping in `CSTParser.swift:354`, and several test force unwraps. These are non-blocking but worth addressing in a follow-up.
- The CST path is opt-in; existing code paths are unaffected.

---

**Link to Devin run**: https://app.devin.ai/sessions/5bb8610d490b409d985296db6e695852  
**Requested by**: @fumiya-kume
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a parallel parsing implementation and a new CST→AST conversion path; while opt-in, correctness relies on parity with existing parsing semantics and could diverge on untested edge cases.
> 
> **Overview**
> Introduces a new **concrete syntax tree (CST) layer** (`SyntaxKind`, `SyntaxNode`) plus a full `CSTParser` that builds a token-indexed syntax tree for top-level structure, statements, and expressions, including safeguards for *input size* and *nesting depth*.
> 
> Adds an `ASTBuilder` that walks the CST to produce the existing `Statement`/`Expression` AST (including control-flow, declarations, calls, array/field access, and assignments) and exposes this via new `Parser.parseCST(_:)` and `Parser.parseViaCST(_:)` APIs without changing the existing `Parser.parse(_:)` path.
> 
> Adds CST-focused unit tests and round-trip tests asserting `parseViaCST` matches the direct AST parse, plus basic CST structure/classification and error-handling coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5044b22b639d35a5e6c8c393299fd36b5e884032. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 新しい構文解析パイプラインを追加。トークンから直接構文木を構築し、より効率的な言語処理が可能に。
  * 制御フロー、宣言、式など複雑な言語構文の解析に対応。
  * 詳細なエラー報告により、構文エラーの診断が向上。

* **Tests**
  * 構文解析と変換プロセスの包括的なテストスイートを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->