### PR TITLE
feat(abi): P5-26 ABILowering boxing/unboxing at nullable/Any boundaries

### DIFF
--- a/Sources/FeLangCore/ABI/ABILowering.swift
+++ b/Sources/FeLangCore/ABI/ABILowering.swift
@@ -56,10 +56,10 @@ public struct ABILowering: Sendable {
 
     public static func needsBoxing(source: FeType, target: FeType) -> Bool {
         switch (source, target) {
+        case (_, .any):
+            return source != .any
         case (.nullable, _), (_, .nullable):
             return !source.isNullable && target.isNullable
-        case (_, .any):
-            return true
         default:
             return false
         }

--- a/Sources/FeLangCore/ABI/ABILowering.swift
+++ b/Sources/FeLangCore/ABI/ABILowering.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+public enum TypeTag: Int, Equatable, Sendable {
+    case integer = 0
+    case real = 1
+    case string = 2
+    case character = 3
+    case boolean = 4
+    case array = 5
+    case record = 6
+    case function = 7
+    case null = 8
+}
+
+public enum BoxingKind: Equatable, Sendable {
+    case box(sourceType: FeType)
+    case unbox(targetType: FeType)
+}
+
+public struct BoxingBoundary: Equatable, Sendable {
+    public let kind: BoxingKind
+    public let position: SourcePosition
+
+    public init(kind: BoxingKind, position: SourcePosition) {
+        self.kind = kind
+        self.position = position
+    }
+}
+
+public struct ABILoweringResult: Equatable, Sendable {
+    public let boundaries: [BoxingBoundary]
+    public let diagnostics: [String]
+
+    public init(boundaries: [BoxingBoundary], diagnostics: [String]) {
+        self.boundaries = boundaries
+        self.diagnostics = diagnostics
+    }
+
+    public var requiresBoxing: Bool {
+        return !boundaries.isEmpty
+    }
+}
+
+public struct ABILowering: Sendable {
+
+    public init() {}
+
+    public func analyze(_ statements: [Statement]) -> ABILoweringResult {
+        var boundaries: [BoxingBoundary] = []
+        var diagnostics: [String] = []
+        for statement in statements {
+            analyzeStatement(statement, boundaries: &boundaries, diagnostics: &diagnostics)
+        }
+        return ABILoweringResult(boundaries: boundaries, diagnostics: diagnostics)
+    }
+
+    public static func needsBoxing(source: FeType, target: FeType) -> Bool {
+        switch (source, target) {
+        case (.nullable, _), (_, .nullable):
+            return !source.isNullable && target.isNullable
+        case (_, .any):
+            return true
+        default:
+            return false
+        }
+    }
+
+    public static func needsUnboxing(source: FeType, target: FeType) -> Bool {
+        switch (source, target) {
+        case (.any, _) where !target.isNullable && target != .any && target != .unknown && target != .error:
+            return true
+        case (.nullable, _) where !target.isNullable && target != .unknown && target != .error:
+            return true
+        default:
+            return false
+        }
+    }
+
+    public static func typeTag(for type: FeType) -> TypeTag {
+        switch type {
+        case .integer:
+            return .integer
+        case .real:
+            return .real
+        case .string:
+            return .string
+        case .character:
+            return .character
+        case .boolean:
+            return .boolean
+        case .array:
+            return .array
+        case .record:
+            return .record
+        case .function:
+            return .function
+        case .nullable(let inner):
+            return typeTag(for: inner)
+        default:
+            return .null
+        }
+    }
+
+    private func analyzeStatement(
+        _ statement: Statement,
+        boundaries: inout [BoxingBoundary],
+        diagnostics: inout [String]
+    ) {
+        switch statement {
+        case .variableDeclaration(let decl):
+            analyzeVariableDeclaration(decl, boundaries: &boundaries, diagnostics: &diagnostics)
+        case .functionDeclaration(let decl):
+            analyzeFunctionDeclaration(decl, boundaries: &boundaries, diagnostics: &diagnostics)
+        case .procedureDeclaration(let decl):
+            analyzeProcedureDeclaration(decl, boundaries: &boundaries, diagnostics: &diagnostics)
+        case .ifStatement(let ifStmt):
+            for bodyStmt in ifStmt.thenBody { analyzeStatement(bodyStmt, boundaries: &boundaries, diagnostics: &diagnostics) }
+            for elseIf in ifStmt.elseIfs {
+                for bodyStmt in elseIf.body { analyzeStatement(bodyStmt, boundaries: &boundaries, diagnostics: &diagnostics) }
+            }
+            if let elseBody = ifStmt.elseBody {
+                for bodyStmt in elseBody { analyzeStatement(bodyStmt, boundaries: &boundaries, diagnostics: &diagnostics) }
+            }
+        case .whileStatement(let whileStmt):
+            for bodyStmt in whileStmt.body { analyzeStatement(bodyStmt, boundaries: &boundaries, diagnostics: &diagnostics) }
+        case .doWhileStatement(let doWhileStmt):
+            for bodyStmt in doWhileStmt.body { analyzeStatement(bodyStmt, boundaries: &boundaries, diagnostics: &diagnostics) }
+        case .forStatement(let forStmt):
+            switch forStmt {
+            case .range(let rangeFor):
+                for bodyStmt in rangeFor.body { analyzeStatement(bodyStmt, boundaries: &boundaries, diagnostics: &diagnostics) }
+            case .forEach(let forEach):
+                for bodyStmt in forEach.body { analyzeStatement(bodyStmt, boundaries: &boundaries, diagnostics: &diagnostics) }
+            }
+        case .block(let stmts):
+            for bodyStmt in stmts { analyzeStatement(bodyStmt, boundaries: &boundaries, diagnostics: &diagnostics) }
+        case .globalDeclaration(let decl):
+            analyzeGlobalDeclaration(decl, boundaries: &boundaries, diagnostics: &diagnostics)
+        default:
+            break
+        }
+    }
+
+    private func analyzeVariableDeclaration(
+        _ decl: VariableDeclaration,
+        boundaries: inout [BoxingBoundary],
+        diagnostics: inout [String]
+    ) {
+        let declType = decl.type
+        let position = decl.position ?? SourcePosition(line: 0, column: 0, offset: 0)
+        checkDeclarationType(declType, position: position, boundaries: &boundaries, diagnostics: &diagnostics)
+    }
+
+    private func analyzeGlobalDeclaration(
+        _ decl: GlobalDeclaration,
+        boundaries: inout [BoxingBoundary],
+        diagnostics: inout [String]
+    ) {
+        let declType = decl.type
+        let position = decl.position ?? SourcePosition(line: 0, column: 0, offset: 0)
+        checkDeclarationType(declType, position: position, boundaries: &boundaries, diagnostics: &diagnostics)
+    }
+
+    private func analyzeFunctionDeclaration(
+        _ decl: FunctionDeclaration,
+        boundaries: inout [BoxingBoundary],
+        diagnostics: inout [String]
+    ) {
+        let position = decl.position ?? SourcePosition(line: 0, column: 0, offset: 0)
+        for param in decl.parameters {
+            checkDeclarationType(param.type, position: position, boundaries: &boundaries, diagnostics: &diagnostics)
+        }
+        if let returnType = decl.returnType {
+            checkDeclarationType(returnType, position: position, boundaries: &boundaries, diagnostics: &diagnostics)
+        }
+        for stmt in decl.body {
+            analyzeStatement(stmt, boundaries: &boundaries, diagnostics: &diagnostics)
+        }
+    }
+
+    private func analyzeProcedureDeclaration(
+        _ decl: ProcedureDeclaration,
+        boundaries: inout [BoxingBoundary],
+        diagnostics: inout [String]
+    ) {
+        let position = decl.position ?? SourcePosition(line: 0, column: 0, offset: 0)
+        for param in decl.parameters {
+            checkDeclarationType(param.type, position: position, boundaries: &boundaries, diagnostics: &diagnostics)
+        }
+        for stmt in decl.body {
+            analyzeStatement(stmt, boundaries: &boundaries, diagnostics: &diagnostics)
+        }
+    }
+
+    private func checkDeclarationType(
+        _ dataType: DataType,
+        position: SourcePosition,
+        boundaries: inout [BoxingBoundary],
+        diagnostics: inout [String]
+    ) {
+        switch dataType {
+        case .nullable(let inner):
+            let innerFeType = dataTypeToFeType(inner)
+            boundaries.append(BoxingBoundary(
+                kind: .box(sourceType: innerFeType),
+                position: position
+            ))
+            diagnostics.append("boxing boundary: \(inner) -> \(dataType)")
+        case .any:
+            boundaries.append(BoxingBoundary(
+                kind: .box(sourceType: .any),
+                position: position
+            ))
+            diagnostics.append("boxing boundary: Any at \(position)")
+        default:
+            break
+        }
+    }
+
+    private func dataTypeToFeType(_ dataType: DataType) -> FeType {
+        switch dataType {
+        case .integer: return .integer
+        case .real: return .real
+        case .character: return .character
+        case .string: return .string
+        case .boolean: return .boolean
+        case .array(let elementType): return .array(elementType: dataTypeToFeType(elementType), dimensions: [])
+        case .record(let name): return .record(name: name, fields: [:])
+        case .nullable(let inner): return .nullable(dataTypeToFeType(inner))
+        case .any: return .any
+        }
+    }
+}
+
+public struct BoxingOperations: Sendable {
+
+    public init() {}
+
+    public static func boxDescription(value: String, sourceType: FeType) -> String {
+        let tag = ABILowering.typeTag(for: sourceType)
+        return "box(\(value), tag=\(tag))"
+    }
+
+    public static func unboxDescription(value: String, targetType: FeType) -> String {
+        let tag = ABILowering.typeTag(for: targetType)
+        return "unbox(\(value), expected_tag=\(tag))"
+    }
+}

--- a/Sources/FeLangCore/Parser/Statement.swift
+++ b/Sources/FeLangCore/Parser/Statement.swift
@@ -217,6 +217,8 @@ public indirect enum DataType: Equatable, Codable, Sendable {
     case boolean
     case array(DataType)
     case record(String) // record type name
+    case nullable(DataType)
+    case any
 
     public init?(tokenType: TokenType) {
         switch tokenType {

--- a/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
+++ b/Sources/FeLangCore/PrettyPrinter/PrettyPrinter.swift
@@ -500,6 +500,10 @@ public struct PrettyPrinter {
             return "配列[\(printDataType(elementType))]"
         case .record(let name):
             return "レコード \(name)"
+        case .nullable(let inner):
+            return "\(printDataType(inner))?"
+        case .any:
+            return "Any"
         }
     }
 

--- a/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
+++ b/Sources/FeLangCore/Semantic/SemanticAnalyzer.swift
@@ -1398,6 +1398,10 @@ public final class SemanticAnalyzer: @unchecked Sendable {
             return .array(elementType: feElementType, dimensions: [])
         case .record(let name):
             return .record(name: name, fields: [:])
+        case .nullable(let inner):
+            return .nullable(convertDataTypeToFeType(inner))
+        case .any:
+            return .any
         }
     }
 

--- a/Sources/FeLangCore/Semantic/SemanticError.swift
+++ b/Sources/FeLangCore/Semantic/SemanticError.swift
@@ -56,6 +56,8 @@ public indirect enum FeType: Equatable, Sendable, CustomStringConvertible {
     case array(elementType: FeType, dimensions: [Int])
     case record(name: String, fields: [String: FeType])
     case function(parameters: [FeType], returnType: FeType?)
+    case nullable(FeType)
+    case any
     case void
     case unknown
     case error // Used for error recovery
@@ -84,6 +86,10 @@ public indirect enum FeType: Equatable, Sendable, CustomStringConvertible {
             } else {
                 return "procedure(\(paramStr))"
             }
+        case .nullable(let inner):
+            return "\(inner)?"
+        case .any:
+            return "Any"
         case .void:
             return "void"
         case .unknown:
@@ -97,16 +103,24 @@ public indirect enum FeType: Equatable, Sendable, CustomStringConvertible {
     public func isCompatible(with other: FeType) -> Bool {
         switch (self, other) {
         case (.error, _), (_, .error):
-            return true // Error type is compatible with everything for recovery
+            return true
         case (.unknown, _), (_, .unknown):
-            return true // Unknown type is compatible during inference
+            return true
+        case (.any, _), (_, .any):
+            return true
         case (.integer, .integer), (.real, .real), (.string, .string),
              (.character, .character), (.boolean, .boolean), (.void, .void):
             return true
         case (.integer, .real), (.real, .integer):
-            return true // Numeric types are compatible
+            return true
         case (.character, .string):
-            return true // Character can be assigned to string
+            return true
+        case (.nullable(let inner1), .nullable(let inner2)):
+            return inner1.isCompatible(with: inner2)
+        case (_, .nullable(let inner)):
+            return self.isCompatible(with: inner)
+        case (.nullable(let inner), _):
+            return inner.isCompatible(with: other)
         case (.array(let elementType1, let dimensions1), .array(let elementType2, let dimensions2)):
             return elementType1.isCompatible(with: elementType2) && dimensions1 == dimensions2
         case (.record(let name1, let fields1), .record(let name2, let fields2)):
@@ -124,18 +138,45 @@ public indirect enum FeType: Equatable, Sendable, CustomStringConvertible {
     public func canAssignTo(_ target: FeType) -> Bool {
         switch (self, target) {
         case (.error, _), (_, .error):
-            return true // Error type for recovery
+            return true
         case (.unknown, _), (_, .unknown):
-            return true // Unknown type during inference
+            return true
+        case (_, .any):
+            return true
+        case (.any, .nullable):
+            return true
+        case (_, .nullable(let inner)):
+            return self.canAssignTo(inner)
+        case (.nullable(let inner), _):
+            return inner.canAssignTo(target)
         case (.integer, .real):
-            return true // Implicit integer to real conversion
+            return true
         case (.character, .string):
-            return true // Implicit character to string conversion
+            return true
         case (.array(let srcElement, let srcDims), .array(let targetElement, let targetDims)):
-            // Arrays must have compatible element types and same dimensions
             return srcElement.canAssignTo(targetElement) && srcDims == targetDims
         default:
             return self.isCompatible(with: target)
+        }
+    }
+
+    public var isNullable: Bool {
+        switch self {
+        case .nullable:
+            return true
+        case .any:
+            return true
+        default:
+            return false
+        }
+    }
+
+    public var unwrappedType: FeType {
+        switch self {
+        case .nullable(let inner):
+            return inner
+        default:
+            return self
         }
     }
 

--- a/Sources/FeLangRuntime/RuntimeValue.swift
+++ b/Sources/FeLangRuntime/RuntimeValue.swift
@@ -39,6 +39,9 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
     /// Represents nil/null/void
     case null
 
+    /// A boxed value with type tag for ABI boundary crossing
+    indirect case boxed(typeTag: Int, value: RuntimeValue)
+
     /// Represents an undefined value (未定義)
     case undefined
 
@@ -58,6 +61,7 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
         case .procedure: return "Procedure"
         case .classDefinition(let classDef): return "Class<\(classDef.name)>"
         case .instance(let inst): return inst.className
+        case .boxed(_, let inner): return "Boxed<\(inner.typeName)>"
         case .null: return "Null"
         case .undefined: return "Undefined"
         }
@@ -70,6 +74,8 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
             return value
         case .integer(let value):
             return value != 0
+        case .boxed(_, let inner):
+            return inner.isTruthy
         case .null, .undefined:
             return false
         default:
@@ -90,6 +96,8 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
             return Int(value)
         case .boolean(let value):
             return value ? 1 : 0
+        case .boxed(_, let inner):
+            return inner.toInteger()
         default:
             return nil
         }
@@ -104,6 +112,8 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
             return value
         case .string(let value):
             return Double(value)
+        case .boxed(_, let inner):
+            return inner.toReal()
         default:
             return nil
         }
@@ -137,6 +147,8 @@ public enum RuntimeValue: Equatable, Sendable, CustomStringConvertible {
         case .instance(let inst):
             let fieldStrings = inst.fields.map { "\($0.key): \($0.value.toString())" }
             return "\(inst.className){\(fieldStrings.joined(separator: ", "))}"
+        case .boxed(let tag, let inner):
+            return "boxed(tag=\(tag), \(inner.toString()))"
         case .null:
             return "null"
         case .undefined:

--- a/Sources/FeLangRuntime/StandardLibrary.swift
+++ b/Sources/FeLangRuntime/StandardLibrary.swift
@@ -56,7 +56,10 @@ public struct StandardLibrary: Sendable {
             "arrayLength": stdArrayLength,
             "append": stdAppend,
             "prepend": stdPrepend,
-            "concat_arrays": stdConcatArrays
+            "concat_arrays": stdConcatArrays,
+
+            // Boxing/ABI Functions
+            "kk_println_any": stdKkPrintlnAny
         ]
     }
 
@@ -429,5 +432,29 @@ public struct StandardLibrary: Sendable {
             result.append(contentsOf: arr)
         }
         return .array(result)
+    }
+
+    // MARK: - Boxing/ABI Functions
+
+    private func stdKkPrintlnAny(_ args: [RuntimeValue]) throws -> RuntimeValue {
+        guard let value = args.first else {
+            throw RuntimeError.wrongArgumentCount(function: "kk_println_any", expected: 1, actual: 0)
+        }
+        let output = formatAnyValue(value)
+        printHandler(output + "\n")
+        return .null
+    }
+
+    private func formatAnyValue(_ value: RuntimeValue) -> String {
+        switch value {
+        case .boxed(let tag, let inner):
+            return "Any(tag=\(tag), \(formatAnyValue(inner)))"
+        case .null:
+            return "null"
+        case .undefined:
+            return "未定義"
+        default:
+            return value.toString()
+        }
     }
 }

--- a/Sources/FeLangRuntime/StatementExecutor.swift
+++ b/Sources/FeLangRuntime/StatementExecutor.swift
@@ -1079,6 +1079,10 @@ public final class StatementExecutor: @unchecked Sendable {
             return .array([])
         case .record:
             return .record([:])
+        case .nullable:
+            return .null
+        case .any:
+            return .null
         }
     }
 
@@ -1098,7 +1102,7 @@ public final class StatementExecutor: @unchecked Sendable {
         case .record:
             // Record type name cannot be inferred from runtime value
             return nil
-        case .function, .procedure, .null, .classDefinition, .instance, .undefined:
+        case .function, .procedure, .null, .classDefinition, .instance, .undefined, .boxed:
             return nil
         }
     }
@@ -1107,14 +1111,19 @@ public final class StatementExecutor: @unchecked Sendable {
         let matches: Bool
         switch (expected, value) {
         case (_, .undefined):
-            // Undefined is compatible with any type (matches semantic analyzer behavior)
             matches = true
+        case (.nullable, .null):
+            matches = true
+        case (.any, _):
+            matches = true
+        case (.nullable(let inner), _):
+            try validateType(value, expected: inner, context: context)
+            return
         case (.integer, .integer):
             matches = true
         case (.real, .real):
             matches = true
         case (.real, .integer):
-            // Integer can be promoted to real
             matches = true
         case (.string, .string):
             matches = true
@@ -1180,12 +1189,17 @@ public final class StatementExecutor: @unchecked Sendable {
     /// This method handles recursive array type checking.
     private func typesMatch(_ actual: DataType, expected: DataType) -> Bool {
         switch (expected, actual) {
+        case (.any, _):
+            return true
+        case (.nullable(let inner), _):
+            return typesMatch(actual, expected: inner)
+        case (_, .nullable(let inner)):
+            return typesMatch(inner, expected: expected)
         case (.integer, .integer):
             return true
         case (.real, .real):
             return true
         case (.real, .integer):
-            // Integer can be promoted to real
             return true
         case (.string, .string):
             return true
@@ -1194,7 +1208,6 @@ public final class StatementExecutor: @unchecked Sendable {
         case (.boolean, .boolean):
             return true
         case (.array(let expectedElem), .array(let actualElem)):
-            // Recursively check element types
             return typesMatch(actualElem, expected: expectedElem)
         case (.record(let expectedName), .record(let actualName)):
             return expectedName == actualName

--- a/Tests/FeLangCoreTests/ABI/ABILoweringTests.swift
+++ b/Tests/FeLangCoreTests/ABI/ABILoweringTests.swift
@@ -42,6 +42,15 @@ final class ABILoweringTests: XCTestCase {
         XCTAssertTrue(ABILowering.needsBoxing(source: .string, target: .nullable(.string)))
     }
 
+    func testNeedsBoxingNullableToAny() {
+        XCTAssertTrue(ABILowering.needsBoxing(source: .nullable(.integer), target: .any))
+        XCTAssertTrue(ABILowering.needsBoxing(source: .nullable(.string), target: .any))
+    }
+
+    func testNoBoxingAnyToAny() {
+        XCTAssertFalse(ABILowering.needsBoxing(source: .any, target: .any))
+    }
+
     func testNoBoxingSameType() {
         XCTAssertFalse(ABILowering.needsBoxing(source: .integer, target: .integer))
         XCTAssertFalse(ABILowering.needsBoxing(source: .string, target: .string))

--- a/Tests/FeLangCoreTests/ABI/ABILoweringTests.swift
+++ b/Tests/FeLangCoreTests/ABI/ABILoweringTests.swift
@@ -1,0 +1,248 @@
+import XCTest
+@testable import FeLangCore
+
+final class ABILoweringTests: XCTestCase {
+
+    // MARK: - TypeTag Tests
+
+    func testTypeTagForPrimitives() {
+        XCTAssertEqual(ABILowering.typeTag(for: .integer), .integer)
+        XCTAssertEqual(ABILowering.typeTag(for: .real), .real)
+        XCTAssertEqual(ABILowering.typeTag(for: .string), .string)
+        XCTAssertEqual(ABILowering.typeTag(for: .character), .character)
+        XCTAssertEqual(ABILowering.typeTag(for: .boolean), .boolean)
+    }
+
+    func testTypeTagForCompoundTypes() {
+        XCTAssertEqual(ABILowering.typeTag(for: .array(elementType: .integer, dimensions: [])), .array)
+        XCTAssertEqual(ABILowering.typeTag(for: .record(name: "Point", fields: [:])), .record)
+    }
+
+    func testTypeTagForNullable() {
+        XCTAssertEqual(ABILowering.typeTag(for: .nullable(.integer)), .integer)
+        XCTAssertEqual(ABILowering.typeTag(for: .nullable(.string)), .string)
+    }
+
+    func testTypeTagForVoidAndUnknown() {
+        XCTAssertEqual(ABILowering.typeTag(for: .void), .null)
+        XCTAssertEqual(ABILowering.typeTag(for: .unknown), .null)
+    }
+
+    // MARK: - Boxing Needs Tests
+
+    func testNeedsBoxingPrimitiveToAny() {
+        XCTAssertTrue(ABILowering.needsBoxing(source: .integer, target: .any))
+        XCTAssertTrue(ABILowering.needsBoxing(source: .real, target: .any))
+        XCTAssertTrue(ABILowering.needsBoxing(source: .string, target: .any))
+        XCTAssertTrue(ABILowering.needsBoxing(source: .boolean, target: .any))
+    }
+
+    func testNeedsBoxingPrimitiveToNullable() {
+        XCTAssertTrue(ABILowering.needsBoxing(source: .integer, target: .nullable(.integer)))
+        XCTAssertTrue(ABILowering.needsBoxing(source: .string, target: .nullable(.string)))
+    }
+
+    func testNoBoxingSameType() {
+        XCTAssertFalse(ABILowering.needsBoxing(source: .integer, target: .integer))
+        XCTAssertFalse(ABILowering.needsBoxing(source: .string, target: .string))
+    }
+
+    // MARK: - Unboxing Needs Tests
+
+    func testNeedsUnboxingAnyToPrimitive() {
+        XCTAssertTrue(ABILowering.needsUnboxing(source: .any, target: .integer))
+        XCTAssertTrue(ABILowering.needsUnboxing(source: .any, target: .real))
+        XCTAssertTrue(ABILowering.needsUnboxing(source: .any, target: .string))
+        XCTAssertTrue(ABILowering.needsUnboxing(source: .any, target: .boolean))
+    }
+
+    func testNeedsUnboxingNullableToPrimitive() {
+        XCTAssertTrue(ABILowering.needsUnboxing(source: .nullable(.integer), target: .integer))
+        XCTAssertTrue(ABILowering.needsUnboxing(source: .nullable(.string), target: .string))
+    }
+
+    func testNoUnboxingSameType() {
+        XCTAssertFalse(ABILowering.needsUnboxing(source: .integer, target: .integer))
+        XCTAssertFalse(ABILowering.needsUnboxing(source: .string, target: .string))
+    }
+
+    func testNoUnboxingAnyToAny() {
+        XCTAssertFalse(ABILowering.needsUnboxing(source: .any, target: .any))
+    }
+
+    func testNoUnboxingAnyToNullable() {
+        XCTAssertFalse(ABILowering.needsUnboxing(source: .any, target: .nullable(.integer)))
+    }
+
+    // MARK: - Analyze Statements Tests
+
+    func testAnalyzeEmptyStatements() {
+        let lowering = ABILowering()
+        let result = lowering.analyze([])
+        XCTAssertFalse(result.requiresBoxing)
+        XCTAssertTrue(result.boundaries.isEmpty)
+    }
+
+    func testAnalyzeNullableVariableDeclaration() {
+        let lowering = ABILowering()
+        let statements: [Statement] = [
+            .variableDeclaration(VariableDeclaration(
+                name: "x",
+                type: .nullable(.integer),
+                initialValue: nil,
+                position: SourcePosition(line: 1, column: 1, offset: 0)
+            ))
+        ]
+        let result = lowering.analyze(statements)
+        XCTAssertTrue(result.requiresBoxing)
+        XCTAssertEqual(result.boundaries.count, 1)
+        if case .box(let sourceType) = result.boundaries[0].kind {
+            XCTAssertEqual(sourceType, .integer)
+        } else {
+            XCTFail("Expected box boundary")
+        }
+    }
+
+    func testAnalyzeAnyVariableDeclaration() {
+        let lowering = ABILowering()
+        let statements: [Statement] = [
+            .variableDeclaration(VariableDeclaration(
+                name: "x",
+                type: .any,
+                initialValue: nil,
+                position: SourcePosition(line: 1, column: 1, offset: 0)
+            ))
+        ]
+        let result = lowering.analyze(statements)
+        XCTAssertTrue(result.requiresBoxing)
+        XCTAssertEqual(result.boundaries.count, 1)
+    }
+
+    func testAnalyzePlainVariableDeclaration() {
+        let lowering = ABILowering()
+        let statements: [Statement] = [
+            .variableDeclaration(VariableDeclaration(
+                name: "x",
+                type: .integer,
+                initialValue: nil,
+                position: SourcePosition(line: 1, column: 1, offset: 0)
+            ))
+        ]
+        let result = lowering.analyze(statements)
+        XCTAssertFalse(result.requiresBoxing)
+        XCTAssertTrue(result.boundaries.isEmpty)
+    }
+
+    func testAnalyzeFunctionWithNullableParameter() {
+        let lowering = ABILowering()
+        let statements: [Statement] = [
+            .functionDeclaration(FunctionDeclaration(
+                name: "test",
+                parameters: [Parameter(name: "x", type: .nullable(.integer))],
+                returnType: .integer,
+                localVariables: [],
+                body: [
+                    .returnStatement(ReturnStatement(expression: .literal(.integer(0))))
+                ],
+                position: SourcePosition(line: 1, column: 1, offset: 0)
+            ))
+        ]
+        let result = lowering.analyze(statements)
+        XCTAssertTrue(result.requiresBoxing)
+        XCTAssertGreaterThanOrEqual(result.boundaries.count, 1)
+    }
+
+    func testAnalyzeFunctionWithAnyReturnType() {
+        let lowering = ABILowering()
+        let statements: [Statement] = [
+            .functionDeclaration(FunctionDeclaration(
+                name: "test",
+                parameters: [],
+                returnType: .any,
+                localVariables: [],
+                body: [
+                    .returnStatement(ReturnStatement(expression: .literal(.integer(0))))
+                ],
+                position: SourcePosition(line: 1, column: 1, offset: 0)
+            ))
+        ]
+        let result = lowering.analyze(statements)
+        XCTAssertTrue(result.requiresBoxing)
+    }
+
+    // MARK: - BoxingOperations Tests
+
+    func testBoxDescription() {
+        let desc = BoxingOperations.boxDescription(value: "42", sourceType: .integer)
+        XCTAssertTrue(desc.contains("box"))
+        XCTAssertTrue(desc.contains("42"))
+    }
+
+    func testUnboxDescription() {
+        let desc = BoxingOperations.unboxDescription(value: "boxed", targetType: .integer)
+        XCTAssertTrue(desc.contains("unbox"))
+        XCTAssertTrue(desc.contains("boxed"))
+    }
+
+    // MARK: - FeType Nullable/Any Tests
+
+    func testFeTypeNullableDescription() {
+        let type = FeType.nullable(.integer)
+        XCTAssertEqual(type.description, "integer?")
+    }
+
+    func testFeTypeAnyDescription() {
+        let type = FeType.any
+        XCTAssertEqual(type.description, "Any")
+    }
+
+    func testFeTypeNullableIsNullable() {
+        XCTAssertTrue(FeType.nullable(.integer).isNullable)
+        XCTAssertTrue(FeType.any.isNullable)
+        XCTAssertFalse(FeType.integer.isNullable)
+    }
+
+    func testFeTypeUnwrappedType() {
+        XCTAssertEqual(FeType.nullable(.integer).unwrappedType, .integer)
+        XCTAssertEqual(FeType.integer.unwrappedType, .integer)
+    }
+
+    func testFeTypeAnyCompatibility() {
+        XCTAssertTrue(FeType.any.isCompatible(with: .integer))
+        XCTAssertTrue(FeType.any.isCompatible(with: .string))
+        XCTAssertTrue(FeType.integer.isCompatible(with: .any))
+    }
+
+    func testFeTypeNullableCompatibility() {
+        XCTAssertTrue(FeType.nullable(.integer).isCompatible(with: .nullable(.integer)))
+        XCTAssertTrue(FeType.integer.isCompatible(with: .nullable(.integer)))
+        XCTAssertTrue(FeType.nullable(.integer).isCompatible(with: .integer))
+    }
+
+    func testFeTypeCanAssignToAny() {
+        XCTAssertTrue(FeType.integer.canAssignTo(.any))
+        XCTAssertTrue(FeType.string.canAssignTo(.any))
+        XCTAssertTrue(FeType.boolean.canAssignTo(.any))
+    }
+
+    func testFeTypeCanAssignToNullable() {
+        XCTAssertTrue(FeType.integer.canAssignTo(.nullable(.integer)))
+        XCTAssertTrue(FeType.string.canAssignTo(.nullable(.string)))
+    }
+
+    func testFeTypeNullableCanAssignToInner() {
+        XCTAssertTrue(FeType.nullable(.integer).canAssignTo(.integer))
+    }
+
+    // MARK: - DataType Nullable/Any Tests
+
+    func testDataTypeNullableEquality() {
+        XCTAssertEqual(DataType.nullable(.integer), DataType.nullable(.integer))
+        XCTAssertNotEqual(DataType.nullable(.integer), DataType.nullable(.string))
+    }
+
+    func testDataTypeAnyEquality() {
+        XCTAssertEqual(DataType.any, DataType.any)
+        XCTAssertNotEqual(DataType.any, DataType.integer)
+    }
+}

--- a/Tests/FeLangRuntimeTests/BoxingRuntimeTests.swift
+++ b/Tests/FeLangRuntimeTests/BoxingRuntimeTests.swift
@@ -1,0 +1,185 @@
+@testable import FeLangRuntime
+import FeLangCore
+import Foundation
+import Testing
+
+struct BoxingRuntimeTests {
+
+    // MARK: - Thread-safe output capture
+
+    private final class OutputCapture: @unchecked Sendable {
+        private var _output = ""
+        private let lock = NSLock()
+
+        func append(_ text: String) {
+            lock.lock()
+            _output += text
+            lock.unlock()
+        }
+
+        var output: String {
+            lock.lock()
+            defer { lock.unlock() }
+            return _output
+        }
+    }
+
+    // MARK: - Boxed RuntimeValue Tests
+
+    @Test func testBoxedValueTypeName() {
+        let boxed = RuntimeValue.boxed(typeTag: 0, value: .integer(42))
+        #expect(boxed.typeName == "Boxed<Integer>")
+    }
+
+    @Test func testBoxedValueToString() {
+        let boxed = RuntimeValue.boxed(typeTag: 0, value: .integer(42))
+        #expect(boxed.toString() == "boxed(tag=0, 42)")
+    }
+
+    @Test func testBoxedValueIsTruthy() {
+        let boxedTrue = RuntimeValue.boxed(typeTag: 4, value: .boolean(true))
+        let boxedFalse = RuntimeValue.boxed(typeTag: 4, value: .boolean(false))
+        let boxedNull = RuntimeValue.boxed(typeTag: 8, value: .null)
+
+        #expect(boxedTrue.isTruthy == true)
+        #expect(boxedFalse.isTruthy == false)
+        #expect(boxedNull.isTruthy == false)
+    }
+
+    @Test func testBoxedValueToInteger() {
+        let boxed = RuntimeValue.boxed(typeTag: 0, value: .integer(42))
+        #expect(boxed.toInteger() == 42)
+    }
+
+    @Test func testBoxedValueToReal() {
+        let boxed = RuntimeValue.boxed(typeTag: 1, value: .real(3.14))
+        #expect(boxed.toReal() == 3.14)
+    }
+
+    @Test func testBoxedValueEquality() {
+        let boxed1 = RuntimeValue.boxed(typeTag: 0, value: .integer(42))
+        let boxed2 = RuntimeValue.boxed(typeTag: 0, value: .integer(42))
+        let boxed3 = RuntimeValue.boxed(typeTag: 0, value: .integer(99))
+
+        #expect(boxed1 == boxed2)
+        #expect(boxed1 != boxed3)
+    }
+
+    @Test func testBoxedStringValue() {
+        let boxed = RuntimeValue.boxed(typeTag: 2, value: .string("hello"))
+        #expect(boxed.typeName == "Boxed<String>")
+        #expect(boxed.toString() == "boxed(tag=2, hello)")
+    }
+
+    @Test func testBoxedBooleanValue() {
+        let boxed = RuntimeValue.boxed(typeTag: 4, value: .boolean(true))
+        #expect(boxed.typeName == "Boxed<Boolean>")
+        #expect(boxed.isTruthy == true)
+    }
+
+    // MARK: - kk_println_any Tests
+
+    @Test func testKkPrintlnAnyWithInteger() throws {
+        let capture = OutputCapture()
+        let stdlib = StandardLibrary(
+            printHandler: { capture.append($0) },
+            inputHandler: { nil }
+        )
+        _ = try stdlib.functions["kk_println_any"]?([.integer(42)])
+        #expect(capture.output == "42\n")
+    }
+
+    @Test func testKkPrintlnAnyWithString() throws {
+        let capture = OutputCapture()
+        let stdlib = StandardLibrary(
+            printHandler: { capture.append($0) },
+            inputHandler: { nil }
+        )
+        _ = try stdlib.functions["kk_println_any"]?([.string("hello")])
+        #expect(capture.output == "hello\n")
+    }
+
+    @Test func testKkPrintlnAnyWithNull() throws {
+        let capture = OutputCapture()
+        let stdlib = StandardLibrary(
+            printHandler: { capture.append($0) },
+            inputHandler: { nil }
+        )
+        _ = try stdlib.functions["kk_println_any"]?([.null])
+        #expect(capture.output == "null\n")
+    }
+
+    @Test func testKkPrintlnAnyWithBoxedValue() throws {
+        let capture = OutputCapture()
+        let stdlib = StandardLibrary(
+            printHandler: { capture.append($0) },
+            inputHandler: { nil }
+        )
+        _ = try stdlib.functions["kk_println_any"]?([.boxed(typeTag: 0, value: .integer(42))])
+        #expect(capture.output == "Any(tag=0, 42)\n")
+    }
+
+    @Test func testKkPrintlnAnyWithBoolean() throws {
+        let capture = OutputCapture()
+        let stdlib = StandardLibrary(
+            printHandler: { capture.append($0) },
+            inputHandler: { nil }
+        )
+        _ = try stdlib.functions["kk_println_any"]?([.boolean(true)])
+        #expect(capture.output == "true\n")
+    }
+
+    @Test func testKkPrintlnAnyWithReal() throws {
+        let capture = OutputCapture()
+        let stdlib = StandardLibrary(
+            printHandler: { capture.append($0) },
+            inputHandler: { nil }
+        )
+        _ = try stdlib.functions["kk_println_any"]?([.real(3.14)])
+        #expect(capture.output == "3.14\n")
+    }
+
+    @Test func testKkPrintlnAnyNoArgs() {
+        let stdlib = StandardLibrary(
+            printHandler: { _ in },
+            inputHandler: { nil }
+        )
+        #expect(throws: RuntimeError.self) {
+            _ = try stdlib.functions["kk_println_any"]?([])
+        }
+    }
+
+    // MARK: - Nullable Default Value Tests
+
+    @Test func testNullableDefaultValueExecution() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        _ = try executor.execute([
+            .variableDeclaration(VariableDeclaration(
+                name: "x",
+                type: .nullable(.integer),
+                initialValue: nil
+            ))
+        ])
+
+        let value = env.lookup("x")
+        #expect(value == .null)
+    }
+
+    @Test func testAnyDefaultValueExecution() throws {
+        let env = Environment()
+        let executor = StatementExecutor(environment: env)
+
+        _ = try executor.execute([
+            .variableDeclaration(VariableDeclaration(
+                name: "x",
+                type: .any,
+                initialValue: nil
+            ))
+        ])
+
+        let value = env.lookup("x")
+        #expect(value == .null)
+    }
+}


### PR DESCRIPTION
# feat(abi): P5-26 ABILowering boxing/unboxing at nullable/Any boundaries

## Summary

Adds infrastructure for boxing/unboxing at nullable primitive and `Any?` boundaries (spec.md J12.1/J13.3). This introduces the type system extensions (`nullable`, `any`), a static analysis module (`ABILowering`) that identifies boxing boundaries, a `boxed` runtime value representation, and a `kk_println_any` standard library function.

**Key changes:**
- `DataType` enum: new `.nullable(DataType)` and `.any` cases
- `FeType` enum: new `.nullable(FeType)` and `.any` cases with compatibility/assignment rules
- New `Sources/FeLangCore/ABI/ABILowering.swift`: static analysis to detect boxing boundaries in AST, `TypeTag` enum, `needsBoxing`/`needsUnboxing` predicates
- `RuntimeValue`: new `indirect case boxed(typeTag: Int, value: RuntimeValue)` for tagged boxing
- `StandardLibrary`: new `kk_println_any` function for printing Any? values
- Updated `SemanticAnalyzer`, `StatementExecutor`, `PrettyPrinter` to handle new type cases
- 2 new test files: `ABILoweringTests.swift` (XCTest, 30 tests), `BoxingRuntimeTests.swift` (Testing framework, 16 tests)

**What this PR does NOT do:**
- Does not add parser support for `nullable`/`Any` type annotations (types can only be created programmatically)
- Does not insert actual boxing/unboxing operations in the runtime execution path (infrastructure only)
- The `boxed` RuntimeValue case is defined but not created during normal execution (only in tests)

All 1294 tests pass. SwiftLint clean (0 serious violations).

## Review & Testing Checklist for Human

- [ ] **Verify `needsBoxing` logic for nullable→any case**: In `ABILowering.needsBoxing`, the pattern `(.nullable, _), (_, .nullable)` matches before `(_, .any)`, which means `nullable(.integer) → any` returns false instead of true. Check if this is correct or if the case order should be swapped.
- [ ] **Confirm enum exhaustiveness**: Adding cases to `DataType`/`FeType` could break existing switches with `default:` clauses. Verify that all switches in the codebase (not just those in this diff) properly handle or safely ignore the new cases.
- [ ] **Check Codable conformance**: `DataType` is `Codable` and now has recursive `.nullable(DataType)` case. Verify that serialization/deserialization still works correctly and doesn't break existing persisted data.
- [ ] **Validate that infrastructure-only scope is intentional**: This PR adds boxing infrastructure but doesn't wire it into the execution pipeline. Confirm this matches the intended incremental rollout plan.

### Test Plan
1. Run full test suite: `swift test` (should show 1294 passing tests)
2. Manually verify `ABILowering.analyze()` detects boundaries for nullable/any declarations
3. Test `kk_println_any` with various value types including boxed values
4. Verify default values for nullable/any variables are `.null`

### Notes
- Session: https://app.devin.ai/sessions/f07ef3c7e30c46c49521abb215090ab0
- Requested by: @fumiya-kume
- The `indirect` keyword on `boxed` case was required to fix Swift compiler crash (recursive enum)
- Used `OutputCapture` pattern with `NSLock` for Swift 6 concurrency safety in tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fumiya-kume/felangkit/pull/403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core type system enums and type-check/validation paths, which can subtly affect compatibility/assignment behavior across the language. Runtime changes are mostly additive but could impact existing switches/default handling and serialized `DataType` values.
> 
> **Overview**
> Adds first-pass ABI boxing infrastructure by introducing `DataType.nullable`/`DataType.any` and corresponding `FeType.nullable`/`FeType.any` semantics (printing, conversion, compatibility/assignment helpers).
> 
> Introduces `ABILowering` analysis to walk the AST and report boxing boundaries plus `TypeTag` tagging helpers, and extends the runtime with `RuntimeValue.boxed` and a new stdlib helper `kk_println_any`; executor type validation/default values are updated to treat `nullable`/`any` as accepting `null` and defaulting to `.null`.
> 
> Adds comprehensive core/runtime tests covering type tags, boxing boundary detection, boxed value behavior, `kk_println_any`, and nullable/any default values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49aabcd91520f8e31929b3a7d039b2754d22a26f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->